### PR TITLE
Implement buyer order filtering and pagination

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -60,7 +60,7 @@ public class HomepageController extends BaseController {
         navItems.add(productLink);
 
         Map<String, String> orderLink = new HashMap<>();
-        orderLink.put("href", contextPath + "/orders");
+        orderLink.put("href", contextPath + "/orders/my");
         orderLink.put("label", "Đơn đã mua");
         navItems.add(orderLink);
 

--- a/MMO_Trader_Market/src/java/controller/product/ProductListController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductListController.java
@@ -79,7 +79,7 @@ public class ProductListController extends BaseController {
         List<Map<String, String>> items = new ArrayList<>();
         items.add(createNavItem(contextPath + "/dashboard", "Bảng điều khiển"));
         items.add(createNavItem(contextPath + "/products", "Sản phẩm"));
-        items.add(createNavItem(contextPath + "/orders", "Đơn đã mua"));
+        items.add(createNavItem(contextPath + "/orders/my", "Đơn đã mua"));
         items.add(createNavItem(contextPath + "/styleguide", "Styleguide"));
         return items;
     }

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -26,20 +26,25 @@ public class OrderService {
     private final ProductService productService = new ProductService();
     private final BuyerDAO buyerDAO = new BuyerDAO();
 
-    public PaginatedResult<Order> listOrders(int page, int pageSize) {
+    public PaginatedResult<Order> listOrders(int buyerId, int page, int pageSize, OrderStatus status) {
+        if (buyerId <= 0) {
+            throw new IllegalArgumentException("Người dùng không hợp lệ.");
+        }
         if (pageSize <= 0) {
             throw new IllegalArgumentException("Số lượng mỗi trang phải lớn hơn 0.");
         }
         if (page < 1) {
             throw new IllegalArgumentException("Số trang phải lớn hơn hoặc bằng 1.");
         }
-        int totalItems = orderDAO.countAll();
-        int totalPages = Math.max(1, (int) Math.ceil((double) totalItems / pageSize));
-        int currentPage = Math.min(page, totalPages);
+        int totalItems = orderDAO.countByBuyer(buyerId, status);
+        int totalPages = totalItems == 0
+                ? 0
+                : (int) Math.ceil((double) totalItems / pageSize);
+        int currentPage = totalPages == 0 ? 1 : Math.min(page, totalPages);
         int offset = (currentPage - 1) * pageSize;
         List<Order> items = totalItems == 0
                 ? List.of()
-                : orderDAO.findAll(pageSize, offset);
+                : orderDAO.findByBuyer(buyerId, status, pageSize, offset);
         return new PaginatedResult<>(items, currentPage, totalPages, pageSize, totalItems);
     }
 

--- a/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
@@ -55,7 +55,7 @@
                             Bằng việc tiếp tục, bạn xác nhận đã đọc quy định bảo vệ người mua và sẵn sàng thanh toán.
                         </p>
                         <div style="display: flex; gap: 0.75rem;">
-                            <a class="button button--ghost" href="${pageContext.request.contextPath}/orders">Trở lại</a>
+                            <a class="button button--ghost" href="${pageContext.request.contextPath}/orders/my">Trở lại</a>
                             <button class="button button--primary" type="submit">Bước 2: Thanh toán</button>
                         </div>
                     </form>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/confirmation.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/confirmation.jsp
@@ -67,13 +67,13 @@
                         </div>
                     </div>
                     <div style="display: flex; gap: 0.75rem;">
-                        <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Xem danh sách đơn hàng</a>
+                        <a class="button button--primary" href="${pageContext.request.contextPath}/orders/my">Xem danh sách đơn hàng</a>
                         <a class="button button--ghost" href="${pageContext.request.contextPath}/home">Tiếp tục mua sắm</a>
                     </div>
                 </c:when>
                 <c:otherwise>
                     <div class="alert alert--error" role="alert">Không tìm thấy thông tin đơn hàng.</div>
-                    <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Quay lại danh sách</a>
+                    <a class="button button--primary" href="${pageContext.request.contextPath}/orders/my">Quay lại danh sách</a>
                 </c:otherwise>
             </c:choose>
         </div>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
@@ -15,9 +15,24 @@
             <c:if test="${not empty error}">
                 <div class="alert alert--error" role="alert"><c:out value="${error}" /></div>
             </c:if>
-            <p class="profile-card__note">Có tổng cộng ${totalItems} đơn hàng trong hệ thống.</p>
+            <p class="profile-card__note">Có tổng cộng ${total} đơn hàng đã mua.</p>
+            <form class="form form--inline" method="get" action="${pageContext.request.contextPath}/orders/my">
+                <input type="hidden" name="size" value="${size}" />
+                <label class="form__control">
+                    <span class="form__label">Trạng thái</span>
+                    <select name="status" class="form__select">
+                        <option value="">Tất cả</option>
+                        <c:forEach var="option" items="${statusOptions}">
+                            <option value="${option.key}" <c:if test="${option.key == statusFilter}">selected</c:if>>
+                                <c:out value="${option.value}" />
+                            </option>
+                        </c:forEach>
+                    </select>
+                </label>
+                <button type="submit" class="button button--ghost">Lọc</button>
+            </form>
             <c:choose>
-                <c:when test="${not empty orders}">
+                <c:when test="${not empty items}">
                     <table class="table table--interactive">
                         <thead>
                         <tr>
@@ -30,7 +45,7 @@
                         </tr>
                         </thead>
                         <tbody>
-                        <c:forEach var="order" items="${orders}">
+                        <c:forEach var="order" items="${items}">
                             <c:set var="orderId" value="${order.id}" />
                             <tr>
                                 <td>#<c:out value="${order.id}" /></td>
@@ -72,28 +87,36 @@
                     </table>
                 </c:when>
                 <c:otherwise>
-                    <p>Chưa có dữ liệu.</p>
+                    <p>Chưa có đơn hàng.</p>
                 </c:otherwise>
             </c:choose>
             <c:if test="${totalPages > 1}">
                 <nav class="pagination" aria-label="Phân trang đơn hàng">
                     <c:choose>
-                        <c:when test="${currentPage == 1}">
+                        <c:when test="${page == 1}">
                             <span class="pagination__item pagination__item--disabled" aria-disabled="true">«</span>
                         </c:when>
                         <c:otherwise>
-                            <c:url var="prevUrl" value="/orders">
-                                <c:param name="page" value="${currentPage - 1}" />
+                            <c:url var="prevUrl" value="/orders/my">
+                                <c:param name="page" value="${page - 1}" />
+                                <c:if test="${not empty statusFilter}">
+                                    <c:param name="status" value="${statusFilter}" />
+                                </c:if>
+                                <c:param name="size" value="${size}" />
                             </c:url>
                             <a class="pagination__item" href="${prevUrl}">«</a>
                         </c:otherwise>
                     </c:choose>
                     <c:forEach var="pageNumber" begin="1" end="${totalPages}">
-                        <c:url var="pageUrl" value="/orders">
+                        <c:url var="pageUrl" value="/orders/my">
                             <c:param name="page" value="${pageNumber}" />
+                            <c:if test="${not empty statusFilter}">
+                                <c:param name="status" value="${statusFilter}" />
+                            </c:if>
+                            <c:param name="size" value="${size}" />
                         </c:url>
                         <c:choose>
-                            <c:when test="${pageNumber == currentPage}">
+                            <c:when test="${pageNumber == page}">
                                 <a class="pagination__item pagination__item--active" href="${pageUrl}" aria-current="page">${pageNumber}</a>
                             </c:when>
                             <c:otherwise>
@@ -102,12 +125,16 @@
                         </c:choose>
                     </c:forEach>
                     <c:choose>
-                        <c:when test="${currentPage >= totalPages}">
+                        <c:when test="${page >= totalPages}">
                             <span class="pagination__item pagination__item--disabled" aria-disabled="true">»</span>
                         </c:when>
                         <c:otherwise>
-                            <c:url var="nextUrl" value="/orders">
-                                <c:param name="page" value="${currentPage + 1}" />
+                            <c:url var="nextUrl" value="/orders/my">
+                                <c:param name="page" value="${page + 1}" />
+                                <c:if test="${not empty statusFilter}">
+                                    <c:param name="status" value="${statusFilter}" />
+                                </c:if>
+                                <c:param name="size" value="${size}" />
                             </c:url>
                             <a class="pagination__item" href="${nextUrl}">»</a>
                         </c:otherwise>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -54,7 +54,7 @@
                                             <c:url var="buyUrl" value="/orders/buy">
                                                 <c:param name="productId" value="${product.id}" />
                                             </c:url>
-                                            <c:url var="ordersUrl" value="/orders" />
+                                            <c:url var="ordersUrl" value="/orders/my" />
                                             <a class="button button--primary" href="${buyUrl}">Mua ngay</a>
                                             <a class="button button--ghost" href="${ordersUrl}">Đơn đã mua</a>
                                         </c:when>


### PR DESCRIPTION
## Summary
- update the order controller to serve buyer history from `/orders/my`, pulling pagination and status filters from the request and session
- add DAO and service support for fetching paginated buyer orders with an optional status filter
- refresh JSP views to consume the new `{items, total, page, totalPages}` contract and link to the new route

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f4fb62f18c83209073f121a12b3d19