### PR TITLE
Unify navigation and add wallet overview

### DIFF
--- a/MMO_Trader_Market/src/java/controller/BaseController.java
+++ b/MMO_Trader_Market/src/java/controller/BaseController.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import units.NavigationBuilder;
+
 /**
  * Base servlet that provides convenience helpers for forwarding to JSP views.
  */
@@ -14,7 +16,14 @@ public abstract class BaseController extends HttpServlet {
 
     protected void forward(HttpServletRequest request, HttpServletResponse response, String view)
             throws ServletException, IOException {
+        ensureNavigation(request);
         String jsp = ViewResolver.resolve(view);
         request.getRequestDispatcher(jsp).forward(request, response);
+    }
+
+    private void ensureNavigation(HttpServletRequest request) {
+        if (request.getAttribute("navItems") == null) {
+            request.setAttribute("navItems", NavigationBuilder.build(request));
+        }
     }
 }

--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -12,7 +12,6 @@ import service.OrderService;
 
 import java.io.IOException;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +90,7 @@ public class OrderController extends BaseController {
     private void showOrderHistory(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         int page = resolvePage(request.getParameter("page"));
-        prepareNavigation(request);
+        request.setAttribute("bodyClass", BODY_CLASS);
         request.setAttribute("pageTitle", "Đơn hàng đã mua");
         request.setAttribute("headerTitle", "Lịch sử đơn mua");
         request.setAttribute("headerSubtitle", "Theo dõi trạng thái và thông tin bàn giao sản phẩm");
@@ -109,7 +108,7 @@ public class OrderController extends BaseController {
 
     private void prepareCheckoutPage(HttpServletRequest request, Products product, String error)
             throws ServletException {
-        prepareNavigation(request);
+        request.setAttribute("bodyClass", BODY_CLASS);
         request.setAttribute("pageTitle", "Mua ngay sản phẩm");
         request.setAttribute("headerTitle", "Hoàn tất đơn hàng");
         request.setAttribute("headerSubtitle", "Bước 1: Kiểm tra thông tin trước khi thanh toán");
@@ -126,7 +125,7 @@ public class OrderController extends BaseController {
 
     private void showConfirmation(HttpServletRequest request, HttpServletResponse response, Order order)
             throws ServletException, IOException {
-        prepareNavigation(request);
+        request.setAttribute("bodyClass", BODY_CLASS);
         request.setAttribute("pageTitle", "Thanh toán thành công");
         request.setAttribute("headerTitle", "Đơn hàng đã tạo");
         request.setAttribute("headerSubtitle", "Bước 2: Nhận thông tin bàn giao sản phẩm");
@@ -161,29 +160,6 @@ public class OrderController extends BaseController {
         } catch (NumberFormatException ex) {
             return -1;
         }
-    }
-
-    private void prepareNavigation(HttpServletRequest request) {
-        String contextPath = request.getContextPath();
-        List<Map<String, String>> navItems = new ArrayList<>();
-
-        request.setAttribute("bodyClass", BODY_CLASS);
-        Map<String, String> homeLink = new HashMap<>();
-        homeLink.put("href", contextPath + "/home");
-        homeLink.put("label", "Trang chủ");
-        navItems.add(homeLink);
-
-        Map<String, String> productLink = new HashMap<>();
-        productLink.put("href", contextPath + "/products");
-        productLink.put("label", "Sản phẩm");
-        navItems.add(productLink);
-
-        Map<String, String> orderLink = new HashMap<>();
-        orderLink.put("href", contextPath + "/orders");
-        orderLink.put("label", "Đơn đã mua");
-        navItems.add(orderLink);
-
-        request.setAttribute("navItems", navItems);
     }
 
     private Map<Integer, String> buildStatusClassMap(List<Order> orders) {

--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -38,38 +38,9 @@ public class HomepageController extends BaseController {
         request.setAttribute("headerTitle", "MMO Trader Market");
         request.setAttribute("headerSubtitle", "Nền tảng demo mua bán tài khoản an toàn");
 
-        populateNavigation(request);
         populateHomepageData(request);
 
         forward(request, response, "product/home");
-    }
-
-    private void populateNavigation(HttpServletRequest request) {
-        String contextPath = request.getContextPath();
-        List<Map<String, String>> navItems = new ArrayList<>();
-
-        Map<String, String> loginLink = new HashMap<>();
-        loginLink.put("href", contextPath + "/login.jsp");
-        loginLink.put("label", "Đăng nhập");
-        loginLink.put("modifier", "button button--primary");
-        navItems.add(loginLink);
-
-        Map<String, String> productLink = new HashMap<>();
-        productLink.put("href", contextPath + "/products");
-        productLink.put("label", "Quản lý sản phẩm");
-        navItems.add(productLink);
-
-        Map<String, String> orderLink = new HashMap<>();
-        orderLink.put("href", contextPath + "/orders");
-        orderLink.put("label", "Đơn đã mua");
-        navItems.add(orderLink);
-
-        Map<String, String> guideLink = new HashMap<>();
-        guideLink.put("href", contextPath + "/styleguide");
-        guideLink.put("label", "Styleguide");
-        navItems.add(guideLink);
-
-        request.setAttribute("navItems", navItems);
     }
 
     private void populateHomepageData(HttpServletRequest request) {
@@ -91,6 +62,9 @@ public class HomepageController extends BaseController {
 
         List<SystemConfigs> systemNotes = homepageService.loadSystemNotes();
         request.setAttribute("systemNotes", systemNotes);
+
+        request.setAttribute("productTypes", buildProductTypeList());
+        request.setAttribute("faqs", buildFaqEntries());
     }
 
     private Map<String, String> buildShopIconMap() {
@@ -99,5 +73,38 @@ public class HomepageController extends BaseController {
         icons.put("Pending", "⏳");
         icons.put("Suspended", "⚠️");
         return icons;
+    }
+
+    private List<Map<String, String>> buildProductTypeList() {
+        List<Map<String, String>> types = new ArrayList<>();
+
+        types.add(createEntry("Tài khoản game", "Tài khoản đã được xác minh và đảm bảo an toàn."));
+        types.add(createEntry("Dịch vụ nâng hạng", "Gói hỗ trợ tăng cấp nhanh chóng cho nhiều tựa game."));
+        types.add(createEntry("Vật phẩm số", "Mã nạp, skin hiếm và vật phẩm sự kiện giới hạn."));
+        types.add(createEntry("Gian hàng doanh nghiệp", "Gói tuỳ chỉnh cho studio và nhà phát hành."));
+
+        return types;
+    }
+
+    private List<Map<String, String>> buildFaqEntries() {
+        List<Map<String, String>> faqs = new ArrayList<>();
+
+        faqs.add(createEntry("Làm sao để mua tài khoản an toàn?",
+                "Hãy kiểm tra trạng thái duyệt và chỉ thanh toán qua kênh được hỗ trợ trong hệ thống."));
+        faqs.add(createEntry("Tôi có thể yêu cầu hoàn tiền không?",
+                "Người mua có thể mở khiếu nại trong vòng 24 giờ sau khi nhận tài khoản."));
+        faqs.add(createEntry("Ví điện tử hoạt động như thế nào?",
+                "Ví cho phép nạp tiền nhanh, thanh toán tức thì và theo dõi lịch sử giao dịch."));
+        faqs.add(createEntry("Seller cần chuẩn bị gì để đăng bán?",
+                "Hãy xác minh danh tính KYC và cung cấp mô tả chi tiết cho từng sản phẩm."));
+
+        return faqs;
+    }
+
+    private Map<String, String> createEntry(String title, String description) {
+        Map<String, String> entry = new HashMap<>();
+        entry.put("title", title);
+        entry.put("description", description);
+        return entry;
     }
 }

--- a/MMO_Trader_Market/src/java/controller/product/ProductController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductController.java
@@ -10,10 +10,6 @@ import model.Products;
 import service.ProductService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Controller hiển thị danh sách sản phẩm trong marketplace.
@@ -53,23 +49,6 @@ public class ProductController extends BaseController {
         request.setAttribute("headerTitle", "Danh sách sản phẩm");
         request.setAttribute("headerSubtitle", "Quản lý sản phẩm theo mô hình MVC");
         request.setAttribute("headerModifier", HEADER_MODIFIER);
-        request.setAttribute("navItems", buildNavigation(request.getContextPath()));
-    }
-
-    private List<Map<String, String>> buildNavigation(String contextPath) {
-        List<Map<String, String>> items = new ArrayList<>();
-        items.add(createNavItem(contextPath + "/home", "Trang chủ"));
-        items.add(createNavItem(contextPath + "/products", "Sản phẩm"));
-        items.add(createNavItem(contextPath + "/orders", "Đơn đã mua"));
-        items.add(createNavItem(contextPath + "/styleguide", "Styleguide"));
-        return items;
-    }
-
-    private Map<String, String> createNavItem(String href, String label) {
-        Map<String, String> item = new HashMap<>();
-        item.put("href", href);
-        item.put("label", label);
-        return item;
     }
 
     private String normalizeKeyword(String keywordParam) {

--- a/MMO_Trader_Market/src/java/controller/wallet/WalletController.java
+++ b/MMO_Trader_Market/src/java/controller/wallet/WalletController.java
@@ -1,0 +1,83 @@
+package controller.wallet;
+
+import controller.BaseController;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Hiển thị ví điện tử dành cho người mua.
+ */
+@WebServlet(name = "WalletController", urlPatterns = {"/wallet"})
+public class WalletController extends BaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute("pageTitle", "Ví điện tử - MMO Trader Market");
+        request.setAttribute("bodyClass", "layout");
+        request.setAttribute("headerTitle", "Ví điện tử");
+        request.setAttribute("headerSubtitle", "Theo dõi số dư và giao dịch gần đây");
+        request.setAttribute("headerModifier", "layout__header--split");
+
+        request.setAttribute("walletBalance", new BigDecimal("1250000"));
+        request.setAttribute("walletHold", new BigDecimal("250000"));
+        request.setAttribute("walletCurrency", "VND");
+        request.setAttribute("walletStatus", "Đang hoạt động");
+        request.setAttribute("walletUpdatedAt", "12/05/2024 09:30");
+
+        request.setAttribute("transactions", buildTransactions());
+        request.setAttribute("shortcuts", buildShortcuts(request.getContextPath()));
+
+        forward(request, response, "wallet/overview");
+    }
+
+    private List<Map<String, String>> buildTransactions() {
+        List<Map<String, String>> transactions = new ArrayList<>();
+
+        transactions.add(createTransaction("Nạp tiền Momo", "+500.000 đ", "Hoàn tất", "12/05/2024 09:30"));
+        transactions.add(createTransaction("Thanh toán đơn #1024", "-320.000 đ", "Hoàn tất", "08/05/2024 21:10"));
+        transactions.add(createTransaction("Hoàn tiền đơn #1008", "+320.000 đ", "Đã hoàn", "02/05/2024 14:20"));
+        transactions.add(createTransaction("Rút về ngân hàng", "-1.000.000 đ", "Đang xử lý", "28/04/2024 08:45"));
+
+        return transactions;
+    }
+
+    private List<Map<String, String>> buildShortcuts(String contextPath) {
+        List<Map<String, String>> shortcuts = new ArrayList<>();
+
+        shortcuts.add(createShortcut(contextPath + "/orders", "Đơn đã mua", "Theo dõi lịch sử giao dịch mua", "🧾"));
+        shortcuts.add(createShortcut(contextPath + "/products", "Sản phẩm", "Khám phá thêm sản phẩm mới", "🛒"));
+        shortcuts.add(createShortcut(contextPath + "/profile", "Tài khoản", "Cập nhật thông tin bảo mật", "🔐"));
+
+        return shortcuts;
+    }
+
+    private Map<String, String> createTransaction(String title, String amount, String status, String time) {
+        Map<String, String> transaction = new HashMap<>();
+        transaction.put("title", title);
+        transaction.put("amount", amount);
+        transaction.put("status", status);
+        transaction.put("time", time);
+        return transaction;
+    }
+
+    private Map<String, String> createShortcut(String href, String title, String description, String icon) {
+        Map<String, String> shortcut = new HashMap<>();
+        shortcut.put("href", href);
+        shortcut.put("title", title);
+        shortcut.put("description", description);
+        shortcut.put("icon", icon);
+        return shortcut;
+    }
+}

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -1,0 +1,124 @@
+package units;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a consistent navigation menu based on the authenticated user role.
+ */
+public final class NavigationBuilder {
+
+    private static final String ACTIVE_CLASS = "menu__item--active";
+    private static final String ICON_CLASS = "menu__item--icon";
+    private static final String BUTTON_CLASS = "menu__item--button";
+
+    private NavigationBuilder() {
+    }
+
+    public static List<Map<String, String>> build(HttpServletRequest request) {
+        List<Map<String, String>> items = new ArrayList<>();
+        String contextPath = request.getContextPath();
+        String currentPath = resolveCurrentPath(request);
+
+        HttpSession session = request.getSession(false);
+        Integer roleId = session == null ? null : (Integer) session.getAttribute("userRole");
+
+        if (isAdminRole(roleId)) {
+            items.add(createNavItem(contextPath + "/dashboard", "Dashboard",
+                    isActive(currentPath, "/dashboard")));
+            items.add(createNavItem(contextPath + "/orders", "Quản lý đơn hàng",
+                    isActive(currentPath, "/orders")));
+        }
+
+        addBaseItems(items, contextPath, currentPath);
+
+        if (roleId == null) {
+            items.add(createIconItem(contextPath + "/auth", "👤", "Đăng nhập", true,
+                    isActive(currentPath, "/auth")));
+            return items;
+        }
+
+        if (isBuyerRole(roleId)) {
+            items.add(createNavItem(contextPath + "/wallet", "Ví của tôi",
+                    isActive(currentPath, "/wallet")));
+            items.add(createNavItem(contextPath + "/orders", "Đơn hàng",
+                    isActive(currentPath, "/orders")));
+            items.add(createIconItem(contextPath + "/profile", "👤", "Tài khoản", false,
+                    isActive(currentPath, "/profile")));
+        } else {
+            items.add(createIconItem(contextPath + "/profile", "👤", "Quản trị viên", false,
+                    isActive(currentPath, "/profile")));
+        }
+
+        items.add(createLogoutItem(contextPath));
+        return items;
+    }
+
+    private static void addBaseItems(List<Map<String, String>> items, String contextPath, String currentPath) {
+        items.add(createNavItem(contextPath + "/products", "Danh sách sản phẩm",
+                isActive(currentPath, "/products")));
+        items.add(createNavItem(contextPath + "/home#product-types", "Loại sản phẩm", false));
+        items.add(createNavItem(contextPath + "/home#faq", "FAQ", false));
+    }
+
+    private static Map<String, String> createNavItem(String href, String text, boolean active) {
+        return createNavItem(href, text, active, null);
+    }
+
+    private static Map<String, String> createNavItem(String href, String text, boolean active, String extraClasses) {
+        Map<String, String> item = new HashMap<>();
+        item.put("href", href);
+        item.put("text", text);
+        item.put("label", text);
+        if (active) {
+            item.put("modifier", ACTIVE_CLASS + (extraClasses == null ? "" : " " + extraClasses));
+        } else if (extraClasses != null && !extraClasses.isBlank()) {
+            item.put("modifier", extraClasses.trim());
+        }
+        return item;
+    }
+
+    private static Map<String, String> createIconItem(String href, String icon, String text,
+            boolean highlight, boolean active) {
+        String extraClasses = ICON_CLASS + (highlight ? " " + BUTTON_CLASS : "");
+        Map<String, String> item = createNavItem(href, text, active, extraClasses);
+        item.put("icon", icon);
+        item.put("srText", text);
+        return item;
+    }
+
+    private static Map<String, String> createLogoutItem(String contextPath) {
+        Map<String, String> item = createNavItem(contextPath + "/auth?action=logout", "Đăng xuất", false);
+        item.put("modifier", (item.containsKey("modifier") ? item.get("modifier") + " " : "") + "menu__item--danger");
+        return item;
+    }
+
+    private static boolean isActive(String currentPath, String path) {
+        if (path == null || path.isEmpty()) {
+            return currentPath == null || currentPath.isEmpty() || "/".equals(currentPath);
+        }
+        return currentPath.equals(path) || currentPath.startsWith(path + "/");
+    }
+
+    private static String resolveCurrentPath(HttpServletRequest request) {
+        String uri = request.getRequestURI();
+        String contextPath = request.getContextPath();
+        if (contextPath != null && !contextPath.isEmpty() && uri.startsWith(contextPath)) {
+            return uri.substring(contextPath.length());
+        }
+        return uri;
+    }
+
+    private static boolean isBuyerRole(Integer roleId) {
+        return roleId != null && roleId == 3;
+    }
+
+    private static boolean isAdminRole(Integer roleId) {
+        return roleId != null && roleId != 3;
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
@@ -8,23 +8,6 @@
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <style>
   /* Thu gọn khoảng cách giữa các nút hướng dẫn dưới form */
-  .auth-page .guide-link { 
-    margin-top: 10px;           /* giảm khoảng cách giữa các khối */
-  }
-  .auth-page .guide-link:first-of-type { 
-    margin-top: 16px;           /* cách form 1 chút */
-  }
-  .auth-page .guide-link p {
-    margin: 0 0 6px 0;          /* thu gọn dòng “Chưa có tài khoản?” */
-    text-align: center;
-  }
-  .auth-page .guide-link .button {
-    display: block;
-    width: 100%;
-    max-width: 540px;           /* đồng nhất bề ngang nút */
-    margin: 0 auto;             /* căn giữa */
-  }
-
   /* Tùy chọn: thu gọn form cho đều mắt */
   .form-card { gap: 12px; }
   .form-card__field { margin-bottom: 10px; }
@@ -62,9 +45,6 @@
             <a class="button button--ghost" href="<c:url value='/register' />">Đăng ký ngay</a>
         </div>
     </form>
-    <section class="guide-link">
-        <a class="button button--ghost" href="<c:url value='/styleguide' />">Xem thư viện giao diện</a>
-    </section>
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/profile.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/profile.jsp
@@ -1,37 +1,11 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ page import="java.util.List" %>
-<%@ page import="java.util.ArrayList" %>
-<%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.Map" %>
-<%@ page import="model.Products" %>
 <%
     request.setAttribute("pageTitle", "Bảng điều khiển - MMO Trader Market");
     request.setAttribute("bodyClass", "layout");
     request.setAttribute("headerTitle", "Menu");
     request.setAttribute("headerSubtitle", "Tổng quan nhanh về thị trường của bạn");
     request.setAttribute("headerModifier", "layout__header--split");
-
-    List<Map<String, String>> navItems = new ArrayList<>();
-    String contextPath = request.getContextPath();
-
-    Map<String, String> productLink = new HashMap<>();
-    productLink.put("href", contextPath + "/products");
-    productLink.put("label", "Danh sách sản phẩm");
-    navItems.add(productLink);
-
-    Map<String, String> guideLink = new HashMap<>();
-    guideLink.put("href", contextPath + "/styleguide");
-    guideLink.put("label", "Thư viện giao diện");
-    navItems.add(guideLink);
-
-    Map<String, String> logoutLink = new HashMap<>();
-    logoutLink.put("href", contextPath + "/auth?action=logout");
-    logoutLink.put("label", "Đăng xuất");
-    logoutLink.put("modifier", "menu__item--danger");
-    navItems.add(logoutLink);
-
-    request.setAttribute("navItems", navItems);
 %>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/dashboard/index.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/dashboard/index.jsp
@@ -1,8 +1,5 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ page import="java.util.List" %>
-<%@ page import="java.util.ArrayList" %>
-<%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.Map" %>
 <%@ page import="model.Products" %>
 <%
     request.setAttribute("pageTitle", "Bảng điều khiển - MMO Trader Market");
@@ -10,27 +7,6 @@
     request.setAttribute("headerTitle", "Bảng điều khiển");
     request.setAttribute("headerSubtitle", "Tổng quan nhanh về thị trường của bạn");
     request.setAttribute("headerModifier", "layout__header--split");
-
-    List<Map<String, String>> navItems = new ArrayList<>();
-    String contextPath = request.getContextPath();
-
-    Map<String, String> productLink = new HashMap<>();
-    productLink.put("href", contextPath + "/products");
-    productLink.put("label", "Danh sách sản phẩm");
-    navItems.add(productLink);
-
-    Map<String, String> guideLink = new HashMap<>();
-    guideLink.put("href", contextPath + "/styleguide");
-    guideLink.put("label", "Thư viện giao diện");
-    navItems.add(guideLink);
-
-    Map<String, String> logoutLink = new HashMap<>();
-    logoutLink.put("href", contextPath + "/auth?action=logout");
-    logoutLink.put("label", "Đăng xuất");
-    logoutLink.put("modifier", "menu__item--danger");
-    navItems.add(logoutLink);
-
-    request.setAttribute("navItems", navItems);
 %>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -37,22 +37,20 @@
             </div>
         </div>
 
-        <aside class="landing__categories">
-            <h3 class="landing__aside-title">Shop nổi bật</h3>
+        <aside class="landing__categories" id="product-types">
+            <h3 class="landing__aside-title">Loại sản phẩm phổ biến</h3>
             <c:choose>
-                <c:when test="${empty shops}">
-                    <p>Chưa có dữ liệu.</p>
+                <c:when test="${empty productTypes}">
+                    <p>Đang cập nhật dữ liệu.</p>
                 </c:when>
                 <c:otherwise>
                     <ul class="category-menu">
-                        <c:forEach var="shop" items="${shops}">
+                        <c:forEach var="type" items="${productTypes}">
                             <li class="category-menu__item">
-                                <span class="category-menu__icon">
-                                    <c:out value="${shopIcons[shop.status]}" />
-                                </span>
+                                <span class="category-menu__icon">🏷️</span>
                                 <div>
-                                    <strong><c:out value="${shop.name}" /></strong>
-                                    <p><c:out value="${shop.description}" /></p>
+                                    <strong><c:out value="${type.title}" /></strong>
+                                    <p><c:out value="${type.description}" /></p>
                                 </div>
                             </li>
                         </c:forEach>
@@ -60,6 +58,32 @@
                 </c:otherwise>
             </c:choose>
         </aside>
+    </section>
+
+    <section class="panel landing__section">
+        <div class="panel__header">
+            <h3 class="panel__title">Shop nổi bật</h3>
+        </div>
+        <c:choose>
+            <c:when test="${empty shops}">
+                <p>Chưa có dữ liệu.</p>
+            </c:when>
+            <c:otherwise>
+                <ul class="category-menu category-menu--grid">
+                    <c:forEach var="shop" items="${shops}">
+                        <li class="category-menu__item">
+                            <span class="category-menu__icon">
+                                <c:out value="${shopIcons[shop.status]}" />
+                            </span>
+                            <div>
+                                <strong><c:out value="${shop.name}" /></strong>
+                                <p><c:out value="${shop.description}" /></p>
+                            </div>
+                        </li>
+                    </c:forEach>
+                </ul>
+            </c:otherwise>
+        </c:choose>
     </section>
 
     <section class="panel landing__section">
@@ -179,6 +203,29 @@
                             </article>
                         </c:forEach>
                     </div>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+
+    <section class="panel landing__section" id="faq">
+        <div class="panel__header">
+            <h3 class="panel__title">Câu hỏi thường gặp</h3>
+        </div>
+        <div class="panel__body faq-list">
+            <c:choose>
+                <c:when test="${empty faqs}">
+                    <p>Đang cập nhật câu hỏi.</p>
+                </c:when>
+                <c:otherwise>
+                    <c:forEach var="faq" items="${faqs}">
+                        <details class="faq-item">
+                            <summary class="faq-item__question">
+                                <span><c:out value="${faq.title}" /></span>
+                            </summary>
+                            <p class="faq-item__answer"><c:out value="${faq.description}" /></p>
+                        </details>
+                    </c:forEach>
                 </c:otherwise>
             </c:choose>
         </div>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -10,14 +10,19 @@
     String headerSubtitle = (String) request.getAttribute("headerSubtitle");
     java.util.List<java.util.Map<String, String>> headerNavigationItems =
             (java.util.List<java.util.Map<String, String>>) request.getAttribute("navItems");
+    String brandName = "MMO Trader Market";
+    String homeHref = request.getContextPath() + "/home";
 %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <header class="layout__header <%= headerModifier %>">
-    <div>
-        <h1><%= headerTitle %></h1>
-        <% if (headerSubtitle != null && !headerSubtitle.trim().isEmpty()) { %>
-        <p class="subtitle"><%= headerSubtitle %></p>
-        <% } %>
+    <div class="layout__brand">
+        <a class="layout__logo" href="<%= homeHref %>" title="<%= brandName %>"><%= brandName %></a>
+        <div class="layout__heading">
+            <h1><%= headerTitle %></h1>
+            <% if (headerSubtitle != null && !headerSubtitle.trim().isEmpty()) { %>
+            <p class="subtitle"><%= headerSubtitle %></p>
+            <% } %>
+        </div>
     </div>
     <% if (headerNavigationItems != null && !headerNavigationItems.isEmpty()) { %>
     <nav class="menu menu--horizontal">
@@ -27,8 +32,24 @@
                if (extra != null && !extra.trim().isEmpty()) {
                    itemClass += " " + extra.trim();
                }
+               String icon = item.get("icon");
+               String text = item.get("text");
+               if ((text == null || text.trim().isEmpty()) && item.get("label") != null) {
+                   text = item.get("label");
+               }
+               String srText = item.get("srText");
         %>
-        <a class="<%= itemClass %>" href="<%= item.get("href") %>"><%= item.get("label") %></a>
+        <a class="<%= itemClass %>" href="<%= item.get("href") %>">
+            <% if (icon != null && !icon.isEmpty()) { %>
+            <span class="menu__icon" aria-hidden="true"><%= icon %></span>
+            <% } %>
+            <% if (text != null && !text.isEmpty()) { %>
+            <span class="menu__text"><%= text %></span>
+            <% } %>
+            <% if (srText != null && !srText.isEmpty()) { %>
+            <span class="sr-only"><%= srText %></span>
+            <% } %>
+        </a>
         <% } %>
     </nav>
     <% } %>

--- a/MMO_Trader_Market/web/WEB-INF/views/styleguide/index.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/styleguide/index.jsp
@@ -1,35 +1,10 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
-<%@ page import="java.util.ArrayList" %>
-<%@ page import="java.util.HashMap" %>
-<%@ page import="java.util.List" %>
-<%@ page import="java.util.Map" %>
 <%
     request.setAttribute("pageTitle", "Thư viện giao diện - MMO Trader Market");
     request.setAttribute("bodyClass", "layout");
     request.setAttribute("headerTitle", "Thư viện giao diện");
     request.setAttribute("headerSubtitle", "Template UI cho dự án Servlet + JSP (MVC)");
     request.setAttribute("headerModifier", "layout__header--split");
-
-    List<Map<String, String>> navItems = new ArrayList<>();
-    String contextPath = request.getContextPath();
-
-    Map<String, String> dashboardLink = new HashMap<>();
-    dashboardLink.put("href", contextPath + "/dashboard");
-    dashboardLink.put("label", "Dashboard");
-    navItems.add(dashboardLink);
-
-    Map<String, String> productLink = new HashMap<>();
-    productLink.put("href", contextPath + "/products");
-    productLink.put("label", "Sản phẩm");
-    navItems.add(productLink);
-
-    Map<String, String> loginLink = new HashMap<>();
-    loginLink.put("href", contextPath + "/auth");
-    loginLink.put("label", "Đăng nhập");
-    loginLink.put("modifier", "menu__item--ghost");
-    navItems.add(loginLink);
-
-    request.setAttribute("navItems", navItems);
 %>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/wallet/overview.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/wallet/overview.jsp
@@ -1,0 +1,97 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<fmt:setLocale value="vi_VN" scope="page" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content wallet">
+    <section class="panel wallet__summary">
+        <div class="panel__header">
+            <h2 class="panel__title">Tổng quan ví</h2>
+            <span class="badge"><c:out value="${walletStatus}" /></span>
+        </div>
+        <div class="panel__body wallet__stats">
+            <article class="wallet-stat">
+                <p class="wallet-stat__label">Số dư khả dụng</p>
+                <p class="wallet-stat__value">
+                    <fmt:formatNumber value="${walletBalance}" type="number" minFractionDigits="0" />
+                    <span class="wallet-stat__currency"><c:out value="${walletCurrency}" /></span>
+                </p>
+            </article>
+            <article class="wallet-stat">
+                <p class="wallet-stat__label">Số tiền tạm giữ</p>
+                <p class="wallet-stat__value wallet-stat__value--muted">
+                    <fmt:formatNumber value="${walletHold}" type="number" minFractionDigits="0" />
+                    <span class="wallet-stat__currency"><c:out value="${walletCurrency}" /></span>
+                </p>
+            </article>
+            <article class="wallet-stat">
+                <p class="wallet-stat__label">Cập nhật gần nhất</p>
+                <p class="wallet-stat__meta"><c:out value="${walletUpdatedAt}" /></p>
+            </article>
+        </div>
+    </section>
+
+    <section class="panel wallet__shortcuts">
+        <div class="panel__header">
+            <h3 class="panel__title">Thao tác nhanh</h3>
+        </div>
+        <div class="panel__body wallet-shortcuts">
+            <c:choose>
+                <c:when test="${empty shortcuts}">
+                    <p>Không có thao tác nhanh.</p>
+                </c:when>
+                <c:otherwise>
+                    <div class="wallet-shortcuts__grid">
+                        <c:forEach var="shortcut" items="${shortcuts}">
+                            <a class="wallet-shortcut" href="${shortcut.href}">
+                                <span class="wallet-shortcut__icon" aria-hidden="true"><c:out value="${shortcut.icon}" /></span>
+                                <div>
+                                    <strong class="wallet-shortcut__title"><c:out value="${shortcut.title}" /></strong>
+                                    <p class="wallet-shortcut__description"><c:out value="${shortcut.description}" /></p>
+                                </div>
+                            </a>
+                        </c:forEach>
+                    </div>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+
+    <section class="panel wallet__section">
+        <div class="panel__header">
+            <h3 class="panel__title">Lịch sử giao dịch</h3>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${empty transactions}">
+                    <p>Chưa có giao dịch nào được ghi nhận.</p>
+                </c:when>
+                <c:otherwise>
+                    <table class="table table--interactive">
+                        <thead>
+                        <tr>
+                            <th>Nội dung</th>
+                            <th>Số tiền</th>
+                            <th>Trạng thái</th>
+                            <th>Thời gian</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <c:forEach var="transaction" items="${transactions}">
+                            <tr>
+                                <td><c:out value="${transaction.title}" /></td>
+                                <td><strong><c:out value="${transaction.amount}" /></strong></td>
+                                <td><span class="badge"><c:out value="${transaction.status}" /></span></td>
+                                <td><c:out value="${transaction.time}" /></td>
+                            </tr>
+                        </c:forEach>
+                        </tbody>
+                    </table>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -82,6 +82,35 @@ code {
     gap: 1rem;
 }
 
+.layout__brand {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.layout__logo {
+    font-weight: 800;
+    font-size: 1.15rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--primary-color);
+    text-decoration: none;
+}
+
+.layout__logo:hover,
+.layout__logo:focus {
+    color: var(--accent-color);
+}
+
+.layout__heading h1 {
+    margin: 0;
+}
+
+.layout__heading {
+    display: grid;
+    gap: 0.35rem;
+}
+
 .layout__header--split {
     border-bottom: 1px solid rgba(0, 0, 0, 0.05);
 }
@@ -406,6 +435,22 @@ code {
     transition: var(--transition);
 }
 
+.menu__item--icon {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.menu__icon {
+    font-size: 1.1rem;
+}
+
+.menu__text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
 .menu__item:hover,
 .menu__item--active {
     background: rgba(0, 91, 150, 0.12);
@@ -417,6 +462,26 @@ code {
 
 .menu__item--ghost {
     color: var(--muted-color);
+}
+
+.menu__item--button,
+.menu__item--button:hover,
+.menu__item--button:focus {
+    background: var(--primary-color);
+    color: #fff;
+    box-shadow: 0 12px 30px rgba(0, 91, 150, 0.25);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Search bar */
@@ -726,6 +791,9 @@ code {
     display: grid;
     gap: 1rem;
 }
+.category-menu--grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
 
 .category-menu__item {
     display: grid;
@@ -756,6 +824,93 @@ code {
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
     gap: 1.5rem;
     padding: 1.5rem 2rem 2rem;
+}
+
+.wallet {
+    display: grid;
+    gap: 2rem;
+}
+
+.wallet__stats {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.wallet-stat {
+    padding: 1.5rem;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, rgba(0, 91, 150, 0.08), rgba(255, 183, 3, 0.08));
+    display: grid;
+    gap: 0.5rem;
+}
+
+.wallet-stat__label {
+    margin: 0;
+    font-weight: 600;
+    color: var(--text-light);
+}
+
+.wallet-stat__value {
+    margin: 0;
+    font-size: 1.6rem;
+    font-weight: 700;
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+}
+
+.wallet-stat__value--muted {
+    color: var(--muted-color);
+}
+
+.wallet-stat__currency {
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text-light);
+}
+
+.wallet-stat__meta {
+    margin: 0;
+    color: var(--text-light);
+}
+
+.wallet-shortcuts__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.wallet-shortcut {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    border-radius: var(--radius-md);
+    text-decoration: none;
+    color: inherit;
+    background: rgba(15, 23, 42, 0.04);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    transition: var(--transition);
+}
+
+.wallet-shortcut:hover {
+    transform: translateY(-2px);
+    background: rgba(0, 91, 150, 0.08);
+}
+
+.wallet-shortcut__icon {
+    font-size: 1.5rem;
+}
+
+.wallet-shortcut__title {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.wallet-shortcut__description {
+    margin: 0;
+    color: var(--text-light);
 }
 
 .product-card {
@@ -886,6 +1041,34 @@ code {
     display: grid;
     gap: 1rem;
     font-weight: 500;
+    color: var(--text-light);
+}
+
+.faq-list {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem 2rem 2rem;
+}
+
+.faq-item {
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: var(--radius-md);
+    padding: 1rem 1.25rem;
+    background: var(--surface-color);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+}
+
+.faq-item__question {
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    cursor: pointer;
+}
+
+.faq-item__answer {
+    margin: 0.75rem 0 0;
     color: var(--text-light);
 }
 

--- a/MMO_Trader_Market/web/index.html
+++ b/MMO_Trader_Market/web/index.html
@@ -14,9 +14,13 @@
 <main class="layout__content">
     <p>Nếu trình duyệt không tự chuyển hướng, vui lòng chọn một trong các đường dẫn sau:</p>
     <nav class="menu menu--horizontal">
-        <a class="menu__item button button--primary" href="home">Trang chủ</a>
-        <a class="menu__item" href="login.jsp">Đăng nhập</a>
-        <a class="menu__item button button--ghost" href="styleguide">Xem thư viện giao diện</a>
+        <a class="menu__item" href="products">Danh sách sản phẩm</a>
+        <a class="menu__item" href="home#product-types">Loại sản phẩm</a>
+        <a class="menu__item" href="home#faq">FAQ</a>
+        <a class="menu__item menu__item--icon menu__item--button" href="auth">
+            <span class="menu__icon" aria-hidden="true">👤</span>
+            <span class="menu__text">Đăng nhập</span>
+        </a>
     </nav>
 </main>
 <footer class="layout__footer">


### PR DESCRIPTION
## Summary
- centralize navigation generation with role-specific menu items and update the shared header branding
- refresh the homepage content with product types, FAQ anchors, and retire styleguide links from public entry points
- introduce a buyer wallet overview with sample data and supporting styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f516c0e310832091232f6ec6bdb0fb