### PR TITLE
Implement async buy-now flow with wallet holds

### DIFF
--- a/MMO_Trader_Market/src/java/dao/user/BuyerDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/BuyerDAO.java
@@ -53,7 +53,7 @@ public class BuyerDAO extends BaseDAO {
                 + "ORDER BY COUNT(o.id) DESC, u.created_at ASC LIMIT 1";
         try (Connection connection = getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setString(1, OrderStatus.COMPLETED.toDatabaseValue());
+            statement.setString(1, OrderStatus.CONFIRMED.toDatabaseValue());
             statement.setString(2, BUYER_ROLE);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {

--- a/MMO_Trader_Market/src/java/dao/wallet/WalletDAO.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/WalletDAO.java
@@ -1,121 +1,289 @@
 package dao.wallet;
 
+import dao.BaseDAO;
+
 import java.math.BigDecimal;
-import java.util.Map;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
- * Simplified DAO that keeps track of wallet holds. In a production system this
- * would be persisted inside the database but for the purposes of this
- * application we keep the state in-memory to focus on the orchestration logic.
+ * DAO responsible for wallet balance mutations.
  */
-public class WalletDAO {
+public class WalletDAO extends BaseDAO {
 
-    private static final Map<String, WalletHoldRecord> HOLDS = new ConcurrentHashMap<>();
+    private static final Logger LOGGER = Logger.getLogger(WalletDAO.class.getName());
 
-    public WalletHoldRecord createHold(int buyerId, int sellerId, BigDecimal amount, int orderId, String orderToken) {
-        WalletHoldRecord record = new WalletHoldRecord(buyerId, sellerId, amount, orderId, orderToken);
-        WalletHoldRecord existing = HOLDS.putIfAbsent(orderToken, record);
-        if (existing != null) {
-            throw new IllegalStateException("Hold already exists for token " + orderToken);
+    public Optional<WalletSnapshot> findWalletForUpdate(Connection connection, int userId) throws SQLException {
+        String sql = "SELECT id, balance, hold_balance FROM wallets WHERE user_id = ? FOR UPDATE";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, userId);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    BigDecimal balance = rs.getBigDecimal("balance");
+                    BigDecimal holdBalance = rs.getBigDecimal("hold_balance");
+                    return Optional.of(new WalletSnapshot(rs.getInt("id"), balance, holdBalance));
+                }
+            }
         }
-        return record;
+        return Optional.empty();
+    }
+
+    public WalletHoldRecord createHold(int buyerId, int sellerId, BigDecimal amount, int orderId, String orderToken)
+            throws SQLException {
+        try (Connection connection = getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                WalletSnapshot wallet = findWalletForUpdate(connection, buyerId)
+                        .orElseThrow(() -> new IllegalStateException("Không tìm thấy ví khách hàng"));
+
+                BigDecimal available = wallet.balance().subtract(wallet.holdBalance());
+                if (available.compareTo(amount) < 0) {
+                    throw new IllegalStateException("Số dư ví không đủ");
+                }
+
+                updateHoldBalance(connection, wallet.id(), amount, true);
+                long transactionId = insertTransaction(connection, wallet.id(), orderId, "HOLD", amount,
+                        wallet.balance(), wallet.balance(), orderToken);
+                long holdId = insertHold(connection, wallet.id(), orderId, orderToken, amount, "HOLD", transactionId);
+
+                connection.commit();
+                return new WalletHoldRecord(holdId, wallet.id(), buyerId, sellerId, amount, orderId, orderToken,
+                        transactionId, WalletHoldStatus.HOLD);
+            } catch (SQLException | RuntimeException ex) {
+                connection.rollback();
+                if (ex instanceof RuntimeException runtime && !(runtime instanceof IllegalStateException)) {
+                    LOGGER.log(Level.SEVERE, "createHold failed", ex);
+                }
+                throw ex;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        }
+    }
+
+    public WalletHoldRecord capture(String orderToken) throws SQLException {
+        return transition(orderToken, WalletHoldStatus.CAPTURED, true, false);
+    }
+
+    public WalletHoldRecord release(String orderToken) throws SQLException {
+        return transition(orderToken, WalletHoldStatus.RELEASED, false, true);
+    }
+
+    public WalletHoldRecord refund(String orderToken) throws SQLException {
+        return transition(orderToken, WalletHoldStatus.REFUNDED, false, false);
     }
 
     public Optional<WalletHoldRecord> findHold(String orderToken) {
-        return Optional.ofNullable(HOLDS.get(orderToken));
+        String sql = "SELECT id, wallet_id, order_id, order_token, amount, status, transaction_id "
+                + "FROM wallet_holds WHERE order_token = ? LIMIT 1";
+        try (Connection connection = getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, orderToken);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapHold(rs));
+                }
+            }
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "findHold failed", ex);
+        }
+        return Optional.empty();
     }
 
-    public WalletHoldRecord capture(String orderToken) {
-        WalletHoldRecord record = HOLDS.get(orderToken);
-        if (record == null) {
-            throw new IllegalStateException("Hold not found for token " + orderToken);
+    private WalletHoldRecord transition(String orderToken, WalletHoldStatus targetStatus,
+            boolean subtractBalance, boolean releaseBalance) throws SQLException {
+        try (Connection connection = getConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                HoldSnapshot hold = lockHold(connection, orderToken);
+                if (hold.status() != WalletHoldStatus.HOLD) {
+                    return mapRecord(hold);
+                }
+                WalletSnapshot wallet = findWalletForUpdate(connection, hold.buyerId())
+                        .orElseThrow(() -> new IllegalStateException("Không tìm thấy ví khách hàng"));
+
+                if (subtractBalance) {
+                    BigDecimal newBalance = wallet.balance().subtract(hold.amount());
+                    if (newBalance.compareTo(BigDecimal.ZERO) < 0) {
+                        throw new IllegalStateException("Ví không đủ để ghi nhận thanh toán");
+                    }
+                    updateBalance(connection, wallet.id(), newBalance);
+                }
+                if (releaseBalance) {
+                    updateHoldBalance(connection, wallet.id(), hold.amount(), false);
+                } else {
+                    updateHoldBalance(connection, wallet.id(), hold.amount(), false);
+                }
+
+                WalletSnapshot refreshed = findWalletForUpdate(connection, hold.buyerId())
+                        .orElseThrow(() -> new IllegalStateException("Không tìm thấy ví khách hàng"));
+
+                BigDecimal balanceBefore = wallet.balance();
+                BigDecimal balanceAfter = refreshed.balance();
+                if (!subtractBalance) {
+                    balanceAfter = balanceBefore;
+                }
+                long txId = insertTransaction(connection, wallet.id(), hold.orderId(), targetStatus.name(), hold.amount(),
+                        balanceBefore, balanceAfter, orderToken);
+                updateHoldStatus(connection, hold.id(), targetStatus, txId);
+
+                connection.commit();
+                return new WalletHoldRecord(hold.id(), wallet.id(), hold.buyerId(), hold.sellerId(), hold.amount(),
+                        hold.orderId(), orderToken, txId, targetStatus);
+            } catch (SQLException | RuntimeException ex) {
+                connection.rollback();
+                if (ex instanceof RuntimeException runtime && !(runtime instanceof IllegalStateException)) {
+                    LOGGER.log(Level.SEVERE, "transition hold failed", ex);
+                }
+                throw ex;
+            } finally {
+                connection.setAutoCommit(true);
+            }
         }
-        record.setCaptured(true);
-        return record;
     }
 
-    public WalletHoldRecord release(String orderToken) {
-        WalletHoldRecord record = HOLDS.remove(orderToken);
-        if (record == null) {
-            throw new IllegalStateException("Hold not found for token " + orderToken);
+    private void updateHoldBalance(Connection connection, int walletId, BigDecimal amount, boolean increase)
+            throws SQLException {
+        String sql = increase
+                ? "UPDATE wallets SET hold_balance = hold_balance + ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?"
+                : "UPDATE wallets SET hold_balance = hold_balance - ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setBigDecimal(1, amount);
+            statement.setInt(2, walletId);
+            statement.executeUpdate();
         }
-        record.setCaptured(false);
-        record.setReleased(true);
-        return record;
     }
 
-    public WalletHoldRecord refund(String orderToken) {
-        WalletHoldRecord record = HOLDS.remove(orderToken);
-        if (record == null) {
-            throw new IllegalStateException("Hold not found for token " + orderToken);
+    private void updateBalance(Connection connection, int walletId, BigDecimal balance) throws SQLException {
+        String sql = "UPDATE wallets SET balance = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setBigDecimal(1, balance);
+            statement.setInt(2, walletId);
+            statement.executeUpdate();
         }
-        record.setCaptured(false);
-        record.setRefunded(true);
-        return record;
     }
 
-    public static final class WalletHoldRecord {
-        private final int buyerId;
-        private final int sellerId;
-        private final BigDecimal amount;
-        private final int orderId;
-        private final String orderToken;
-        private volatile boolean captured;
-        private volatile boolean released;
-        private volatile boolean refunded;
-
-        private WalletHoldRecord(int buyerId, int sellerId, BigDecimal amount, int orderId, String orderToken) {
-            this.buyerId = buyerId;
-            this.sellerId = sellerId;
-            this.amount = amount;
-            this.orderId = orderId;
-            this.orderToken = orderToken;
+    private long insertTransaction(Connection connection, int walletId, int orderId, String type,
+            BigDecimal amount, BigDecimal before, BigDecimal after, String orderToken) throws SQLException {
+        String sql = "INSERT INTO wallet_transactions (wallet_id, related_entity_id, transaction_type, amount, "
+                + "balance_before, balance_after, note, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)";
+        try (PreparedStatement statement = connection.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, walletId);
+            statement.setInt(2, orderId);
+            statement.setString(3, type);
+            statement.setBigDecimal(4, amount);
+            statement.setBigDecimal(5, before);
+            statement.setBigDecimal(6, after);
+            statement.setString(7, orderToken);
+            statement.executeUpdate();
+            try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
         }
+        throw new SQLException("Không thể tạo giao dịch ví");
+    }
 
-        public int getBuyerId() {
-            return buyerId;
+    private long insertHold(Connection connection, int walletId, int orderId, String orderToken,
+            BigDecimal amount, String status, long transactionId) throws SQLException {
+        String sql = "INSERT INTO wallet_holds (wallet_id, order_id, order_token, amount, status, transaction_id, "
+                + "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)";
+        try (PreparedStatement statement = connection.prepareStatement(sql, PreparedStatement.RETURN_GENERATED_KEYS)) {
+            statement.setInt(1, walletId);
+            statement.setInt(2, orderId);
+            statement.setString(3, orderToken);
+            statement.setBigDecimal(4, amount);
+            statement.setString(5, status);
+            statement.setLong(6, transactionId);
+            statement.executeUpdate();
+            try (ResultSet keys = statement.getGeneratedKeys()) {
+                if (keys.next()) {
+                    return keys.getLong(1);
+                }
+            }
         }
+        throw new SQLException("Không thể tạo hold ví");
+    }
 
-        public int getSellerId() {
-            return sellerId;
+    private HoldSnapshot lockHold(Connection connection, String orderToken) throws SQLException {
+        String sql = "SELECT h.id, h.wallet_id, w.user_id AS buyer_id, h.amount, h.status, h.transaction_id, h.order_id, "
+                + "h.created_at, h.updated_at, s.owner_id AS seller_id "
+                + "FROM wallet_holds h "
+                + "JOIN wallets w ON w.id = h.wallet_id "
+                + "JOIN orders o ON o.id = h.order_id "
+                + "JOIN products p ON p.id = o.product_id "
+                + "JOIN shops s ON s.id = p.shop_id "
+                + "WHERE h.order_token = ? FOR UPDATE";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, orderToken);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException("Không tìm thấy giao dịch hold");
+                }
+                return new HoldSnapshot(
+                        rs.getLong("id"),
+                        rs.getInt("wallet_id"),
+                        rs.getInt("buyer_id"),
+                        rs.getInt("seller_id"),
+                        rs.getInt("order_id"),
+                        rs.getBigDecimal("amount"),
+                        WalletHoldStatus.valueOf(rs.getString("status")),
+                        rs.getLong("transaction_id"));
+            }
         }
+    }
 
-        public BigDecimal getAmount() {
-            return amount;
+    private void updateHoldStatus(Connection connection, long holdId, WalletHoldStatus status, long transactionId)
+            throws SQLException {
+        String sql = "UPDATE wallet_holds SET status = ?, transaction_id = ?, updated_at = ? WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, status.name());
+            statement.setLong(2, transactionId);
+            statement.setTimestamp(3, Timestamp.from(Instant.now()));
+            statement.setLong(4, holdId);
+            statement.executeUpdate();
         }
+    }
 
-        public int getOrderId() {
-            return orderId;
-        }
+    private WalletHoldRecord mapHold(ResultSet rs) throws SQLException {
+        long id = rs.getLong("id");
+        int walletId = rs.getInt("wallet_id");
+        int orderId = rs.getInt("order_id");
+        String token = rs.getString("order_token");
+        BigDecimal amount = rs.getBigDecimal("amount");
+        WalletHoldStatus status = WalletHoldStatus.valueOf(rs.getString("status"));
+        long transactionId = rs.getLong("transaction_id");
+        return new WalletHoldRecord(id, walletId, 0, 0, amount, orderId, token, transactionId, status);
+    }
 
-        public String getOrderToken() {
-            return orderToken;
-        }
+    private WalletHoldRecord mapRecord(HoldSnapshot snapshot) {
+        return new WalletHoldRecord(snapshot.id(), snapshot.walletId(), snapshot.buyerId(), snapshot.sellerId(),
+                snapshot.amount(), snapshot.orderId(), null, snapshot.transactionId(), snapshot.status());
+    }
 
-        public boolean isCaptured() {
-            return captured;
-        }
+    public record WalletSnapshot(int id, BigDecimal balance, BigDecimal holdBalance) {
+    }
 
-        public void setCaptured(boolean captured) {
-            this.captured = captured;
-        }
+    public enum WalletHoldStatus {
+        HOLD,
+        CAPTURED,
+        RELEASED,
+        REFUNDED
+    }
 
-        public boolean isReleased() {
-            return released;
-        }
+    public record WalletHoldRecord(long id, int walletId, int buyerId, int sellerId, BigDecimal amount,
+            int orderId, String orderToken, long transactionId, WalletHoldStatus status) {
+    }
 
-        public void setReleased(boolean released) {
-            this.released = released;
-        }
-
-        public boolean isRefunded() {
-            return refunded;
-        }
-
-        public void setRefunded(boolean refunded) {
-            this.refunded = refunded;
-        }
+    private record HoldSnapshot(long id, int walletId, int buyerId, int sellerId, int orderId, BigDecimal amount,
+            WalletHoldStatus status, long transactionId) {
     }
 }

--- a/MMO_Trader_Market/src/java/model/Order.java
+++ b/MMO_Trader_Market/src/java/model/Order.java
@@ -1,12 +1,11 @@
 package model;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
- * Represents a purchase order created by a buyer after completing the checkout flow.
- * @version 1.0 21/05/2024
- * @author gpt-5-codex
+ * Represents an order placed by a buyer.
  */
 public class Order implements Serializable {
 
@@ -15,7 +14,7 @@ public class Order implements Serializable {
     private final int id;
     private final Products product;
     private final String buyerEmail;
-    private final String paymentMethod;
+    private final BigDecimal totalAmount;
     private final LocalDateTime createdAt;
     private final Integer buyerId;
     private final String orderToken;
@@ -24,23 +23,13 @@ public class Order implements Serializable {
     private String activationCode;
     private String deliveryLink;
 
-    public Order(int id, Products product, String buyerEmail, String paymentMethod,
-            OrderStatus status, LocalDateTime createdAt) {
-        this(id, product, buyerEmail, paymentMethod, status, createdAt, null, null, null, null, null);
-    }
-
-    public Order(int id, Products product, String buyerEmail, String paymentMethod,
-            OrderStatus status, LocalDateTime createdAt, String activationCode, String deliveryLink) {
-        this(id, product, buyerEmail, paymentMethod, status, createdAt, activationCode, deliveryLink, null, null, null);
-    }
-
-    public Order(int id, Products product, String buyerEmail, String paymentMethod,
-            OrderStatus status, LocalDateTime createdAt, String activationCode, String deliveryLink,
-            Integer buyerId, String orderToken, Integer quantity) {
+    public Order(int id, Products product, String buyerEmail, BigDecimal totalAmount,
+            OrderStatus status, LocalDateTime createdAt, String activationCode,
+            String deliveryLink, Integer buyerId, String orderToken, Integer quantity) {
         this.id = id;
         this.product = product;
         this.buyerEmail = buyerEmail;
-        this.paymentMethod = paymentMethod;
+        this.totalAmount = totalAmount;
         this.status = status;
         this.createdAt = createdAt;
         this.activationCode = activationCode;
@@ -62,8 +51,8 @@ public class Order implements Serializable {
         return buyerEmail;
     }
 
-    public String getPaymentMethod() {
-        return paymentMethod;
+    public BigDecimal getTotalAmount() {
+        return totalAmount;
     }
 
     public LocalDateTime getCreatedAt() {
@@ -106,39 +95,6 @@ public class Order implements Serializable {
         this.deliveryLink = deliveryLink;
     }
 
-    /**
-     * Marks the order as currently being processed.
-     */
-    public void markProcessing() {
-        this.status = OrderStatus.PROCESSING;
-        this.activationCode = null;
-        this.deliveryLink = null;
-    }
-
-    /**
-     * Marks the order as completed and stores the delivery artefacts.
-     * @param activationCode unique key or password delivered to the buyer
-     * @param deliveryLink optional URL for downloading the product
-     */
-    public void markCompleted(String activationCode, String deliveryLink) {
-        this.status = OrderStatus.COMPLETED;
-        this.activationCode = activationCode;
-        this.deliveryLink = deliveryLink;
-    }
-
-    /**
-     * Marks the order as disputed but keeps the current activation code for reference.
-     * @param activationCode activation code to show during dispute resolution
-     */
-    public void markDisputed(String activationCode) {
-        this.status = OrderStatus.DISPUTED;
-        this.activationCode = activationCode;
-    }
-
-    /**
-     * Indicates whether the digital delivery information is ready to display to the buyer.
-     * @return {@code true} if at least the activation code exists
-     */
     public boolean hasDeliveryInformation() {
         return activationCode != null && !activationCode.isBlank();
     }

--- a/MMO_Trader_Market/src/java/model/OrderStatus.java
+++ b/MMO_Trader_Market/src/java/model/OrderStatus.java
@@ -1,17 +1,15 @@
 package model;
 
 /**
- * Enumeration that describes the current lifecycle state of a buyer order.
- * @version 1.0 21/05/2024
- * @author gpt-5-codex
+ * Order states supported by the asynchronous checkout pipeline.
  */
 public enum OrderStatus {
     PENDING,
-    PROCESSING,
-    COMPLETED,
+    CONFIRMED,
     FAILED,
+    DELIVERED,
     REFUNDED,
-    DISPUTED;
+    CANCELLED;
 
     public static OrderStatus fromDatabaseValue(String value) {
         if (value == null) {
@@ -19,23 +17,23 @@ public enum OrderStatus {
         }
         return switch (value.toUpperCase()) {
             case "PENDING" -> PENDING;
-            case "PROCESSING" -> PROCESSING;
-            case "COMPLETED" -> COMPLETED;
+            case "CONFIRMED" -> CONFIRMED;
             case "FAILED" -> FAILED;
+            case "DELIVERED" -> DELIVERED;
             case "REFUNDED" -> REFUNDED;
-            case "DISPUTED" -> DISPUTED;
+            case "CANCELLED" -> CANCELLED;
             default -> null;
         };
     }
 
     public String toDatabaseValue() {
         return switch (this) {
-            case PENDING -> "Pending";
-            case PROCESSING -> "Processing";
-            case COMPLETED -> "Completed";
-            case FAILED -> "Failed";
-            case REFUNDED -> "Refunded";
-            case DISPUTED -> "Disputed";
+            case PENDING -> "PENDING";
+            case CONFIRMED -> "CONFIRMED";
+            case FAILED -> "FAILED";
+            case DELIVERED -> "DELIVERED";
+            case REFUNDED -> "REFUNDED";
+            case CANCELLED -> "CANCELLED";
         };
     }
 }

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -41,7 +41,7 @@ public class HomepageService {
     }
 
     public MarketplaceSummary loadMarketplaceSummary() {
-        long completedOrders = orderDAO.countByStatus(OrderStatus.COMPLETED);
+        long completedOrders = orderDAO.countByStatus(OrderStatus.CONFIRMED);
         long activeShops = shopDAO.countActive();
         long activeBuyers = buyerDAO.countActiveBuyers();
         return new MarketplaceSummary(completedOrders, activeShops, activeBuyers);
@@ -63,8 +63,8 @@ public class HomepageService {
 
     private CustomerProfileView buildProfile(Users buyer) {
         long totalOrders = orderDAO.countByBuyer(buyer.getId());
-        long completedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.COMPLETED);
-        long disputedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.DISPUTED);
+        long completedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.CONFIRMED);
+        long refundedOrders = orderDAO.countByBuyerAndStatus(buyer.getId(), OrderStatus.REFUNDED);
         double satisfaction = totalOrders == 0 ? 0 : roundToOneDecimal((completedOrders * 5.0) / totalOrders);
         LocalDate joinDate = toLocalDate(buyer.getCreatedAt());
         return new CustomerProfileView(
@@ -73,7 +73,7 @@ public class HomepageService {
                 joinDate,
                 totalOrders,
                 completedOrders,
-                disputedOrders,
+                refundedOrders,
                 satisfaction);
     }
 

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -1,13 +1,13 @@
 package service;
 
 import dao.order.OrderDAO;
-import dao.user.BuyerDAO;
 import model.Order;
 import model.OrderStatus;
 import model.PaginatedResult;
 import model.Products;
 import model.Users;
 import queue.OrderQueueProducer;
+import service.dto.OrderDetailView;
 import service.dto.OrderPlacementResult;
 import service.dto.OrderStatusView;
 
@@ -21,15 +21,14 @@ import java.util.UUID;
 
 /**
  * Contains the business rules for processing a buyer checkout request.
- * @version 1.0 21/05/2024
  */
 public class OrderService {
 
-    private static final Set<String> PURCHASABLE_STATUSES = Set.of("AVAILABLE");
+    private static final Set<String> ALLOWED_PRODUCT_STATUSES = Set.of("APPROVED");
+    private static final Set<Integer> PURCHASER_ROLES = Set.of(2, 3); // 2: Seller, 3: Buyer
 
     private final OrderDAO orderDAO = new OrderDAO();
     private final ProductService productService = new ProductService();
-    private final BuyerDAO buyerDAO = new BuyerDAO();
     private final WalletService walletService = new WalletService();
     private final OrderQueueProducer orderQueueProducer = OrderQueueProducer.getInstance();
 
@@ -40,26 +39,19 @@ public class OrderService {
         if (pageSize <= 0) {
             throw new IllegalArgumentException("Số lượng mỗi trang phải lớn hơn 0.");
         }
-        if (page < 1) {
-            throw new IllegalArgumentException("Số trang phải lớn hơn hoặc bằng 1.");
-        }
+        int safePage = Math.max(page, 1);
         int totalItems = orderDAO.countByBuyer(buyerId, status);
-        int totalPages = totalItems == 0
-                ? 0
-                : (int) Math.ceil((double) totalItems / pageSize);
-        int currentPage = totalPages == 0 ? 1 : Math.min(page, totalPages);
-        int offset = (currentPage - 1) * pageSize;
+        int totalPages = totalItems == 0 ? 0 : (int) Math.ceil((double) totalItems / pageSize);
+        if (totalPages > 0 && safePage > totalPages) {
+            safePage = totalPages;
+        }
+        int offset = (safePage - 1) * pageSize;
         List<Order> items = totalItems == 0
                 ? List.of()
                 : orderDAO.findByBuyer(buyerId, status, pageSize, offset);
-        return new PaginatedResult<>(items, currentPage, totalPages, pageSize, totalItems);
+        return new PaginatedResult<>(items, safePage, totalPages, pageSize, totalItems);
     }
 
-    /**
-     * Ensures the product exists and has been approved before buyers can continue checkout.
-     * @param productId identifier coming from the UI
-     * @return the validated product
-     */
     public Products validatePurchasableProduct(int productId) {
         Products product = productService.findOptionalById(productId)
                 .orElseThrow(() -> new IllegalArgumentException("Sản phẩm bạn chọn không tồn tại hoặc đã bị gỡ."));
@@ -69,19 +61,31 @@ public class OrderService {
         return product;
     }
 
-    public OrderPlacementResult placeOrder(Users buyer, int productId, int quantity) {
+    public OrderPlacementResult placeOrder(Users buyer, int productId, int quantity, String existingToken) {
         if (buyer == null || buyer.getId() == null) {
             throw new IllegalStateException("Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.");
         }
+        if (!PURCHASER_ROLES.contains(buyer.getRoleId())) {
+            throw new IllegalStateException("Tài khoản của bạn không được phép mua hàng.");
+        }
         if (quantity <= 0) {
             throw new IllegalArgumentException("Số lượng mua phải lớn hơn 0.");
+        }
+
+        String normalizedToken = existingToken == null ? null : existingToken.trim();
+        if (normalizedToken != null && !normalizedToken.isEmpty()) {
+            Optional<Order> existing = orderDAO.findByTokenAndBuyer(normalizedToken, buyer.getId());
+            if (existing.isPresent()) {
+                Order current = existing.get();
+                return new OrderPlacementResult(current.getId(), current.getOrderToken(),
+                        current.getProduct(), quantityOf(current, quantity), current.getStatus());
+            }
         }
 
         Products product = validatePurchasableProduct(productId);
         if (product.getInventoryCount() != null && product.getInventoryCount() < quantity) {
             throw new IllegalStateException("Sản phẩm không đủ tồn kho.");
         }
-
         int sellerId = productService.findOwnerIdByProduct(productId)
                 .orElseThrow(() -> new IllegalStateException("Không xác định được chủ shop của sản phẩm."));
         if (buyer.getId().equals(sellerId)) {
@@ -100,38 +104,15 @@ public class OrderService {
         }
 
         try {
-            walletService.hold(buyer.getId(), sellerId, total, pending.getId(), orderToken);
+            var holdRecord = walletService.hold(buyer.getId(), sellerId, total, pending.getId(), orderToken);
+            orderDAO.updatePaymentTransaction(pending.getId(), holdRecord.transactionId());
         } catch (RuntimeException ex) {
             orderDAO.updateStatus(pending.getId(), orderToken, OrderStatus.FAILED);
-            throw new IllegalStateException("Không thể giữ tiền thanh toán. Vui lòng thử lại sau.", ex);
+            throw ex;
         }
 
         orderQueueProducer.publish(pending.getId(), orderToken);
-
         return new OrderPlacementResult(pending.getId(), orderToken, product, quantity, pending.getStatus());
-    }
-
-    /**
-     * Creates a new order after validating the buyer information and generates delivery assets.
-     * @param productId the product that the buyer wants to purchase
-     * @param buyerEmail email used to deliver digital goods
-     * @param paymentMethod the payment option selected during checkout
-     * @return the persisted order enriched with activation details
-     */
-    public Order createOrder(int productId, String buyerEmail, String paymentMethod) {
-        if (buyerEmail == null || buyerEmail.isBlank()) {
-            throw new IllegalArgumentException("Vui lòng nhập email nhận sản phẩm.");
-        }
-        if (paymentMethod == null || paymentMethod.isBlank()) {
-            throw new IllegalArgumentException("Vui lòng chọn phương thức thanh toán.");
-        }
-        Products product = validatePurchasableProduct(productId);
-        Users buyer = resolveBuyer(buyerEmail.trim());
-        try {
-            return orderDAO.createOrder(product, buyer.getId(), paymentMethod.trim());
-        } catch (SQLException ex) {
-            throw new IllegalStateException("Không thể tạo đơn hàng. Vui lòng thử lại sau.", ex);
-        }
     }
 
     public OrderStatusView getOrderStatus(int orderId, String orderToken, Users currentUser) {
@@ -141,63 +122,69 @@ public class OrderService {
         Order order = orderDAO.findByIdAndToken(orderId, orderToken)
                 .orElseThrow(() -> new IllegalArgumentException("Đơn hàng không tồn tại hoặc đã hết hạn."));
         ensureOrderAccessibility(order, currentUser);
+        boolean deliverable = isDeliverable(order.getStatus());
+        String activation = null;
+        String deliveryLink = null;
+        if (deliverable) {
+            List<String> credentials = orderDAO.findCredentials(order.getId());
+            if (!credentials.isEmpty()) {
+                activation = credentials.get(0);
+            }
+        }
         return new OrderStatusView(order.getId(), orderToken, order.getStatus(),
-                order.hasDeliveryInformation(), order.getActivationCode(), order.getDeliveryLink());
+                deliverable, activation, deliveryLink);
     }
 
-    /**
-     * Maps order status to the appropriate badge style.
-     * @param status current order status
-     * @return CSS class for the badge component
-     */
+    public OrderDetailView getOrderDetail(int orderId, Users currentUser) {
+        if (currentUser == null || currentUser.getId() == null) {
+            throw new IllegalStateException("Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.");
+        }
+        Order order = orderDAO.findByIdAndBuyer(orderId, currentUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy đơn hàng."));
+        ensureOrderAccessibility(order, currentUser);
+        List<String> credentials = isDeliverable(order.getStatus())
+                ? orderDAO.findCredentials(order.getId())
+                : List.of();
+        return new OrderDetailView(order, credentials);
+    }
+
     public String getStatusBadgeClass(OrderStatus status) {
         if (status == null) {
             return "badge";
         }
         return switch (status) {
-            case COMPLETED -> "badge";
-            case PROCESSING, PENDING -> "badge badge--warning";
-            case DISPUTED, FAILED -> "badge badge--danger";
+            case PENDING -> "badge badge--warning";
+            case CONFIRMED -> "badge badge--success";
+            case FAILED -> "badge badge--danger";
+            case DELIVERED -> "badge";
             case REFUNDED -> "badge badge--ghost";
+            case CANCELLED -> "badge badge--ghost";
         };
     }
 
-    /**
-     * Converts the status enum to a localized label for display.
-     * @param status current order status
-     * @return user-friendly Vietnamese label
-     */
     public String getFriendlyStatus(OrderStatus status) {
         if (status == null) {
             return "Không xác định";
         }
         return switch (status) {
-            case COMPLETED -> "Hoàn thành";
-            case PROCESSING -> "Đang xử lý";
-            case DISPUTED -> "Đang khiếu nại";
-            case PENDING -> "Chờ xử lý";
-            case FAILED -> "Thanh toán thất bại";
+            case PENDING -> "Đang xử lý";
+            case CONFIRMED -> "Đã thanh toán";
+            case FAILED -> "Thất bại";
+            case DELIVERED -> "Đã bàn giao";
             case REFUNDED -> "Đã hoàn tiền";
+            case CANCELLED -> "Đã huỷ";
         };
     }
 
-    private Users resolveBuyer(String email) {
-        Optional<Users> existing = buyerDAO.findActiveBuyerByEmail(email);
-        if (existing.isPresent()) {
-            return existing.get();
-        }
-        try {
-            return buyerDAO.createBuyer(email);
-        } catch (SQLException ex) {
-            throw new IllegalStateException("Không thể khởi tạo người mua mới.", ex);
-        }
+    private boolean isDeliverable(OrderStatus status) {
+        return status == OrderStatus.CONFIRMED || status == OrderStatus.DELIVERED || status == OrderStatus.REFUNDED;
     }
 
     private boolean isPurchasable(String status) {
         if (status == null) {
             return false;
         }
-        return PURCHASABLE_STATUSES.contains(status.trim().toUpperCase(Locale.ROOT));
+        return ALLOWED_PRODUCT_STATUSES.contains(status.trim().toUpperCase(Locale.ROOT));
     }
 
     private void ensureOrderAccessibility(Order order, Users currentUser) {
@@ -215,5 +202,10 @@ public class OrderService {
             }
         }
         throw new SecurityException("Bạn không có quyền truy cập đơn hàng này.");
+    }
+
+    private int quantityOf(Order order, int fallback) {
+        Integer quantity = order.getQuantity();
+        return quantity == null || quantity <= 0 ? fallback : quantity;
     }
 }

--- a/MMO_Trader_Market/src/java/service/dto/OrderDetailView.java
+++ b/MMO_Trader_Market/src/java/service/dto/OrderDetailView.java
@@ -1,0 +1,27 @@
+package service.dto;
+
+import model.Order;
+
+import java.util.List;
+
+/**
+ * View model for order detail page.
+ */
+public class OrderDetailView {
+
+    private final Order order;
+    private final List<String> credentials;
+
+    public OrderDetailView(Order order, List<String> credentials) {
+        this.order = order;
+        this.credentials = List.copyOf(credentials);
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public List<String> getCredentials() {
+        return credentials;
+    }
+}

--- a/MMO_Trader_Market/src/java/units/Encoding.java
+++ b/MMO_Trader_Market/src/java/units/Encoding.java
@@ -1,23 +1,14 @@
 package units;
 
 /**
- * Compatibility wrapper that provides the same hashing helper used in legacy
- * controllers while delegating to the current hashing utility.
+ * Compatibility wrapper that now delegates to the new salted hashing utility.
  */
 public final class Encoding {
 
     private Encoding() {
-        // utility class
     }
 
-    /**
-     * Hashes the provided text using the legacy SHA-1 helper to remain backward
-     * compatible with existing code paths.
-     *
-     * @param str original text that needs hashing
-     * @return SHA-1 hash encoded in Base64 format
-     */
     public static String toSHA1(String str) {
-        return HashPassword.toSHA1(str);
+        return HashPassword.hash(str);
     }
 }

--- a/MMO_Trader_Market/src/java/units/HashPassword.java
+++ b/MMO_Trader_Market/src/java/units/HashPassword.java
@@ -1,36 +1,34 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package units;
 
-import java.security.MessageDigest;
-
 /**
- *
- * @author admin
+ * Legacy facade kept for backward compatibility. Internally delegates to the
+ * {@link PasswordHasher} which provides salted SHA-256 hashing.
  */
-public class HashPassword {
-    // md5
-    // sha-1 => thường được sử dụng
-    public static String toSHA1(String str) {
-        String salt = "asjrlkmcoewj@tjle;oxqskjhdjksjf1jurVn";// Làm cho mật khẩu phức tap
-        String result = null;
+public final class HashPassword {
 
-        str = str + salt;
-        try {
-            byte[] dataBytes = str.getBytes("UTF-8");
-            MessageDigest md = MessageDigest.getInstance("SHA-1");
-            result = java.util.Base64.getEncoder().encodeToString(md.digest(dataBytes));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-        return result;
+    private HashPassword() {
     }
-    
-    public static void main(String[] args) {
-        String test = "admin";
-        System.out.println(toSHA1(test));
+
+    /**
+     * @deprecated Prefer {@link PasswordHasher#hash(String)}. This method is
+     * provided to avoid breaking older code paths.
+     */
+    @Deprecated
+    public static String toSHA1(String str) {
+        return PasswordHasher.hash(str);
+    }
+
+    /**
+     * Generates a salted hash for the provided password.
+     */
+    public static String hash(String str) {
+        return PasswordHasher.hash(str);
+    }
+
+    /**
+     * Verifies a raw password against the stored hash.
+     */
+    public static boolean matches(String rawPassword, String storedHash) {
+        return PasswordHasher.matches(rawPassword, storedHash);
     }
 }
-

--- a/MMO_Trader_Market/src/java/units/PasswordHasher.java
+++ b/MMO_Trader_Market/src/java/units/PasswordHasher.java
@@ -1,0 +1,76 @@
+package units;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Utility responsible for hashing and verifying passwords using SHA-256 with a
+ * per-user random salt. The resulting hash is encoded using the format
+ * {@code salt:hash} so it can be stored in a single database column.
+ */
+public final class PasswordHasher {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final int SALT_LENGTH = 16;
+
+    private PasswordHasher() {
+    }
+
+    /**
+     * Generates a salted SHA-256 hash for the provided password.
+     *
+     * @param rawPassword plaintext password
+     * @return encoded hash in the format {@code salt:hash}
+     */
+    public static String hash(String rawPassword) {
+        if (rawPassword == null) {
+            throw new IllegalArgumentException("Mật khẩu không được để trống");
+        }
+        byte[] salt = new byte[SALT_LENGTH];
+        RANDOM.nextBytes(salt);
+        byte[] digest = sha256(salt, rawPassword.getBytes(StandardCharsets.UTF_8));
+        return Base64.getEncoder().encodeToString(salt) + ':'
+                + Base64.getEncoder().encodeToString(digest);
+    }
+
+    /**
+     * Verifies that the provided password matches the stored salted hash.
+     *
+     * @param rawPassword plaintext password entered by the user
+     * @param storedHash  encoded hash retrieved from the database
+     * @return {@code true} when the password matches, {@code false} otherwise
+     */
+    public static boolean matches(String rawPassword, String storedHash) {
+        if (rawPassword == null || storedHash == null || storedHash.isBlank()) {
+            return false;
+        }
+        String[] parts = storedHash.split(":", 2);
+        if (parts.length != 2) {
+            return false;
+        }
+        byte[] salt = Base64.getDecoder().decode(parts[0]);
+        byte[] expected = Base64.getDecoder().decode(parts[1]);
+        byte[] actual = sha256(salt, rawPassword.getBytes(StandardCharsets.UTF_8));
+        if (expected.length != actual.length) {
+            return false;
+        }
+        int result = 0;
+        for (int i = 0; i < expected.length; i++) {
+            result |= expected[i] ^ actual[i];
+        }
+        return result == 0;
+    }
+
+    private static byte[] sha256(byte[] salt, byte[] data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(salt);
+            return digest.digest(data);
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 algorithm not available", ex);
+        }
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -1,0 +1,45 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Chi tiết đơn hàng #<c:out value="${detail.order.id}" /></h2>
+            <span class="${statusClass}"><c:out value="${statusLabel}" /></span>
+        </div>
+        <div class="panel__body">
+            <div class="stat-card" style="margin-bottom: 1rem;">
+                <div>
+                    <p class="stat-card__label">Sản phẩm</p>
+                    <p class="stat-card__value"><c:out value="${detail.order.product.name}" /></p>
+                    <p class="profile-card__note">
+                        Tổng: <fmt:formatNumber value="${detail.order.totalAmount}" type="number" minFractionDigits="0"/> đ –
+                        Số lượng: <strong><c:out value="${detail.order.quantity != null ? detail.order.quantity : 1}" /></strong>
+                    </p>
+                </div>
+            </div>
+            <c:choose>
+                <c:when test="${not empty detail.credentials}">
+                    <h3>Thông tin bàn giao</h3>
+                    <ul class="list">
+                        <c:forEach var="credential" items="${detail.credentials}">
+                            <li><code><c:out value="${credential}" /></code></li>
+                        </c:forEach>
+                    </ul>
+                </c:when>
+                <c:otherwise>
+                    <p class="profile-card__note">Đơn hàng chưa sẵn sàng bàn giao. Vui lòng kiểm tra lại sau.</p>
+                </c:otherwise>
+            </c:choose>
+            <p>
+                <small>Ngày tạo: <c:out value="${detail.order.createdAt}" /></small>
+            </p>
+            <a class="button button--ghost" href="${pageContext.request.contextPath}/orders/my">Quay lại danh sách</a>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/list.jsp
@@ -1,7 +1,6 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
@@ -9,13 +8,9 @@
     <section class="panel">
         <div class="panel__header">
             <h2 class="panel__title">Lịch sử đơn mua</h2>
-            <a class="button button--primary" href="${pageContext.request.contextPath}/home">Tiếp tục mua hàng</a>
+            <a class="button button--primary" href="${pageContext.request.contextPath}/products">Tiếp tục mua hàng</a>
         </div>
         <div class="panel__body">
-            <c:if test="${not empty error}">
-                <div class="alert alert--error" role="alert"><c:out value="${error}" /></div>
-            </c:if>
-            <p class="profile-card__note">Có tổng cộng ${total} đơn hàng đã mua.</p>
             <form class="form form--inline" method="get" action="${pageContext.request.contextPath}/orders/my">
                 <input type="hidden" name="size" value="${size}" />
                 <label class="form__control">
@@ -38,10 +33,10 @@
                         <tr>
                             <th>Mã</th>
                             <th>Sản phẩm</th>
-                            <th>Giá</th>
+                            <th>Số lượng</th>
+                            <th>Tổng tiền</th>
                             <th>Trạng thái</th>
-                            <th>Bàn giao</th>
-                            <th class="table__actions">Thao tác</th>
+                            <th class="table__actions">Chi tiết</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -50,38 +45,25 @@
                             <tr>
                                 <td>#<c:out value="${order.id}" /></td>
                                 <td>
-                                    <strong><c:out value="${order.product.name}" /></strong><br>
+                                    <strong><c:out value="${order.product.name}" /></strong>
+                                    <br/>
                                     <small>Email nhận: <c:out value="${order.buyerEmail}" /></small>
                                 </td>
+                                <td><c:out value="${order.quantity != null ? order.quantity : 1}" /></td>
                                 <td>
-                                    <fmt:formatNumber value="${order.product.price}" type="number" minFractionDigits="0"
-                                                     maxFractionDigits="0" /> đ
+                                    <fmt:formatNumber value="${order.totalAmount}" type="number"
+                                                      minFractionDigits="0" maxFractionDigits="0" /> đ
                                 </td>
                                 <td>
                                     <span class="${statusClasses[orderId]}">
                                         <c:out value="${statusLabels[orderId]}" />
                                     </span>
                                 </td>
-                                <td>
-                                    <c:choose>
-                                        <c:when test="${not empty order.activationCode}">
-                                            <code><c:out value="${order.activationCode}" /></code><br>
-                                            <c:if test="${not empty order.deliveryLink}">
-                                                <a href="${fn:escapeXml(order.deliveryLink)}">Xem link</a>
-                                            </c:if>
-                                        </c:when>
-                                        <c:otherwise>
-                                            <span class="badge badge--ghost">Đang xử lý</span>
-                                        </c:otherwise>
-                                    </c:choose>
-                                </td>
                                 <td class="table__actions">
-                                    <form method="post" action="${pageContext.request.contextPath}/order/buy-now"
-                                          style="display:inline;">
-                                        <input type="hidden" name="productId" value="${order.product.id}" />
-                                        <input type="hidden" name="quantity" value="1" />
-                                        <button class="button button--ghost" type="submit">Mua lại</button>
-                                    </form>
+                                    <c:url value="/orders/detail" var="detailUrl">
+                                        <c:param name="orderId" value="${order.id}" />
+                                    </c:url>
+                                    <a class="button button--ghost" href="${detailUrl}">Xem</a>
                                 </td>
                             </tr>
                         </c:forEach>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -95,11 +95,11 @@
                                 <a class="button button--ghost" href="${pageContext.request.contextPath}/products">Chi tiết</a>
                                 <c:set var="statusUpper" value="${fn:toUpperCase(product.status)}" />
                                 <c:choose>
-                                    <c:when test="${statusUpper eq 'AVAILABLE'}">
+                                <c:when test="${statusUpper eq 'APPROVED'}">
                                         <form method="post" action="${pageContext.request.contextPath}/order/buy-now"
                                               style="display:inline;">
                                             <input type="hidden" name="productId" value="${product.id}" />
-                                            <input type="hidden" name="quantity" value="1" />
+                                            <input type="hidden" name="qty" value="1" />
                                             <button class="button button--primary" type="submit">Mua ngay</button>
                                         </form>
                                     </c:when>


### PR DESCRIPTION
## Summary
- refactor order controller/service/worker to run buy-now via queue with wallet hold and polling status endpoint
- persist wallet holds and transactions in MySQL with HOLD/CAPTURE/RELEASE handling and update order states to PENDING/CONFIRMED/etc
- scope buyer order listing/detail pages to logged-in user and add credential gating plus salted SHA-256 password hashing

## Testing
- `mvn -q -DskipTests package` *(fails: project has no pom.xml in MMO_Trader_Market directory)*

------
https://chatgpt.com/codex/tasks/task_e_68f4f7c789708320b5b91446400bff59