### PR TITLE
Restore layered package layout with validation

### DIFF
--- a/MMO_Trader_Market/src/java/controller/auth/AuthController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/AuthController.java
@@ -3,6 +3,7 @@ package controller.auth;
 import controller.BaseController;
 import model.User;
 import service.UserService;
+import validation.CredentialsValidator;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,6 +41,12 @@ public class AuthController extends BaseController {
             throws ServletException, IOException {
         String username = request.getParameter("username");
         String password = request.getParameter("password");
+        if (!CredentialsValidator.isValid(username, password)) {
+            request.setAttribute("error", "Vui lòng nhập đầy đủ tên đăng nhập và mật khẩu");
+            forward(request, response, "auth/login");
+            return;
+        }
+
         User user = userService.authenticate(username, password);
         if (user == null) {
             request.setAttribute("error", "Sai tên đăng nhập hoặc mật khẩu");

--- a/MMO_Trader_Market/src/java/validation/CredentialsValidator.java
+++ b/MMO_Trader_Market/src/java/validation/CredentialsValidator.java
@@ -1,0 +1,23 @@
+package validation;
+
+/**
+ * Provides simple checks for login credentials before hitting the data layer.
+ */
+public final class CredentialsValidator {
+
+    private CredentialsValidator() {
+        // utility class
+    }
+
+    /**
+     * Basic validation to ensure the username and password are filled in.
+     *
+     * @param username the supplied username
+     * @param password the supplied password
+     * @return {@code true} when both fields contain text, {@code false} otherwise
+     */
+    public static boolean isValid(String username, String password) {
+        return username != null && !username.isBlank()
+                && password != null && !password.isBlank();
+    }
+}

--- a/docs/diagrams/achitecture_diagram.puml
+++ b/docs/diagrams/achitecture_diagram.puml
@@ -1,0 +1,38 @@
+' MMO Trader Market simplified architecture diagram
+@startuml
+skinparam componentStyle rectangle
+skinparam shadowing false
+skinparam linetype ortho
+
+title MMO Trader Market — Simplified MVC Architecture
+
+package "Presentation Layer" {
+  [JSP Views]
+  component "Controllers" as Controllers
+}
+
+package "Application Layer" {
+  component "Services" as Services
+  component "Validation" as Validation
+}
+
+package "Data Layer" {
+  component "DAOs" as DAOs
+  component "Models" as Models
+}
+
+package "Configuration" {
+  component "AppConfig" as AppConfig
+}
+
+[JSP Views] --> Controllers : render
+Controllers --> Validation : check input
+Controllers --> Services : handle requests
+Services --> Validation : reuse rules
+Services --> DAOs : fetch & persist
+DAOs --> Models : map records
+AppConfig --> Controllers : servlet settings
+AppConfig --> Services : service wiring
+AppConfig --> DAOs : datasource info
+
+@enduml

--- a/docs/diagrams/package-diagram.puml
+++ b/docs/diagrams/package-diagram.puml
@@ -1,212 +1,88 @@
-' MMO Trader Market package diagrams (conceptual)
-' Includes overall view, subsystem packages, and naming conventions.
-
-' Overall conceptual package diagram
+' MMO Trader Market layered package diagram
 @startuml
 skinparam packageStyle rectangle
 skinparam defaultTextAlignment left
 skinparam shadowing false
 skinparam linetype ortho
 
-title MMO Trader Market — Overall Conceptual Package Diagram
+title MMO Trader Market — Layered Packages
 
-package auth
-package user
-package marketplace
-package store
-package admin
-package service_core
-package infra
-
-package external {
-  [google_sso]
-  [vnpay_gateway]
-  [mail_gateway]
+package controller {
+  [auth]
+  [product]
+  [dashboard]
+  [guide]
 }
 
-auth ..> service_core : session_api
-user ..> service_core : account_api
-marketplace ..> service_core : order_api
-store ..> service_core : listing_api
-admin ..> service_core : moderation_api
+package service
+package validation
+package dao {
+  [user]
+  [product]
+}
+package model
+package conf
 
-user ..> marketplace : browse_purchase
-store ..> marketplace : publish_inventory
+controller ..> validation : form_checks
+controller ..> service : invoke_use_cases
+service ..> validation : reuse_rules
+service ..> dao : data_access
+validation ..> model : inspect_entities
+service ..> model : build_view_models
+controller ..> model : view_models
+conf ..> dao : datasource
+conf ..> service : config
 
-service_core ..> infra
-infra ..> external
+dao ..> model : hydrate
 
 @enduml
 
-' auth subsystem conceptual view
 @startuml
-title auth (conceptual)
 skinparam packageStyle rectangle
 skinparam shadowing false
+skinparam linetype ortho
 
-package auth {
-  package login
-  package registration
-  package password_recovery
-  package sso
+title Package Responsibilities
+
+package controller {
+  [AuthController]
+  [ProductController]
+  [DashboardController]
+  [UiGuideController]
 }
 
-login ..> sso : optional_google_link
-login ..> password_recovery : trigger_reset
-registration ..> sso : bind_external_id
-auth ..> service_core : token_service
-@enduml
-
-' user subsystem conceptual view
-@startuml
-title user (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package user {
-  package profile
-  package wallet
-  package kyc
-  package complaint
-  package support
+package service {
+  [UserService]
+  [ProductService]
 }
 
-wallet ..> kyc : withdraw_requires_kyc
-complaint ..> support : follow_up
-user ..> service_core : account_api, wallet_api, notification_api
-@enduml
-
-' marketplace subsystem conceptual view
-@startuml
-title marketplace (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package marketplace {
-  package catalog
-  package product_detail
-  package checkout
-  package order_history
+package validation {
+  [CredentialsValidator]
 }
 
-catalog ..> product_detail
-checkout ..> product_detail
-marketplace ..> service_core : order_api, payment_api, review_api
-@enduml
-
-' store subsystem conceptual view
-@startuml
-title store (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package store {
-  package store_dashboard
-  package product_management
-  package store_request
-  package flag_store
+package dao {
+  [UserDAO]
+  [ProductDAO]
 }
 
-product_management ..> store_dashboard
-store_request ..> store_dashboard
-flag_store ..> store_dashboard
-store ..> service_core : listing_api, moderation_api
-@enduml
-
-' admin subsystem conceptual view
-@startuml
-title admin (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package admin {
-  package dashboard
-  package user_approval
-  package kyc_review
-  package complaint_review
-  package product_approval
-  package store_approval
-  package payment_review
+package model {
+  [User]
+  [Role]
+  [Product]
+  [ProductStatus]
 }
 
-dashboard ..> user_approval
-
-dashboard ..> kyc_review
-
-dashboard ..> complaint_review
-
-dashboard ..> product_approval
-
-dashboard ..> store_approval
-
-dashboard ..> payment_review
-
-admin ..> service_core : approvals_api, audit_api, reporting_api
-@enduml
-
-' service_core subsystem conceptual view
-@startuml
-title service_core (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package service_core {
-  package auth_appservice
-  package catalog_appservice
-  package order_payment_appservice
-  package wallet_appservice
-  package kyc_appservice
-  package complaint_appservice
-  package store_appservice
-  package admin_ops_appservice
-  package notification_appservice
-  package configuration
+package conf {
+  [AppConfig]
 }
 
-order_payment_appservice ..> wallet_appservice
-order_payment_appservice ..> notification_appservice : receipt_events
-admin_ops_appservice ..> configuration
-notification_appservice ..> configuration
-
-service_core ..> infra : persistence, integrations
-@enduml
-
-' infra subsystem conceptual view
-@startuml
-title infra (conceptual)
-skinparam packageStyle rectangle
-skinparam shadowing false
-
-package infra {
-  package persistence
-  package integrations
-}
-
-integrations ..> [google_sso]
-integrations ..> [vnpay_gateway]
-integrations ..> [mail_gateway]
-@enduml
-
-' Naming conventions and module descriptions
-@startuml
-title MMO Trader Market — Package Naming Conventions
-
-skinparam backgroundColor #FFFFFF
-skinparam shadowing false
-
-salt
-{
-{T
-+ Scope | Package | Responsibility | Naming Guideline
-"Overall" | auth | User authentication flows (login, registration, recovery, SSO) | Prefix concrete components with Auth* (e.g., AuthController)
-"Overall" | user | Manage profile, wallet, KYC, complaint, and support features | Use User*, Wallet*, Kyc* for sub-packages and artifacts
-"Overall" | marketplace | Buyer-facing browsing, checkout, and order history | Use Market*, Catalog*, Order* naming for controllers/services
-"Overall" | store | Seller operations (dashboard, listings, store requests) | Use Store* prefix for seller tools and request handlers
-"Overall" | admin | Administrative dashboards, approvals, and audits | Use Admin* prefix and suffix with function (e.g., AdminApprovalService)
-service_core | *_appservice | Application service coordination per domain (auth, catalog, order, etc.) | snake_case package name with CamelCase class names (AuthAppService)
-infra | persistence | Database repositories and ORM adapters | Use <Domain>Repository naming
-infra | integrations | Adapters for third-party gateways (SSO, payments, mail) | Use <Provider>Client naming
-}
-}
+controller ..> service
+controller ..> validation
+service ..> dao
+service ..> validation
+service ..> model
+validation ..> model
+conf ..> service
+conf ..> dao
 
 @enduml


### PR DESCRIPTION
## Summary
- restore the layered controller/dao/model/service/conf packages and remove the previous domain-based namespaces
- add a dedicated validation package with a reusable CredentialsValidator used by the auth flow
- redraw the package and architecture diagrams to reflect the simplified layered structure the team requested

## Testing
- ant -f MMO_Trader_Market/build.xml compile *(fails: `ant` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9488fd9748320bef7d60742b3417f