### PR TITLE
Refine header behavior and logout alignment

### DIFF
--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -94,7 +94,13 @@ public final class NavigationBuilder {
 
     private static Map<String, String> createLogoutItem(String contextPath) {
         Map<String, String> item = createNavItem(contextPath + "/auth?action=logout", "Đăng xuất", false);
-        item.put("modifier", (item.containsKey("modifier") ? item.get("modifier") + " " : "") + "menu__item--danger");
+        String existingModifier = item.get("modifier");
+        StringBuilder modifierBuilder = new StringBuilder();
+        if (existingModifier != null && !existingModifier.isBlank()) {
+            modifierBuilder.append(existingModifier.trim()).append(' ');
+        }
+        modifierBuilder.append("menu__item--danger menu__item--logout");
+        item.put("modifier", modifierBuilder.toString());
         return item;
     }
 

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/forgot-password.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/forgot-password.jsp
@@ -2,7 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Quên mật khẩu" />
 <c:set var="bodyClass" value="layout layout--center" />
-<c:set var="headerTitle" value="MMO Trader Market" />
+<c:set var="headerTitle" value="Quên mật khẩu" />
 <c:set var="headerSubtitle" value="Khôi phục mật khẩu" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
@@ -2,7 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng nhập" />
 <c:set var="bodyClass" value="layout layout--center" />
-<c:set var="headerTitle" value="MMO Trader Market" />
+<c:set var="headerTitle" value="Đăng nhập" />
 <c:set var="headerSubtitle" value="Đăng nhập để quản lý giao dịch" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
@@ -34,7 +34,7 @@
             <label class="form-card__option form-card__option--inline" for="rememberMe">
                 <input class="form-card__checkbox" id="rememberMe" name="rememberMe" type="checkbox"
                        <c:if test="${rememberMeChecked}">checked</c:if>>
-                <span class="form-card__option-text">Ghi nhớ đăng nhập</span>
+                <span class="form-card__option-text">Ghi nhớ mật khẩu</span>
             </label>
             <a class="form-card__link" href="<c:url value='/forgot-password' />">Quên mật khẩu?</a>
         </div>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
@@ -2,7 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng ký" />
 <c:set var="bodyClass" value="layout layout--center" />
-<c:set var="headerTitle" value="MMO Trader Market" />
+<c:set var="headerTitle" value="Đăng ký" />
 <c:set var="headerSubtitle" value="Tạo tài khoản mới" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/reset-password.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/reset-password.jsp
@@ -2,7 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đặt lại mật khẩu" />
 <c:set var="bodyClass" value="layout layout--center" />
-<c:set var="headerTitle" value="MMO Trader Market" />
+<c:set var="headerTitle" value="Đặt lại mật khẩu" />
 <c:set var="headerSubtitle" value="Nhập mật khẩu mới" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -4,10 +4,19 @@
         headerModifier = "";
     }
     String headerTitle = (String) request.getAttribute("headerTitle");
-    if (headerTitle == null) {
-        headerTitle = "MMO Trader Market";
+    if (headerTitle != null) {
+        headerTitle = headerTitle.trim();
+        if (headerTitle.isEmpty()) {
+            headerTitle = null;
+        }
     }
     String headerSubtitle = (String) request.getAttribute("headerSubtitle");
+    if (headerSubtitle != null) {
+        headerSubtitle = headerSubtitle.trim();
+        if (headerSubtitle.isEmpty()) {
+            headerSubtitle = null;
+        }
+    }
     java.util.List<java.util.Map<String, String>> headerNavigationItems =
             (java.util.List<java.util.Map<String, String>>) request.getAttribute("navItems");
     String brandName = "MMO Trader Market";
@@ -17,12 +26,16 @@
 <header class="layout__header <%= headerModifier %>">
     <div class="layout__brand">
         <a class="layout__logo" href="<%= homeHref %>" title="<%= brandName %>"><%= brandName %></a>
+        <% if (headerTitle != null || headerSubtitle != null) { %>
         <div class="layout__heading">
+            <% if (headerTitle != null) { %>
             <h1><%= headerTitle %></h1>
-            <% if (headerSubtitle != null && !headerSubtitle.trim().isEmpty()) { %>
+            <% } %>
+            <% if (headerSubtitle != null) { %>
             <p class="subtitle"><%= headerSubtitle %></p>
             <% } %>
         </div>
+        <% } %>
     </div>
     <% if (headerNavigationItems != null && !headerNavigationItems.isEmpty()) { %>
     <nav class="menu menu--horizontal">

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -82,6 +82,12 @@ code {
     gap: 1rem;
 }
 
+.layout__header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+}
+
 .layout__brand {
     display: flex;
     align-items: center;
@@ -458,6 +464,10 @@ code {
 
 .menu__item--danger {
     color: var(--danger-color);
+}
+
+.menu__item--logout {
+    margin-left: auto;
 }
 
 .menu__item--ghost {


### PR DESCRIPTION
## Summary
- update shared header to avoid duplicating the site name and keep subtitles tidy
- make the header sticky, align logout on the right, and ensure auth views show contextual titles
- label the remember option as remembering the password for clarity across login screens

## Testing
- Not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68f51e93c9b08320b31ed5612c69272a