### PR TITLE
Fix checkout flow and seed sample marketplace data

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -5,7 +5,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import model.Products;
+import service.ProductService;
+
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -20,6 +25,8 @@ public class HomepageController extends BaseController {
 
     private static final long serialVersionUID = 1L;
 
+    private final ProductService productService = new ProductService();
+
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
@@ -28,6 +35,13 @@ public class HomepageController extends BaseController {
         request.setAttribute("headerTitle", "MMO Trader Market");
         request.setAttribute("headerSubtitle", "Nền tảng demo mua bán tài khoản an toàn");
 
+        populateNavigation(request);
+        populateHomepageData(request);
+
+        forward(request, response, "product/home");
+    }
+
+    private void populateNavigation(HttpServletRequest request) {
         String contextPath = request.getContextPath();
         List<Map<String, String>> navItems = new ArrayList<>();
 
@@ -53,7 +67,69 @@ public class HomepageController extends BaseController {
         navItems.add(guideLink);
 
         request.setAttribute("navItems", navItems);
+    }
 
-        forward(request, response, "product/home");
+    private void populateHomepageData(HttpServletRequest request) {
+        request.setAttribute("categories", buildCategories());
+        request.setAttribute("featuredProducts", loadFeaturedProducts());
+        request.setAttribute("customerProfile", buildCustomerProfile());
+        request.setAttribute("reviews", buildReviews());
+        request.setAttribute("buyerTips", buildBuyerTips());
+    }
+
+    private List<Map<String, String>> buildCategories() {
+        List<Map<String, String>> categories = new ArrayList<>();
+        categories.add(createCategory("🎮", "Tài khoản game", "Nick game phổ biến, bảo hành rõ ràng"));
+        categories.add(createCategory("📧", "Email doanh nghiệp", "Tên miền riêng cho doanh nghiệp vừa và nhỏ"));
+        categories.add(createCategory("💼", "Phần mềm bản quyền", "Các gói Office, Windows chính hãng"));
+        categories.add(createCategory("🛡️", "Bảo mật", "Công cụ bảo vệ tài khoản, 2FA"));
+        return categories;
+    }
+
+    private Map<String, String> createCategory(String icon, String name, String description) {
+        Map<String, String> category = new HashMap<>();
+        category.put("icon", icon);
+        category.put("name", name);
+        category.put("description", description);
+        return category;
+    }
+
+    private List<Products> loadFeaturedProducts() {
+        return productService.homepageHighlights();
+    }
+
+    private Map<String, Object> buildCustomerProfile() {
+        Map<String, Object> profile = new HashMap<>();
+        profile.put("displayName", "Nguyễn Minh Trí");
+        profile.put("membershipLevel", "Thành viên hạng Platinum");
+        profile.put("joinDate", LocalDate.now().minusYears(2).format(DateTimeFormatter.ofPattern("dd/MM/yyyy")));
+        profile.put("successfulOrders", 128);
+        profile.put("satisfactionScore", 4.9);
+        return profile;
+    }
+
+    private List<Map<String, String>> buildReviews() {
+        List<Map<String, String>> reviews = new ArrayList<>();
+        reviews.add(createReview("Trần Anh", "5", "Giao key Netflix trong 2 phút, support nhiệt tình", "Netflix UHD 1 năm"));
+        reviews.add(createReview("Lê Phương", "4.5", "Tài khoản Spotify dùng ổn định, giá hợp lý", "Spotify Premium 12 tháng"));
+        reviews.add(createReview("Phạm Duy", "4.8", "Key Windows kích hoạt thành công ngay", "Windows 11 Pro key"));
+        return reviews;
+    }
+
+    private Map<String, String> createReview(String reviewer, String rating, String comment, String productName) {
+        Map<String, String> review = new HashMap<>();
+        review.put("reviewerName", reviewer);
+        review.put("rating", rating);
+        review.put("comment", comment);
+        review.put("productName", productName);
+        return review;
+    }
+
+    private List<String> buildBuyerTips() {
+        List<String> tips = new ArrayList<>();
+        tips.add("Luôn đổi mật khẩu sau khi nhận tài khoản từ người bán");
+        tips.add("Kích hoạt xác thực hai lớp ngay khi có thể");
+        tips.add("Liên hệ hỗ trợ trong 24h nếu có vấn đề phát sinh");
+        return tips;
     }
 }

--- a/MMO_Trader_Market/src/java/dao/order/OrderDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/OrderDAO.java
@@ -2,6 +2,10 @@ package dao.order;
 
 import dao.BaseDAO;
 import dao.product.ProductDAO;
+import model.Order;
+import model.OrderStatus;
+import model.Products;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -9,14 +13,10 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-import model.Order;
-import model.OrderStatus;
-import model.Products;
 
 /**
  * Provides persistence-like operations for buyer orders using an in-memory store.
  * @version 1.0 21/05/2024
- * @author gpt-5-codex
  */
 public class OrderDAO extends BaseDAO {
 
@@ -36,8 +36,7 @@ public class OrderDAO extends BaseDAO {
 
     /**
      * Persists a new order into the in-memory store.
-     * @param product
-     * @param products product being purchased
+     * @param product product being purchased
      * @param buyerEmail email used for delivery
      * @param paymentMethod selected payment channel
      * @return created order entity
@@ -65,7 +64,7 @@ public class OrderDAO extends BaseDAO {
         if (!ORDERS.isEmpty()) {
             return;
         }
-        List<ProductDAO> products = productDAO.findAll();
+        List<Products> products = productDAO.findAll();
         if (products.isEmpty()) {
             return;
         }

--- a/MMO_Trader_Market/src/java/service/ProductService.java
+++ b/MMO_Trader_Market/src/java/service/ProductService.java
@@ -17,13 +17,16 @@ public class ProductService {
         return productDAO.findHighlighted();
     }
 
-    public Products detail(int id) {
-        Products p = productDAO.findById(id);
-        if (p == null) throw new IllegalArgumentException("Sản phẩm không tồn tại hoặc đã bị xoá");
-        return p;
+    public List<Products> findAll() {
+        return productDAO.findAll();
     }
 
-    public Optional<Product> findById(int id) {
+    public Products detail(int id) {
+        return productDAO.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Sản phẩm không tồn tại hoặc đã bị xoá"));
+    }
+
+    public Optional<Products> findOptionalById(int id) {
         return productDAO.findById(id);
     }
 }

--- a/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
@@ -1,8 +1,8 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ page import="model.Product" %>
+<%@ page import="model.Products" %>
 <%
     request.setAttribute("bodyClass", "layout");
-    Product product = (Product) request.getAttribute("product");
+    Products product = (Products) request.getAttribute("product");
     String errorMessage = (String) request.getAttribute("error");
 %>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -1,15 +1,12 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.util.List" %>
-<%@ page import="model.Product" %>
-<%@ page import="model.ProductCategory" %>
-<%@ page import="model.ProductStatus" %>
-<%@ page import="model.CustomerProfile" %>
-<%@ page import="model.Review" %>
+<%@ page import="java.util.Map" %>
+<%@ page import="model.Products" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%
-    List<ProductCategory> categories = (List<ProductCategory>) request.getAttribute("categories");
-    List<Product> featuredProducts = (List<Product>) request.getAttribute("featuredProducts");
-    CustomerProfile profile = (CustomerProfile) request.getAttribute("customerProfile");
-    List<Review> reviews = (List<Review>) request.getAttribute("reviews");
+    List<Map<String, String>> categories = (List<Map<String, String>>) request.getAttribute("categories");
+    List<Products> featuredProducts = (List<Products>) request.getAttribute("featuredProducts");
+    List<Map<String, String>> reviews = (List<Map<String, String>>) request.getAttribute("reviews");
     List<String> buyerTips = (List<String>) request.getAttribute("buyerTips");
 %>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
@@ -61,7 +58,7 @@
 
         <div class="landing__products">
             <% if (featuredProducts != null) { %>
-                <% for (Product product : featuredProducts) { %>
+                <% for (Products product : featuredProducts) { %>
                     <article class="product-card">
                         <header class="product-card__header">
                             <h4><%= product.getName() %></h4>
@@ -75,7 +72,7 @@
                         </ul>
                         <footer class="product-card__footer">
                             <a class="button button--ghost" href="#">Xem chi tiết demo</a>
-                            <% if (product.getStatus() == ProductStatus.APPROVED) { %>
+                            <% if ("APPROVED".equalsIgnoreCase(product.getStatus())) { %>
                             <a class="button button--primary" href="<%= request.getContextPath() %>/orders/buy?productId=<%= product.getId() %>">Mua ngay</a>
                             <% } else { %>
                             <span class="badge badge--warning">Đang chờ duyệt</span>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -3,7 +3,6 @@
 <%@ page import="java.util.ArrayList" %>
 <%@ page import="java.util.HashMap" %>
 <%@ page import="java.util.Map" %>
-<%@ page import="model.Product" %>
 <%@ page import="model.Products" %>
 <%
     request.setAttribute("pageTitle", "Danh sách sản phẩm - MMO Trader Market");


### PR DESCRIPTION
## Summary
- replace the ad-hoc product DAO with deterministic in-memory demo data and expose helpers for product lookups
- tighten the two-step checkout flow to validate products, capture buyer info, and surface delivery details on confirmation and history pages
- populate the public homepage and product views with consistent sample datasets and correct JSP imports

## Testing
- Not run (ant is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f47a7277b08320bbaf093cfe6576b0