### PR TITLE
Add order detail view with secured credential access

### DIFF
--- a/MMO_Trader_Market/build/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/order/detail.jsp
@@ -1,0 +1,84 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Chi tiết đơn hàng</h2>
+            <c:if test="${not empty order}">
+                <span class="panel__tag">#<c:out value="${order.id}" /></span>
+            </c:if>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not empty order}">
+                    <article class="profile-card" style="margin-bottom: 1.5rem;">
+                        <h4>Sản phẩm: <c:out value="${order.product.name}" /></h4>
+                        <p class="profile-card__subtitle">Mua bởi: <c:out value="${order.buyerEmail}" /></p>
+                        <dl class="profile-card__stats">
+                            <div>
+                                <dt>Giá</dt>
+                                <dd>
+                                    <fmt:formatNumber value="${order.product.price}" type="number" minFractionDigits="0"
+                                                     maxFractionDigits="0" /> đ
+                                </dd>
+                            </div>
+                            <div>
+                                <dt>Thanh toán</dt>
+                                <dd><c:out value="${order.paymentMethod}" /></dd>
+                            </div>
+                            <div>
+                                <dt>Trạng thái</dt>
+                                <dd>
+                                    <span class="${orderStatusClass}">
+                                        <c:out value="${orderStatusLabel}" />
+                                    </span>
+                                </dd>
+                            </div>
+                            <div>
+                                <dt>Thời gian tạo</dt>
+                                <dd><c:out value="${orderCreatedAt}" /></dd>
+                            </div>
+                        </dl>
+                    </article>
+                    <div class="panel panel--sub" style="margin-bottom: 1.5rem;">
+                        <div class="panel__header">
+                            <h3 class="panel__title">Thông tin bàn giao</h3>
+                        </div>
+                        <div class="panel__body">
+                            <c:choose>
+                                <c:when test="${not empty order.activationCode}">
+                                    <p><strong>Activation key:</strong> <code><c:out value="${order.activationCode}" /></code></p>
+                                    <c:if test="${not empty order.deliveryLink}">
+                                        <p>
+                                            <strong>Đường dẫn tải sản phẩm:</strong>
+                                            <a href="${fn:escapeXml(order.deliveryLink)}"><c:out value="${order.deliveryLink}" /></a>
+                                        </p>
+                                    </c:if>
+                                    <p class="profile-card__note">Hãy bảo quản thông tin này cẩn thận để tránh lộ tài khoản.</p>
+                                </c:when>
+                                <c:otherwise>
+                                    <p>Đơn hàng đang chờ xử lý. Khi hoàn tất, thông tin bàn giao sẽ hiển thị tại đây và được gửi qua email.</p>
+                                </c:otherwise>
+                            </c:choose>
+                        </div>
+                    </div>
+                    <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+                        <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Quay lại danh sách</a>
+                        <a class="button button--ghost" href="${pageContext.request.contextPath}/home">Tiếp tục mua sắm</a>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                    <div class="alert alert--error" role="alert">Không tìm thấy thông tin đơn hàng.</div>
+                    <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Quay lại danh sách</a>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/build/web/WEB-INF/views/order/list.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/order/list.jsp
@@ -1,7 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
@@ -50,10 +49,7 @@
                                 <td>
                                     <c:choose>
                                         <c:when test="${not empty order.activationCode}">
-                                            <code><c:out value="${order.activationCode}" /></code><br>
-                                            <c:if test="${not empty order.deliveryLink}">
-                                                <a href="${fn:escapeXml(order.deliveryLink)}">Xem link</a>
-                                            </c:if>
+                                            <span class="badge">Sẵn sàng</span>
                                         </c:when>
                                         <c:otherwise>
                                             <span class="badge badge--ghost">Đang xử lý</span>
@@ -61,9 +57,13 @@
                                     </c:choose>
                                 </td>
                                 <td class="table__actions">
+                                    <c:url var="detailUrl" value="/orders/detail">
+                                        <c:param name="id" value="${order.id}" />
+                                    </c:url>
                                     <c:url var="buyAgainUrl" value="/orders/buy">
                                         <c:param name="productId" value="${order.product.id}" />
                                     </c:url>
+                                    <a class="button button--primary" href="${detailUrl}">Xem chi tiết</a>
                                     <a class="button button--ghost" href="${buyAgainUrl}">Mua lại</a>
                                 </td>
                             </tr>

--- a/MMO_Trader_Market/src/java/dao/user/BuyerDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/BuyerDAO.java
@@ -53,7 +53,7 @@ public class BuyerDAO extends BaseDAO {
                 + "ORDER BY COUNT(o.id) DESC, u.created_at ASC LIMIT 1";
         try (Connection connection = getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setString(1, OrderStatus.COMPLETED.toDatabaseValue());
+            statement.setString(1, OrderStatus.DELIVERED.toDatabaseValue());
             statement.setString(2, BUYER_ROLE);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {

--- a/MMO_Trader_Market/src/java/model/Order.java
+++ b/MMO_Trader_Market/src/java/model/Order.java
@@ -13,6 +13,7 @@ public class Order implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final int id;
+    private final int buyerId;
     private final Products product;
     private final String buyerEmail;
     private final String paymentMethod;
@@ -21,14 +22,15 @@ public class Order implements Serializable {
     private String activationCode;
     private String deliveryLink;
 
-    public Order(int id, Products product, String buyerEmail, String paymentMethod,
+    public Order(int id, int buyerId, Products product, String buyerEmail, String paymentMethod,
             OrderStatus status, LocalDateTime createdAt) {
-        this(id, product, buyerEmail, paymentMethod, status, createdAt, null, null);
+        this(id, buyerId, product, buyerEmail, paymentMethod, status, createdAt, null, null);
     }
 
-    public Order(int id, Products product, String buyerEmail, String paymentMethod,
+    public Order(int id, int buyerId, Products product, String buyerEmail, String paymentMethod,
             OrderStatus status, LocalDateTime createdAt, String activationCode, String deliveryLink) {
         this.id = id;
+        this.buyerId = buyerId;
         this.product = product;
         this.buyerEmail = buyerEmail;
         this.paymentMethod = paymentMethod;
@@ -40,6 +42,10 @@ public class Order implements Serializable {
 
     public int getId() {
         return id;
+    }
+
+    public int getBuyerId() {
+        return buyerId;
     }
 
     public Products getProduct() {
@@ -97,7 +103,7 @@ public class Order implements Serializable {
      * @param deliveryLink optional URL for downloading the product
      */
     public void markCompleted(String activationCode, String deliveryLink) {
-        this.status = OrderStatus.COMPLETED;
+        this.status = OrderStatus.DELIVERED;
         this.activationCode = activationCode;
         this.deliveryLink = deliveryLink;
     }

--- a/MMO_Trader_Market/src/java/model/OrderStatus.java
+++ b/MMO_Trader_Market/src/java/model/OrderStatus.java
@@ -6,12 +6,19 @@ package model;
  * @author gpt-5-codex
  */
 public enum OrderStatus {
-    PENDING,
-    PROCESSING,
-    COMPLETED,
-    FAILED,
-    REFUNDED,
-    DISPUTED;
+    PENDING("Pending"),
+    PROCESSING("Processing"),
+    CONFIRMED("Confirmed"),
+    DELIVERED("Completed"),
+    FAILED("Failed"),
+    REFUNDED("Refunded"),
+    DISPUTED("Disputed");
+
+    private final String databaseValue;
+
+    OrderStatus(String databaseValue) {
+        this.databaseValue = databaseValue;
+    }
 
     public static OrderStatus fromDatabaseValue(String value) {
         if (value == null) {
@@ -20,7 +27,8 @@ public enum OrderStatus {
         return switch (value.toUpperCase()) {
             case "PENDING" -> PENDING;
             case "PROCESSING" -> PROCESSING;
-            case "COMPLETED" -> COMPLETED;
+            case "CONFIRMED" -> CONFIRMED;
+            case "DELIVERED", "COMPLETED" -> DELIVERED;
             case "FAILED" -> FAILED;
             case "REFUNDED" -> REFUNDED;
             case "DISPUTED" -> DISPUTED;
@@ -29,13 +37,6 @@ public enum OrderStatus {
     }
 
     public String toDatabaseValue() {
-        return switch (this) {
-            case PENDING -> "Pending";
-            case PROCESSING -> "Processing";
-            case COMPLETED -> "Completed";
-            case FAILED -> "Failed";
-            case REFUNDED -> "Refunded";
-            case DISPUTED -> "Disputed";
-        };
+        return databaseValue;
     }
 }

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -41,7 +41,7 @@ public class HomepageService {
     }
 
     public MarketplaceSummary loadMarketplaceSummary() {
-        long completedOrders = orderDAO.countByStatus(OrderStatus.COMPLETED);
+        long completedOrders = orderDAO.countByStatus(OrderStatus.DELIVERED);
         long activeShops = shopDAO.countActive();
         long activeBuyers = buyerDAO.countActiveBuyers();
         return new MarketplaceSummary(completedOrders, activeShops, activeBuyers);
@@ -63,7 +63,7 @@ public class HomepageService {
 
     private CustomerProfileView buildProfile(Users buyer) {
         long totalOrders = orderDAO.countByBuyer(buyer.getId());
-        long completedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.COMPLETED);
+        long completedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.DELIVERED);
         long disputedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.DISPUTED);
         double satisfaction = totalOrders == 0 ? 0 : roundToOneDecimal((completedOrders * 5.0) / totalOrders);
         LocalDate joinDate = toLocalDate(buyer.getCreatedAt());

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -1,0 +1,84 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Chi tiết đơn hàng</h2>
+            <c:if test="${not empty order}">
+                <span class="panel__tag">#<c:out value="${order.id}" /></span>
+            </c:if>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not empty order}">
+                    <article class="profile-card" style="margin-bottom: 1.5rem;">
+                        <h4>Sản phẩm: <c:out value="${order.product.name}" /></h4>
+                        <p class="profile-card__subtitle">Mua bởi: <c:out value="${order.buyerEmail}" /></p>
+                        <dl class="profile-card__stats">
+                            <div>
+                                <dt>Giá</dt>
+                                <dd>
+                                    <fmt:formatNumber value="${order.product.price}" type="number" minFractionDigits="0"
+                                                     maxFractionDigits="0" /> đ
+                                </dd>
+                            </div>
+                            <div>
+                                <dt>Thanh toán</dt>
+                                <dd><c:out value="${order.paymentMethod}" /></dd>
+                            </div>
+                            <div>
+                                <dt>Trạng thái</dt>
+                                <dd>
+                                    <span class="${orderStatusClass}">
+                                        <c:out value="${orderStatusLabel}" />
+                                    </span>
+                                </dd>
+                            </div>
+                            <div>
+                                <dt>Thời gian tạo</dt>
+                                <dd><c:out value="${orderCreatedAt}" /></dd>
+                            </div>
+                        </dl>
+                    </article>
+                    <div class="panel panel--sub" style="margin-bottom: 1.5rem;">
+                        <div class="panel__header">
+                            <h3 class="panel__title">Thông tin bàn giao</h3>
+                        </div>
+                        <div class="panel__body">
+                            <c:choose>
+                                <c:when test="${not empty order.activationCode}">
+                                    <p><strong>Activation key:</strong> <code><c:out value="${order.activationCode}" /></code></p>
+                                    <c:if test="${not empty order.deliveryLink}">
+                                        <p>
+                                            <strong>Đường dẫn tải sản phẩm:</strong>
+                                            <a href="${fn:escapeXml(order.deliveryLink)}"><c:out value="${order.deliveryLink}" /></a>
+                                        </p>
+                                    </c:if>
+                                    <p class="profile-card__note">Hãy bảo quản thông tin này cẩn thận để tránh lộ tài khoản.</p>
+                                </c:when>
+                                <c:otherwise>
+                                    <p>Đơn hàng đang chờ xử lý. Khi hoàn tất, thông tin bàn giao sẽ hiển thị tại đây và được gửi qua email.</p>
+                                </c:otherwise>
+                            </c:choose>
+                        </div>
+                    </div>
+                    <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+                        <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Quay lại danh sách</a>
+                        <a class="button button--ghost" href="${pageContext.request.contextPath}/home">Tiếp tục mua sắm</a>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                    <div class="alert alert--error" role="alert">Không tìm thấy thông tin đơn hàng.</div>
+                    <a class="button button--primary" href="${pageContext.request.contextPath}/orders">Quay lại danh sách</a>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
@@ -1,7 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
@@ -50,10 +49,7 @@
                                 <td>
                                     <c:choose>
                                         <c:when test="${not empty order.activationCode}">
-                                            <code><c:out value="${order.activationCode}" /></code><br>
-                                            <c:if test="${not empty order.deliveryLink}">
-                                                <a href="${fn:escapeXml(order.deliveryLink)}">Xem link</a>
-                                            </c:if>
+                                            <span class="badge">Sẵn sàng</span>
                                         </c:when>
                                         <c:otherwise>
                                             <span class="badge badge--ghost">Đang xử lý</span>
@@ -61,9 +57,13 @@
                                     </c:choose>
                                 </td>
                                 <td class="table__actions">
+                                    <c:url var="detailUrl" value="/orders/detail">
+                                        <c:param name="id" value="${order.id}" />
+                                    </c:url>
                                     <c:url var="buyAgainUrl" value="/orders/buy">
                                         <c:param name="productId" value="${order.product.id}" />
                                     </c:url>
+                                    <a class="button button--primary" href="${detailUrl}">Xem chi tiết</a>
                                     <a class="button button--ghost" href="${buyAgainUrl}">Mua lại</a>
                                 </td>
                             </tr>


### PR DESCRIPTION
## Summary
- add /orders/detail handler that validates the signed-in buyer before showing order data and logs the access
- gate credential exposure in the order service/DAO, including new helper to fetch encrypted credentials and updated status mappings
- create an order detail JSP and refresh the order list actions/UI to link to the protected view

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68f4fb6560d8832092c7506ec86e5d4d