### PR TITLE
Add landing homepage for account marketplace demo

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -1,0 +1,72 @@
+package controller.product;
+
+import controller.BaseController;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import model.CustomerProfile;
+import model.Product;
+import model.ProductCategory;
+import model.Review;
+import service.HomepageService;
+
+/**
+ * Handles requests for the public facing homepage where visitors discover
+ * available account products.
+ */
+@WebServlet(name = "HomepageController", urlPatterns = {"/home"})
+public class HomepageController extends BaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    private final HomepageService homepageService = new HomepageService();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute("pageTitle", "Chợ tài khoản MMO - Trang chủ");
+        request.setAttribute("bodyClass", "layout layout--landing");
+        request.setAttribute("headerTitle", "MMO Trader Market");
+        request.setAttribute("headerSubtitle", "Nền tảng demo mua bán tài khoản an toàn");
+
+        String contextPath = request.getContextPath();
+        List<Map<String, String>> navItems = new ArrayList<>();
+
+        Map<String, String> loginLink = new HashMap<>();
+        loginLink.put("href", contextPath + "/login.jsp");
+        loginLink.put("label", "Đăng nhập");
+        loginLink.put("modifier", "button button--primary");
+        navItems.add(loginLink);
+
+        Map<String, String> productLink = new HashMap<>();
+        productLink.put("href", contextPath + "/products");
+        productLink.put("label", "Quản lý sản phẩm");
+        navItems.add(productLink);
+
+        Map<String, String> guideLink = new HashMap<>();
+        guideLink.put("href", contextPath + "/styleguide");
+        guideLink.put("label", "Styleguide");
+        navItems.add(guideLink);
+
+        request.setAttribute("navItems", navItems);
+
+        List<ProductCategory> categories = homepageService.getCategories();
+        List<Product> featuredProducts = homepageService.getFeaturedProducts();
+        CustomerProfile customerProfile = homepageService.getSampleCustomerProfile();
+        List<Review> reviews = homepageService.getSampleReviews();
+
+        request.setAttribute("categories", categories);
+        request.setAttribute("featuredProducts", featuredProducts);
+        request.setAttribute("customerProfile", customerProfile);
+        request.setAttribute("reviews", reviews);
+        request.setAttribute("buyerTips", homepageService.getBuyerSafetyTips());
+
+        forward(request, response, "product/home");
+    }
+}

--- a/MMO_Trader_Market/src/java/model/CustomerProfile.java
+++ b/MMO_Trader_Market/src/java/model/CustomerProfile.java
@@ -1,0 +1,47 @@
+package model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+/**
+ * Represents a demo customer profile that appears on the homepage.
+ */
+public class CustomerProfile implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String displayName;
+    private final String membershipLevel;
+    private final LocalDate joinDate;
+    private final int successfulOrders;
+    private final double satisfactionScore;
+
+    public CustomerProfile(String displayName, String membershipLevel, LocalDate joinDate,
+                           int successfulOrders, double satisfactionScore) {
+        this.displayName = displayName;
+        this.membershipLevel = membershipLevel;
+        this.joinDate = joinDate;
+        this.successfulOrders = successfulOrders;
+        this.satisfactionScore = satisfactionScore;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getMembershipLevel() {
+        return membershipLevel;
+    }
+
+    public LocalDate getJoinDate() {
+        return joinDate;
+    }
+
+    public int getSuccessfulOrders() {
+        return successfulOrders;
+    }
+
+    public double getSatisfactionScore() {
+        return satisfactionScore;
+    }
+}

--- a/MMO_Trader_Market/src/java/model/ProductCategory.java
+++ b/MMO_Trader_Market/src/java/model/ProductCategory.java
@@ -1,0 +1,39 @@
+package model;
+
+import java.io.Serializable;
+
+/**
+ * Represents a product category displayed on the public homepage.
+ */
+public class ProductCategory implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String code;
+    private final String name;
+    private final String description;
+    private final String icon;
+
+    public ProductCategory(String code, String name, String description, String icon) {
+        this.code = code;
+        this.name = name;
+        this.description = description;
+        this.icon = icon;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+}

--- a/MMO_Trader_Market/src/java/model/Review.java
+++ b/MMO_Trader_Market/src/java/model/Review.java
@@ -1,0 +1,39 @@
+package model;
+
+import java.io.Serializable;
+
+/**
+ * Represents a customer review showcased on the homepage.
+ */
+public class Review implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String reviewerName;
+    private final int rating;
+    private final String comment;
+    private final String productName;
+
+    public Review(String reviewerName, int rating, String comment, String productName) {
+        this.reviewerName = reviewerName;
+        this.rating = rating;
+        this.comment = comment;
+        this.productName = productName;
+    }
+
+    public String getReviewerName() {
+        return reviewerName;
+    }
+
+    public int getRating() {
+        return rating;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -1,0 +1,73 @@
+package service;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import model.CustomerProfile;
+import model.Product;
+import model.ProductCategory;
+import model.Review;
+
+/**
+ * Provides demo data for the public homepage without requiring a database.
+ */
+public class HomepageService {
+
+    private final ProductService productService = new ProductService();
+
+    /**
+     * Returns sample categories used to render the navigation menu.
+     */
+    public List<ProductCategory> getCategories() {
+        return Arrays.asList(
+                new ProductCategory("mail", "Mail doanh nghiệp", "Email theo domain, full quyền quản trị", "📧"),
+                new ProductCategory("software", "Phần mềm bản quyền", "Tài khoản học tập, làm việc uy tín", "🛠"),
+                new ProductCategory("game", "Tài khoản game", "Nhiều hạng mức rank, skin hiếm", "🎮"),
+                new ProductCategory("stream", "Giải trí & Stream", "Netflix, Spotify, Fshare, v.v.", "🎬"),
+                new ProductCategory("other", "Khác", "Key bản quyền, gift card và hơn thế nữa", "🪙")
+        );
+    }
+
+    /**
+     * Uses the product service to display highlighted products on the homepage.
+     */
+    public List<Product> getFeaturedProducts() {
+        return productService.getHighlightedProducts();
+    }
+
+    /**
+     * Returns a fictional customer profile to highlight marketplace credibility.
+     */
+    public CustomerProfile getSampleCustomerProfile() {
+        return new CustomerProfile(
+                "Bùi Minh Khôi",
+                "Thành viên Kim cương",
+                LocalDate.of(2021, 3, 12),
+                186,
+                4.9
+        );
+    }
+
+    /**
+     * Provides curated customer reviews for the landing page.
+     */
+    public List<Review> getSampleReviews() {
+        return Arrays.asList(
+                new Review("Linh Trần", 5, "Mua acc Liên Quân full tướng, giao dịch an toàn và nhanh chóng.", "Acc game B"),
+                new Review("Đức Hoàng", 4, "Giao key Microsoft 365 trong 5 phút, hỗ trợ kích hoạt tận tình.", "Phần mềm bản quyền"),
+                new Review("Mai Ngọc", 5, "Mail EDU giá tốt, hạn sử dụng dài, đúng mô tả.", "Mail doanh nghiệp")
+        );
+    }
+
+    /**
+     * Returns suggested safety tips for new buyers.
+     */
+    public List<String> getBuyerSafetyTips() {
+        return Arrays.asList(
+                "Luôn kiểm tra lịch sử giao dịch và đánh giá của người bán.",
+                "Sử dụng kênh thanh toán được hỗ trợ để đảm bảo quyền lợi.",
+                "Đổi mật khẩu ngay sau khi nhận tài khoản để bảo mật.",
+                "Liên hệ hỗ trợ 24/7 nếu cần xác minh thông tin hoặc kháng nghị."
+        );
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -1,0 +1,147 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page import="java.util.List" %>
+<%@ page import="model.Product" %>
+<%@ page import="model.ProductCategory" %>
+<%@ page import="model.CustomerProfile" %>
+<%@ page import="model.Review" %>
+<%
+    List<ProductCategory> categories = (List<ProductCategory>) request.getAttribute("categories");
+    List<Product> featuredProducts = (List<Product>) request.getAttribute("featuredProducts");
+    CustomerProfile profile = (CustomerProfile) request.getAttribute("customerProfile");
+    List<Review> reviews = (List<Review>) request.getAttribute("reviews");
+    List<String> buyerTips = (List<String>) request.getAttribute("buyerTips");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content landing">
+    <%-- /** Hero section: highlights the marketplace value proposition */ --%>
+    <section class="panel landing__hero">
+        <div class="landing__hero-main">
+            <h2>Chợ tài khoản MMO dành cho seller và buyer chuyên nghiệp</h2>
+            <p class="landing__lead">
+                Nơi bạn có thể tìm thấy tài khoản game, mail doanh nghiệp, phần mềm bản quyền và nhiều hơn thế nữa.
+                Toàn bộ dữ liệu trên trang chỉ nhằm mục đích demo basecode phục vụ học tập.
+            </p>
+            <ul class="landing__metrics">
+                <li><strong>250+</strong> giao dịch hoàn tất mỗi tháng</li>
+                <li><strong>50+</strong> đối tác uy tín đang hoạt động</li>
+                <li><strong>24/7</strong> hỗ trợ đa kênh qua chat, ticket</li>
+            </ul>
+            <div class="landing__cta">
+                <a class="button button--primary" href="<%= request.getContextPath() %>/login.jsp">Đăng nhập ngay</a>
+                <a class="button button--ghost" href="<%= request.getContextPath() %>/products">Xem quản trị</a>
+            </div>
+        </div>
+        <aside class="landing__categories">
+            <h3 class="landing__aside-title">Danh mục nổi bật</h3>
+            <ul class="category-menu">
+                <% if (categories != null) { %>
+                    <% for (ProductCategory category : categories) { %>
+                        <li class="category-menu__item">
+                            <span class="category-menu__icon"><%= category.getIcon() %></span>
+                            <div>
+                                <strong><%= category.getName() %></strong>
+                                <p><%= category.getDescription() %></p>
+                            </div>
+                        </li>
+                    <% } %>
+                <% } %>
+            </ul>
+        </aside>
+    </section>
+
+    <%-- /** Featured product cards */ --%>
+    <section class="panel landing__section">
+        <div class="panel__header">
+            <h3 class="panel__title">Sản phẩm gợi ý</h3>
+            <span class="panel__tag">Demo dữ liệu</span>
+        </div>
+        <div class="landing__products">
+            <% if (featuredProducts != null) { %>
+                <% for (Product product : featuredProducts) { %>
+                    <article class="product-card">
+                        <header class="product-card__header">
+                            <h4><%= product.getName() %></h4>
+                            <span class="badge">Tài khoản</span>
+                        </header>
+                        <p class="product-card__description"><%= product.getDescription() %></p>
+                        <ul class="product-card__meta">
+                            <li>Mã sản phẩm: <strong>#<%= product.getId() %></strong></li>
+                            <li>Giá đề xuất: <strong><%= product.getPrice() %> đ</strong></li>
+                            <li>Trạng thái duyệt: <strong><%= product.getStatus() %></strong></li>
+                        </ul>
+                        <footer class="product-card__footer">
+                            <button class="button button--ghost" type="button">Xem chi tiết demo</button>
+                            <button class="button button--primary" type="button">Thêm vào giỏ</button>
+                        </footer>
+                    </article>
+                <% } %>
+            <% } %>
+        </div>
+    </section>
+
+    <%-- /** Customer profile with quick facts */ --%>
+    <section class="panel landing__section landing__grid">
+        <div class="landing__column">
+            <div class="panel__header">
+                <h3 class="panel__title">Khách hàng tiêu biểu</h3>
+            </div>
+            <% if (profile != null) { %>
+            <div class="profile-card">
+                <h4><%= profile.getDisplayName() %></h4>
+                <p class="profile-card__subtitle"><%= profile.getMembershipLevel() %></p>
+                <dl class="profile-card__stats">
+                    <div>
+                        <dt>Ngày tham gia</dt>
+                        <dd><%= profile.getJoinDate().toString() %></dd>
+                    </div>
+                    <div>
+                        <dt>Đơn hàng thành công</dt>
+                        <dd><%= profile.getSuccessfulOrders() %> đơn</dd>
+                    </div>
+                    <div>
+                        <dt>Độ hài lòng</dt>
+                        <dd><%= profile.getSatisfactionScore() %>/5.0</dd>
+                    </div>
+                </dl>
+                <p class="profile-card__note">Khách hàng đã được xác minh danh tính KYC. Thông tin chỉ dùng minh họa.</p>
+            </div>
+            <% } %>
+        </div>
+        <div class="landing__column">
+            <div class="panel__header">
+                <h3 class="panel__title">Đánh giá mới nhất</h3>
+            </div>
+            <div class="reviews">
+                <% if (reviews != null) { %>
+                    <% for (Review review : reviews) { %>
+                        <article class="review-card">
+                            <header>
+                                <strong><%= review.getReviewerName() %></strong>
+                                <span class="review-card__rating">★ <%= review.getRating() %>/5</span>
+                            </header>
+                            <p class="review-card__comment"><%= review.getComment() %></p>
+                            <footer>Về sản phẩm: <em><%= review.getProductName() %></em></footer>
+                        </article>
+                    <% } %>
+                <% } %>
+            </div>
+        </div>
+    </section>
+
+    <%-- /** Buyer safety tips */ --%>
+    <section class="panel landing__section">
+        <div class="panel__header">
+            <h3 class="panel__title">Ghi chú an toàn cho người mua</h3>
+        </div>
+        <ol class="tips-list">
+            <% if (buyerTips != null) { %>
+                <% for (String tip : buyerTips) { %>
+                    <li><%= tip %></li>
+                <% } %>
+            <% } %>
+        </ol>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/web.xml
+++ b/MMO_Trader_Market/web/WEB-INF/web.xml
@@ -7,7 +7,7 @@
     <display-name>MMO Trader Market</display-name>
 
     <welcome-file-list>
-        <welcome-file>login.jsp</welcome-file>
+        <welcome-file>index.html</welcome-file>
     </welcome-file-list>
 
 </web-app>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -535,3 +535,246 @@ code {
         align-items: stretch;
     }
 }
+
+/* Landing page */
+.layout--landing {
+    background: linear-gradient(135deg, rgba(0, 91, 150, 0.08), rgba(255, 183, 3, 0.05));
+}
+
+.landing {
+    display: grid;
+    gap: 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.landing__hero {
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    gap: 2rem;
+    padding: 2.5rem;
+}
+
+@media (max-width: 900px) {
+    .landing__hero {
+        grid-template-columns: 1fr;
+    }
+}
+
+.landing__hero-main h2 {
+    margin-top: 0;
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.landing__lead {
+    margin: 1rem 0 1.5rem;
+    color: var(--text-light);
+    font-size: 1.05rem;
+}
+
+.landing__metrics {
+    display: grid;
+    gap: 0.5rem;
+    padding-left: 1.2rem;
+    margin: 0 0 2rem;
+}
+
+.landing__metrics li {
+    list-style: "✔ ";
+    color: var(--text-light);
+}
+
+.landing__cta {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.landing__categories {
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.landing__aside-title {
+    margin-top: 0;
+    margin-bottom: 1rem;
+}
+
+.category-menu {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.category-menu__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 1rem;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-radius: var(--radius-sm);
+    background: rgba(0, 91, 150, 0.06);
+    transition: var(--transition);
+}
+
+.category-menu__item:hover {
+    background: rgba(0, 91, 150, 0.12);
+    transform: translateY(-2px);
+}
+
+.category-menu__icon {
+    font-size: 1.8rem;
+}
+
+.landing__section {
+    padding: 0;
+}
+
+.landing__products {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+    padding: 1.5rem 2rem 2rem;
+}
+
+.product-card {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    background: var(--surface-color);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1rem;
+}
+
+.product-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.product-card__description {
+    margin: 0;
+    color: var(--text-light);
+}
+
+.product-card__meta {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: var(--text-light);
+    display: grid;
+    gap: 0.3rem;
+}
+
+.product-card__footer {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.landing__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 2rem;
+    padding: 1.5rem 2rem 2rem;
+}
+
+.landing__column {
+    display: grid;
+    gap: 1rem;
+}
+
+.profile-card {
+    background: linear-gradient(135deg, rgba(0, 91, 150, 0.12), rgba(255, 183, 3, 0.12));
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.profile-card__subtitle {
+    margin: 0;
+    color: var(--text-light);
+}
+
+.profile-card__stats {
+    display: grid;
+    gap: 0.8rem;
+    margin: 0;
+}
+
+.profile-card__stats div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-weight: 600;
+}
+
+.profile-card__stats dt {
+    font-weight: 500;
+    color: var(--text-light);
+}
+
+.profile-card__stats dd {
+    margin: 0;
+}
+
+.profile-card__note {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-light);
+}
+
+.reviews {
+    display: grid;
+    gap: 1rem;
+}
+
+.review-card {
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    border-radius: var(--radius-md);
+    padding: 1rem 1.25rem;
+    background: var(--surface-color);
+    box-shadow: 0 10px 25px rgba(15, 23, 42, 0.05);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.review-card header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.review-card__rating {
+    color: #f59e0b;
+    font-weight: 600;
+}
+
+.review-card__comment {
+    margin: 0;
+    color: var(--text-light);
+}
+
+.tips-list {
+    margin: 0;
+    padding: 2rem 3rem 2.5rem;
+    display: grid;
+    gap: 1rem;
+    font-weight: 500;
+    color: var(--text-light);
+}
+
+.tips-list li {
+    background: rgba(0, 91, 150, 0.06);
+    border-radius: var(--radius-sm);
+    padding: 0.75rem 1rem;
+    box-shadow: inset 0 0 0 1px rgba(0, 91, 150, 0.12);
+}

--- a/MMO_Trader_Market/web/index.html
+++ b/MMO_Trader_Market/web/index.html
@@ -2,19 +2,20 @@
 <html lang="vi">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0;URL='login.jsp'" />
+    <meta http-equiv="refresh" content="0;URL='home'" />
     <title>MMO Trader Market</title>
     <link rel="stylesheet" href="assets/css/main.css">
 </head>
 <body class="layout layout--center">
 <header class="layout__header">
     <h1>MMO Trader Market</h1>
-    <p class="subtitle">Demo dự án Servlet + JSP với thư viện giao diện sẵn sàng</p>
+    <p class="subtitle">Demo dự án Servlet + JSP với giao diện trang chủ mới</p>
 </header>
 <main class="layout__content">
     <p>Nếu trình duyệt không tự chuyển hướng, vui lòng chọn một trong các đường dẫn sau:</p>
     <nav class="menu menu--horizontal">
-        <a class="menu__item button button--primary" href="login.jsp">Đăng nhập</a>
+        <a class="menu__item button button--primary" href="home">Trang chủ</a>
+        <a class="menu__item" href="login.jsp">Đăng nhập</a>
         <a class="menu__item button button--ghost" href="styleguide">Xem thư viện giao diện</a>
     </nav>
 </main>


### PR DESCRIPTION
## Summary
- add a servlet-backed homepage that exposes demo categories, products, customer info, and reviews
- build a new JSP landing view with CTA, featured listings, testimonials, and safety tips for account trading
- extend shared styles and redirect the app welcome flow through the new homepage

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da2fef510883208a9d49e98522fdf4