### PR TITLE
Refine header navigation and auth layouts

### DIFF
--- a/MMO_Trader_Market/build/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/auth/login.jsp
@@ -2,16 +2,11 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng nhập" />
 <c:set var="bodyClass" value="layout layout--center" />
+<c:set var="headerModifier" value="layout__header--auth" />
 <%--<c:set var="headerTitle" value="Đăng nhập" />
 <c:set var="headerSubtitle" value="Đăng nhập để quản lý giao dịch" />--%>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
-<style>
-  /* Thu gọn khoảng cách giữa các nút hướng dẫn dưới form */
-  /* Tùy chọn: thu gọn form cho đều mắt */
-  .form-card { gap: 12px; }
-  .form-card__field { margin-bottom: 10px; }
-</style>
 <main class="layout__content auth-page">
     <c:if test="${not empty error}">
         <div class="alert alert--error"><c:out value="${error}" /></div>

--- a/MMO_Trader_Market/build/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/build/web/WEB-INF/views/auth/register.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng ký" />
 <c:set var="bodyClass" value="layout layout--center" />
+<c:set var="headerModifier" value="layout__header--auth" />
 <c:set var="headerTitle" value="Đăng ký" />
 <c:set var="headerSubtitle" value="Tạo tài khoản mới" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>

--- a/MMO_Trader_Market/build/web/assets/css/main.css
+++ b/MMO_Trader_Market/build/web/assets/css/main.css
@@ -51,19 +51,34 @@ code {
 }
 
 .auth-page {
-    max-width: 720px;
+    max-width: 480px;
     width: 100%;
     margin-inline: auto;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.75rem;
+    gap: 1.5rem;
+}
+
+.layout--center .layout__content.auth-page {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: calc(100vh - 14rem);
+    padding-block: clamp(2rem, 8vh, 4rem);
 }
 
 .auth-page .form-card,
 .auth-page .guide-link,
 .auth-page .alert {
-    width: min(100%, 640px);
+    width: 100%;
+}
+
+.auth-page .form-card {
+    max-width: 420px;
+    width: 100%;
+    margin-inline: auto;
 }
 
 .auth-page .guide-link .button {
@@ -88,6 +103,16 @@ code {
     z-index: 1000;
 }
 
+.layout__header--auth {
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
+    background: rgba(255, 255, 255, 0.94);
+    border-bottom: 1px solid rgba(0, 91, 150, 0.08);
+}
+
+.layout__header--auth .layout__brand {
+    margin-inline: auto;
+}
+
 .layout__brand {
     display: flex;
     align-items: center;
@@ -96,16 +121,29 @@ code {
 
 .layout__logo {
     font-weight: 800;
-    font-size: 1.15rem;
+    font-size: clamp(1.3rem, 2vw + 0.5rem, 1.7rem);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.16em;
     color: var(--primary-color);
     text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    transition: var(--transition);
+    background: rgba(0, 91, 150, 0.06);
+    border: 1px solid rgba(0, 91, 150, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .layout__logo:hover,
 .layout__logo:focus {
-    color: var(--accent-color);
+    color: var(--primary-color-dark);
+    text-decoration: none;
+    background: rgba(0, 91, 150, 0.1);
+    transform: translateY(-1px);
 }
 
 .layout__heading h1 {

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -38,8 +38,10 @@ public final class NavigationBuilder {
         addBaseItems(items, contextPath, currentPath);
 
         if (roleId == null) {
-            items.add(createIconItem(contextPath + "/auth", "👤", "Đăng nhập", true,
-                    isActive(currentPath, "/auth")));
+            if (shouldDisplayAuthCta(currentPath)) {
+                items.add(createIconItem(contextPath + "/auth", "👤", "Đăng nhập", true,
+                        isActive(currentPath, "/auth")));
+            }
             return items;
         }
 
@@ -109,6 +111,21 @@ public final class NavigationBuilder {
             return currentPath == null || currentPath.isEmpty() || "/".equals(currentPath);
         }
         return currentPath.equals(path) || currentPath.startsWith(path + "/");
+    }
+
+    private static boolean shouldDisplayAuthCta(String currentPath) {
+        if (currentPath == null) {
+            return true;
+        }
+
+        return !currentPath.equals("/auth")
+                && !currentPath.startsWith("/auth/")
+                && !currentPath.equals("/register")
+                && !currentPath.startsWith("/register/")
+                && !currentPath.equals("/forgot-password")
+                && !currentPath.startsWith("/forgot-password/")
+                && !currentPath.equals("/reset-password")
+                && !currentPath.startsWith("/reset-password/");
     }
 
     private static String resolveCurrentPath(HttpServletRequest request) {

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
@@ -2,16 +2,11 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng nhập" />
 <c:set var="bodyClass" value="layout layout--center" />
+<c:set var="headerModifier" value="layout__header--auth" />
 <%--<c:set var="headerTitle" value="Đăng nhập" />
 <c:set var="headerSubtitle" value="Đăng nhập để quản lý giao dịch" />--%>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
-<style>
-  /* Thu gọn khoảng cách giữa các nút hướng dẫn dưới form */
-  /* Tùy chọn: thu gọn form cho đều mắt */
-  .form-card { gap: 12px; }
-  .form-card__field { margin-bottom: 10px; }
-</style>
 <main class="layout__content auth-page">
     <c:if test="${not empty error}">
         <div class="alert alert--error"><c:out value="${error}" /></div>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng ký" />
 <c:set var="bodyClass" value="layout layout--center" />
+<c:set var="headerModifier" value="layout__header--auth" />
 <c:set var="headerTitle" value="Đăng ký" />
 <c:set var="headerSubtitle" value="Tạo tài khoản mới" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -51,19 +51,34 @@ code {
 }
 
 .auth-page {
-    max-width: 720px;
+    max-width: 480px;
     width: 100%;
     margin-inline: auto;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.75rem;
+    gap: 1.5rem;
+}
+
+.layout--center .layout__content.auth-page {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    min-height: calc(100vh - 14rem);
+    padding-block: clamp(2rem, 8vh, 4rem);
 }
 
 .auth-page .form-card,
 .auth-page .guide-link,
 .auth-page .alert {
-    width: min(100%, 640px);
+    width: 100%;
+}
+
+.auth-page .form-card {
+    max-width: 420px;
+    width: 100%;
+    margin-inline: auto;
 }
 
 .auth-page .guide-link .button {
@@ -88,6 +103,16 @@ code {
     z-index: 1000;
 }
 
+.layout__header--auth {
+    box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
+    background: rgba(255, 255, 255, 0.94);
+    border-bottom: 1px solid rgba(0, 91, 150, 0.08);
+}
+
+.layout__header--auth .layout__brand {
+    margin-inline: auto;
+}
+
 .layout__brand {
     display: flex;
     align-items: center;
@@ -96,16 +121,29 @@ code {
 
 .layout__logo {
     font-weight: 800;
-    font-size: 1.15rem;
+    font-size: clamp(1.3rem, 2vw + 0.5rem, 1.7rem);
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.16em;
     color: var(--primary-color);
     text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    transition: var(--transition);
+    background: rgba(0, 91, 150, 0.06);
+    border: 1px solid rgba(0, 91, 150, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .layout__logo:hover,
 .layout__logo:focus {
-    color: var(--accent-color);
+    color: var(--primary-color-dark);
+    text-decoration: none;
+    background: rgba(0, 91, 150, 0.1);
+    transform: translateY(-1px);
 }
 
 .layout__heading h1 {


### PR DESCRIPTION
## Summary
- center and reduce the login and registration forms while styling the header logo for better emphasis
- add an auth-specific header modifier on login and register pages and mirror the assets in the build output
- avoid showing the login navigation button while already visiting authentication-related pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5b7918fac8320bc9afab99ce89968