### PR TITLE
Add remember-me persistent login support

### DIFF
--- a/DB_v1.sql
+++ b/DB_v1.sql
@@ -52,6 +52,21 @@ CREATE TABLE `password_reset_tokens` (
   CONSTRAINT `fk_password_reset_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
 ) ENGINE=InnoDB;
 
+-- Table for persistent remember-me login tokens
+DROP TABLE IF EXISTS `remember_me_tokens`;
+CREATE TABLE `remember_me_tokens` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `selector` varchar(32) NOT NULL UNIQUE,
+  `hashed_validator` varchar(64) NOT NULL,
+  `expires_at` timestamp NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_used_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_remember_me_user` (`user_id`),
+  CONSTRAINT `fk_remember_me_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 -- Table for Shops
 DROP TABLE IF EXISTS `shops`;
 CREATE TABLE `shops` (

--- a/MMO_Trader_Market/src/java/dao/user/RememberMeTokenDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/RememberMeTokenDAO.java
@@ -1,0 +1,132 @@
+package dao.user;
+
+import dao.BaseDAO;
+import dao.connect.DBConnect;
+import model.RememberMeToken;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Statement;
+
+/**
+ * DAO for managing remember-me persistent login tokens.
+ */
+public class RememberMeTokenDAO extends BaseDAO {
+
+    private static final String COL_ID = "id";
+    private static final String COL_USER_ID = "user_id";
+    private static final String COL_SELECTOR = "selector";
+    private static final String COL_HASHED_VALIDATOR = "hashed_validator";
+    private static final String COL_EXPIRES_AT = "expires_at";
+    private static final String COL_CREATED_AT = "created_at";
+    private static final String COL_LAST_USED_AT = "last_used_at";
+
+    public RememberMeToken createToken(int userId, String selector, String hashedValidator, Timestamp expiresAt)
+            throws SQLException {
+        final String sql = """
+                INSERT INTO remember_me_tokens (user_id, selector, hashed_validator, expires_at, last_used_at)
+                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                """;
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, userId);
+            ps.setString(2, selector);
+            ps.setString(3, hashedValidator);
+            ps.setTimestamp(4, expiresAt);
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    int id = rs.getInt(1);
+                    RememberMeToken token = new RememberMeToken();
+                    token.setId(id);
+                    token.setUserId(userId);
+                    token.setSelector(selector);
+                    token.setHashedValidator(hashedValidator);
+                    token.setExpiresAt(expiresAt);
+                    Timestamp now = new Timestamp(System.currentTimeMillis());
+                    token.setCreatedAt(now);
+                    token.setLastUsedAt(new Timestamp(System.currentTimeMillis()));
+                    return token;
+                }
+            }
+        }
+        return null;
+    }
+
+    public RememberMeToken findBySelector(String selector) {
+        final String sql = """
+                SELECT * FROM remember_me_tokens
+                WHERE selector = ?
+                LIMIT 1
+                """;
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, selector);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return mapRow(rs);
+                }
+            }
+        } catch (SQLException e) {
+            logSqlError("findBySelector", e);
+        }
+        return null;
+    }
+
+    public void updateValidator(int id, String hashedValidator, Timestamp expiresAt) throws SQLException {
+        final String sql = """
+                UPDATE remember_me_tokens
+                SET hashed_validator = ?, expires_at = ?, last_used_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """;
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, hashedValidator);
+            ps.setTimestamp(2, expiresAt);
+            ps.setInt(3, id);
+            ps.executeUpdate();
+        }
+    }
+
+    public void deleteById(int id) throws SQLException {
+        final String sql = "DELETE FROM remember_me_tokens WHERE id = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        }
+    }
+
+    public void deleteBySelector(String selector) throws SQLException {
+        final String sql = "DELETE FROM remember_me_tokens WHERE selector = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, selector);
+            ps.executeUpdate();
+        }
+    }
+
+    public void deleteAllForUser(int userId) throws SQLException {
+        final String sql = "DELETE FROM remember_me_tokens WHERE user_id = ?";
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            ps.executeUpdate();
+        }
+    }
+
+    private RememberMeToken mapRow(ResultSet rs) throws SQLException {
+        RememberMeToken token = new RememberMeToken();
+        token.setId(rs.getInt(COL_ID));
+        token.setUserId(rs.getInt(COL_USER_ID));
+        token.setSelector(rs.getString(COL_SELECTOR));
+        token.setHashedValidator(rs.getString(COL_HASHED_VALIDATOR));
+        token.setExpiresAt(rs.getTimestamp(COL_EXPIRES_AT));
+        token.setCreatedAt(rs.getTimestamp(COL_CREATED_AT));
+        token.setLastUsedAt(rs.getTimestamp(COL_LAST_USED_AT));
+        return token;
+    }
+}

--- a/MMO_Trader_Market/src/java/filter/RememberMeFilter.java
+++ b/MMO_Trader_Market/src/java/filter/RememberMeFilter.java
@@ -1,0 +1,50 @@
+package filter;
+
+import dao.user.RememberMeTokenDAO;
+import dao.user.UserDAO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import model.Users;
+import service.RememberMeService;
+
+import java.io.IOException;
+
+/**
+ * Filter that restores user sessions from remember-me cookies when applicable.
+ */
+@WebFilter("/*")
+public class RememberMeFilter extends HttpFilter {
+
+    private RememberMeService rememberMeService;
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+        super.init(filterConfig);
+        this.rememberMeService = new RememberMeService(new RememberMeTokenDAO(), new UserDAO());
+    }
+
+    @Override
+    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (rememberMeService == null) {
+            rememberMeService = new RememberMeService(new RememberMeTokenDAO(), new UserDAO());
+        }
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("currentUser") == null) {
+            Users user = rememberMeService.autoLogin(request, response);
+            if (user != null) {
+                HttpSession newSession = request.getSession(true);
+                newSession.setAttribute("currentUser", user);
+                newSession.setAttribute("userId", user.getId());
+                newSession.setAttribute("userRole", user.getRoleId());
+            }
+        }
+        chain.doFilter(request, response);
+    }
+}

--- a/MMO_Trader_Market/src/java/model/RememberMeToken.java
+++ b/MMO_Trader_Market/src/java/model/RememberMeToken.java
@@ -1,0 +1,73 @@
+package model;
+
+import java.sql.Timestamp;
+
+/**
+ * Represents a persistent login token used for the "remember me" feature.
+ */
+public class RememberMeToken {
+
+    private int id;
+    private int userId;
+    private String selector;
+    private String hashedValidator;
+    private Timestamp expiresAt;
+    private Timestamp createdAt;
+    private Timestamp lastUsedAt;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public int getUserId() {
+        return userId;
+    }
+
+    public void setUserId(int userId) {
+        this.userId = userId;
+    }
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public void setSelector(String selector) {
+        this.selector = selector;
+    }
+
+    public String getHashedValidator() {
+        return hashedValidator;
+    }
+
+    public void setHashedValidator(String hashedValidator) {
+        this.hashedValidator = hashedValidator;
+    }
+
+    public Timestamp getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Timestamp expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Timestamp getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Timestamp createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Timestamp getLastUsedAt() {
+        return lastUsedAt;
+    }
+
+    public void setLastUsedAt(Timestamp lastUsedAt) {
+        this.lastUsedAt = lastUsedAt;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/RememberMeService.java
+++ b/MMO_Trader_Market/src/java/service/RememberMeService.java
@@ -1,0 +1,215 @@
+package service;
+
+import dao.user.RememberMeTokenDAO;
+import dao.user.UserDAO;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import model.RememberMeToken;
+import model.Users;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Service that encapsulates creation, validation and cleanup of remember-me tokens.
+ */
+public class RememberMeService {
+
+    public static final String COOKIE_NAME = "rememberMeToken";
+    private static final int SELECTOR_BYTES = 12;
+    private static final int VALIDATOR_BYTES = 32;
+    private static final int EXPIRY_DAYS = 30;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final Logger LOGGER = Logger.getLogger(RememberMeService.class.getName());
+
+    private final RememberMeTokenDAO tokenDAO;
+    private final UserDAO userDAO;
+
+    public RememberMeService(RememberMeTokenDAO tokenDAO, UserDAO userDAO) {
+        this.tokenDAO = tokenDAO;
+        this.userDAO = userDAO;
+    }
+
+    public void createRememberMeCookie(HttpServletRequest request, HttpServletResponse response, int userId) {
+        clearRememberMe(request, response);
+        String selector = generateRandomToken(SELECTOR_BYTES);
+        String validator = generateRandomToken(VALIDATOR_BYTES);
+        String hashedValidator = hashValidator(validator);
+        Timestamp expiresAt = Timestamp.from(Instant.now().plus(EXPIRY_DAYS, ChronoUnit.DAYS));
+        try {
+            RememberMeToken created = tokenDAO.createToken(userId, selector, hashedValidator, expiresAt);
+            if (created == null) {
+                LOGGER.log(Level.WARNING, "Failed to persist remember-me token for user {0}", userId);
+                return;
+            }
+            Cookie cookie = buildCookie(request, selector + ':' + validator, expiresAt, request.isSecure());
+            response.addCookie(cookie);
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Failed to persist remember-me token", e);
+        }
+    }
+
+    public Users autoLogin(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = findCookie(request);
+        if (cookie == null) {
+            return null;
+        }
+        String value = cookie.getValue();
+        if (value == null || value.isBlank()) {
+            clearCookie(request, response);
+            return null;
+        }
+        String[] parts = value.split(":");
+        if (parts.length != 2) {
+            clearCookie(request, response);
+            return null;
+        }
+        String selector = parts[0];
+        String validator = parts[1];
+
+        RememberMeToken token = tokenDAO.findBySelector(selector);
+        if (token == null || token.getExpiresAt() == null) {
+            clearCookie(request, response);
+            return null;
+        }
+        if (token.getExpiresAt().toInstant().isBefore(Instant.now())) {
+            removeToken(token);
+            clearCookie(request, response);
+            return null;
+        }
+
+        String hashedValidator = hashValidator(validator);
+        String storedHashed = token.getHashedValidator();
+        if (storedHashed == null || storedHashed.isBlank()
+                || !MessageDigest.isEqual(hashedValidator.getBytes(StandardCharsets.UTF_8),
+                storedHashed.getBytes(StandardCharsets.UTF_8))) {
+            handleCompromisedToken(token, request, response);
+            return null;
+        }
+
+        Users user = userDAO.getUserByUserId(token.getUserId());
+        if (user == null) {
+            removeToken(token);
+            clearCookie(request, response);
+            return null;
+        }
+
+        rotateToken(request, response, token);
+        return user;
+    }
+
+    public void clearRememberMe(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = findCookie(request);
+        if (cookie == null) {
+            return;
+        }
+        String value = cookie.getValue();
+        if (value != null && !value.isBlank()) {
+            String selector = value.split(":")[0];
+            try {
+                tokenDAO.deleteBySelector(selector);
+            } catch (SQLException e) {
+                LOGGER.log(Level.WARNING, "Failed to delete remember-me token during logout", e);
+            }
+        }
+        clearCookie(request, response);
+    }
+
+    private void rotateToken(HttpServletRequest request, HttpServletResponse response, RememberMeToken token) {
+        String newValidator = generateRandomToken(VALIDATOR_BYTES);
+        String hashedValidator = hashValidator(newValidator);
+        Timestamp expiresAt = Timestamp.from(Instant.now().plus(EXPIRY_DAYS, ChronoUnit.DAYS));
+        try {
+            tokenDAO.updateValidator(token.getId(), hashedValidator, expiresAt);
+            Cookie cookie = buildCookie(request, token.getSelector() + ':' + newValidator, expiresAt, request.isSecure());
+            response.addCookie(cookie);
+        } catch (SQLException e) {
+            LOGGER.log(Level.WARNING, "Failed to rotate remember-me token", e);
+            clearCookie(request, response);
+        }
+    }
+
+    private void handleCompromisedToken(RememberMeToken token, HttpServletRequest request, HttpServletResponse response) {
+        try {
+            tokenDAO.deleteAllForUser(token.getUserId());
+        } catch (SQLException e) {
+            LOGGER.log(Level.SEVERE, "Failed to clean remember-me tokens after mismatch", e);
+        }
+        clearCookie(request, response);
+    }
+
+    private void removeToken(RememberMeToken token) {
+        try {
+            tokenDAO.deleteById(token.getId());
+        } catch (SQLException e) {
+            LOGGER.log(Level.WARNING, "Failed to remove remember-me token", e);
+        }
+    }
+
+    private Cookie findCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (COOKIE_NAME.equals(cookie.getName())) {
+                return cookie;
+            }
+        }
+        return null;
+    }
+
+    private void clearCookie(HttpServletRequest request, HttpServletResponse response) {
+        Cookie cookie = new Cookie(COOKIE_NAME, "");
+        cookie.setPath(resolveCookiePath(request));
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(request.isSecure());
+        response.addCookie(cookie);
+    }
+
+    private Cookie buildCookie(HttpServletRequest request, String value, Timestamp expiresAt, boolean secure) {
+        Cookie cookie = new Cookie(COOKIE_NAME, value);
+        cookie.setPath(resolveCookiePath(request));
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        long seconds = ChronoUnit.SECONDS.between(Instant.now(), expiresAt.toInstant());
+        cookie.setMaxAge((int) Math.min(Integer.MAX_VALUE, Math.max(seconds, 0)));
+        return cookie;
+    }
+
+    private String resolveCookiePath(HttpServletRequest request) {
+        String contextPath = request.getContextPath();
+        if (contextPath == null || contextPath.isEmpty()) {
+            return "/";
+        }
+        return contextPath;
+    }
+
+    private String generateRandomToken(int bytes) {
+        byte[] randomBytes = new byte[bytes];
+        RANDOM.nextBytes(randomBytes);
+        return ENCODER.encodeToString(randomBytes);
+    }
+
+    private String hashValidator(String validator) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(validator.getBytes(StandardCharsets.UTF_8));
+            return ENCODER.encodeToString(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a persistent remember-me token table to the database schema
- implement DAO, model, service, and servlet filter to restore logins from remember-me cookies
- update the authentication controller to issue and clear remember-me cookies and redirect authenticated users

## Testing
- not run (project does not include automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68f5303829e48320bc69890f4a1ba94b