### PR TITLE
Align build JSP buy-now endpoints

### DIFF
--- a/MMO_Trader_Market/build/web/WEB-INF/views/order/checkout.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/order/checkout.jsp
@@ -35,7 +35,7 @@
                         <li>Nhập email nhận sản phẩm và chọn phương thức thanh toán.</li>
                         <li>Hoàn tất thanh toán để nhận key/đường dẫn ngay lập tức.</li>
                     </ol>
-                    <form class="form" method="post" action="${pageContext.request.contextPath}/orders/buy">
+                    <form class="form" method="post" action="${pageContext.request.contextPath}/order/buy-now">
                         <input type="hidden" name="productId" value="${product.id}">
                         <div class="form__group" style="margin-bottom: 1rem;">
                             <label class="form__label" for="buyerEmail">Email nhận sản phẩm</label>

--- a/MMO_Trader_Market/build/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/product/list.jsp
@@ -51,11 +51,13 @@
                                            value="${not empty product.status ? fn:toUpperCase(product.status) : ''}" />
                                     <c:choose>
                                         <c:when test="${statusUpper eq 'APPROVED'}">
-                                            <c:url var="buyUrl" value="/orders/buy">
-                                                <c:param name="productId" value="${product.id}" />
-                                            </c:url>
+                                            <form method="post" action="${pageContext.request.contextPath}/order/buy-now"
+                                                  style="display:inline;">
+                                                <input type="hidden" name="productId" value="${product.id}" />
+                                                <input type="hidden" name="qty" value="1" />
+                                                <button class="button button--primary" type="submit">Mua ngay</button>
+                                            </form>
                                             <c:url var="ordersUrl" value="/orders/my" />
-                                            <a class="button button--primary" href="${buyUrl}">Mua ngay</a>
                                             <a class="button button--ghost" href="${ordersUrl}">Đơn đã mua</a>
                                         </c:when>
                                         <c:otherwise>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/checkout.jsp
@@ -35,7 +35,7 @@
                         <li>Nhập email nhận sản phẩm và chọn phương thức thanh toán.</li>
                         <li>Hoàn tất thanh toán để nhận key/đường dẫn ngay lập tức.</li>
                     </ol>
-                    <form class="form" method="post" action="${pageContext.request.contextPath}/orders/buy">
+                    <form class="form" method="post" action="${pageContext.request.contextPath}/order/buy-now">
                         <input type="hidden" name="productId" value="${product.id}">
                         <div class="form__group" style="margin-bottom: 1rem;">
                             <label class="form__label" for="buyerEmail">Email nhận sản phẩm</label>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -51,11 +51,13 @@
                                            value="${not empty product.status ? fn:toUpperCase(product.status) : ''}" />
                                     <c:choose>
                                         <c:when test="${statusUpper eq 'APPROVED'}">
-                                            <c:url var="buyUrl" value="/orders/buy">
-                                                <c:param name="productId" value="${product.id}" />
-                                            </c:url>
+                                            <form method="post" action="${pageContext.request.contextPath}/order/buy-now"
+                                                  style="display:inline;">
+                                                <input type="hidden" name="productId" value="${product.id}" />
+                                                <input type="hidden" name="qty" value="1" />
+                                                <button class="button button--primary" type="submit">Mua ngay</button>
+                                            </form>
                                             <c:url var="ordersUrl" value="/orders/my" />
-                                            <a class="button button--primary" href="${buyUrl}">Mua ngay</a>
                                             <a class="button button--ghost" href="${ordersUrl}">Đơn đã mua</a>
                                         </c:when>
                                         <c:otherwise>


### PR DESCRIPTION
## Summary
- update the tracked build JSP assets to submit product purchases to `/order/buy-now` to match the source views

## Testing
- not run (ant not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f5200bd5688320a91c7893f14a9f00