### PR TITLE
Refine header and auth layouts

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
@@ -1,45 +1,49 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng nhập" />
-<c:set var="bodyClass" value="layout layout--center" />
+<c:set var="bodyClass" value="layout layout--auth" />
 <c:set var="headerModifier" value="layout__header--auth" />
-<%--<c:set var="headerTitle" value="Đăng nhập" />
-<c:set var="headerSubtitle" value="Đăng nhập để quản lý giao dịch" />--%>
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content auth-page">
-    <c:if test="${not empty error}">
-        <div class="alert alert--error"><c:out value="${error}" /></div>
-    </c:if>
-    <c:if test="${not empty success}">
-        <div class="alert alert--success"><c:out value="${success}" /></div>
-    </c:if>
-    <form method="post" action="<c:url value='/auth' />" class="form-card">
-        <div class="form-card__field">
-            <label class="form-card__label" for="email">Email</label>
-            <input class="form-card__input" id="email" name="email" type="email"
-                   placeholder="example@email.com"
-                   value="<c:out value='${prefillEmail}'/>" required>
-        </div>
-        <div class="form-card__field">
-            <label class="form-card__label" for="password">Mật khẩu</label>
-            <input class="form-card__input" id="password" name="password" type="password" placeholder="••••••••" required>
-        </div>
-        <div class="form-card__options-row">
-            <label class="form-card__option form-card__option--inline" for="rememberMe">
-                <input class="form-card__checkbox" id="rememberMe" name="rememberMe" type="checkbox"
-                       <c:if test="${rememberMeChecked}">checked</c:if>>
-                <span class="form-card__option-text">Ghi nhớ mật khẩu</span>
-            </label>
-            <a class="form-card__link" href="<c:url value='/forgot-password' />">Quên mật khẩu?</a>
-        </div>
+    <div class="auth-page__inner">
+        <header class="auth-page__header">
+            <h1>Đăng nhập</h1>
+            <p>Đăng nhập để quản lý giao dịch của bạn trên MMO Trader Market</p>
+        </header>
+        <c:if test="${not empty error}">
+            <div class="alert alert--error auth-page__alert"><c:out value="${error}" /></div>
+        </c:if>
+        <c:if test="${not empty success}">
+            <div class="alert alert--success auth-page__alert"><c:out value="${success}" /></div>
+        </c:if>
+        <form method="post" action="<c:url value='/auth' />" class="form-card auth-page__form">
+            <div class="form-card__field">
+                <label class="form-card__label" for="email">Email</label>
+                <input class="form-card__input" id="email" name="email" type="email"
+                       placeholder="example@email.com"
+                       value="<c:out value='${prefillEmail}'/>" required>
+            </div>
+            <div class="form-card__field">
+                <label class="form-card__label" for="password">Mật khẩu</label>
+                <input class="form-card__input" id="password" name="password" type="password" placeholder="••••••••" required>
+            </div>
+            <div class="form-card__options-row">
+                <label class="form-card__option form-card__option--inline" for="rememberMe">
+                    <input class="form-card__checkbox" id="rememberMe" name="rememberMe" type="checkbox"
+                           <c:if test="${rememberMeChecked}">checked</c:if>>
+                    <span class="form-card__option-text">Ghi nhớ mật khẩu</span>
+                </label>
+                <a class="form-card__link" href="<c:url value='/forgot-password' />">Quên mật khẩu?</a>
+            </div>
 
-        <button class="button button--primary" type="submit">Đăng nhập</button>
-        <div class="form-card__actions-row">
-            <a class="button button--secondary" href="<c:url value='/auth/google' />">Đăng nhập bằng Google</a>
-            <a class="button button--ghost" href="<c:url value='/register' />">Đăng ký ngay</a>
-        </div>
-    </form>
+            <button class="button button--primary" type="submit">Đăng nhập</button>
+            <div class="form-card__actions-row">
+                <a class="button button--secondary" href="<c:url value='/auth/google' />">Đăng nhập bằng Google</a>
+                <a class="button button--ghost" href="<c:url value='/register' />">Đăng ký ngay</a>
+            </div>
+        </form>
+    </div>
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
@@ -1,49 +1,53 @@
 <%@ page contentType="text/html;charset=UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng ký" />
-<c:set var="bodyClass" value="layout layout--center" />
+<c:set var="bodyClass" value="layout layout--auth" />
 <c:set var="headerModifier" value="layout__header--auth" />
-<c:set var="headerTitle" value="Đăng ký" />
-<c:set var="headerSubtitle" value="Tạo tài khoản mới" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content auth-page">
-    <c:if test="${not empty error}">
-        <div class="alert alert--error"><c:out value="${error}" /></div>
-    </c:if>
-    <form method="post" action="<c:url value='/register' />" class="form-card">
-        <div class="form-card__field">
-            <label class="form-card__label" for="name">Tài khoản</label>
-            <input class="form-card__input" id="name" name="name" type="text"
-                   placeholder="VD: username123" value="<c:out value='${name}'/>" required>
-        </div>
-        <div class="form-card__field">
-            <label class="form-card__label" for="email">Email</label>
-            <input class="form-card__input" id="email" name="email" type="email"
-                   placeholder="example@email.com" value="<c:out value='${email}'/>" required>
-        </div>
-        <div class="form-card__field">
-            <label class="form-card__label" for="password">Mật khẩu</label>
-            <input class="form-card__input" id="password" name="password" type="password" placeholder="Tối thiểu 8 ký tự gồm chữ và số" required>
-        </div>
-        <div class="form-card__field">
-            <label class="form-card__label" for="confirmPassword">Nhập lại mật khẩu</label>
-            <input class="form-card__input" id="confirmPassword" name="confirmPassword" type="password" placeholder="Nhập lại mật khẩu" required>
-        </div>
-        <div class="form-card__option">
-            <input class="form-card__checkbox" id="acceptTerms" name="acceptTerms" type="checkbox"
-                   <c:if test="${acceptTermsChecked}">checked</c:if> required>
-            <label class="form-card__option-text" for="acceptTerms">
-                Tôi đã đọc và đồng ý với
-                <a href="#" target="_blank" rel="noopener">Điều khoản sử dụng Tap Hóa MMO</a>
-            </label>
-        </div>
-        <button class="button button--primary" type="submit">Đăng ký</button>
-        <div class="form-card__actions-row">
-            <a class="button button--ghost" href="<c:url value='/auth' />">Quay lại trang đăng nhập</a>
-            <a class="button button--secondary" href="<c:url value='/auth/google' />">Đăng ký bằng Google</a>
-        </div>
-    </form>
+    <div class="auth-page__inner">
+        <header class="auth-page__header">
+            <h1>Đăng ký</h1>
+            <p>Tạo tài khoản MMO Trader Market để bắt đầu giao dịch</p>
+        </header>
+        <c:if test="${not empty error}">
+            <div class="alert alert--error auth-page__alert"><c:out value="${error}" /></div>
+        </c:if>
+        <form method="post" action="<c:url value='/register' />" class="form-card auth-page__form">
+            <div class="form-card__field">
+                <label class="form-card__label" for="name">Tài khoản</label>
+                <input class="form-card__input" id="name" name="name" type="text"
+                       placeholder="VD: username123" value="<c:out value='${name}'/>" required>
+            </div>
+            <div class="form-card__field">
+                <label class="form-card__label" for="email">Email</label>
+                <input class="form-card__input" id="email" name="email" type="email"
+                       placeholder="example@email.com" value="<c:out value='${email}'/>" required>
+            </div>
+            <div class="form-card__field">
+                <label class="form-card__label" for="password">Mật khẩu</label>
+                <input class="form-card__input" id="password" name="password" type="password" placeholder="Tối thiểu 8 ký tự gồm chữ và số" required>
+            </div>
+            <div class="form-card__field">
+                <label class="form-card__label" for="confirmPassword">Nhập lại mật khẩu</label>
+                <input class="form-card__input" id="confirmPassword" name="confirmPassword" type="password" placeholder="Nhập lại mật khẩu" required>
+            </div>
+            <div class="form-card__option">
+                <input class="form-card__checkbox" id="acceptTerms" name="acceptTerms" type="checkbox"
+                       <c:if test="${acceptTermsChecked}">checked</c:if> required>
+                <label class="form-card__option-text" for="acceptTerms">
+                    Tôi đã đọc và đồng ý với
+                    <a href="#" target="_blank" rel="noopener">Điều khoản sử dụng Tap Hóa MMO</a>
+                </label>
+            </div>
+            <button class="button button--primary" type="submit">Đăng ký</button>
+            <div class="form-card__actions-row">
+                <a class="button button--ghost" href="<c:url value='/auth' />">Quay lại trang đăng nhập</a>
+                <a class="button button--secondary" href="<c:url value='/auth/google' />">Đăng ký bằng Google</a>
+            </div>
+        </form>
+    </div>
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -1,52 +1,113 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
-<c:set var="brandName" value="MMO Trader Market" />
-<c:set var="homeHref" value="${pageContext.request.contextPath}/home" />
+<c:choose>
+  <c:when test="${not empty headerBrandName}">
+    <c:set var="brandName" value="${headerBrandName}" />
+  </c:when>
+  <c:otherwise>
+    <c:set var="brandName" value="MMO Trader Market" />
+  </c:otherwise>
+</c:choose>
 
-<!-- M?c ??nh headerModifier l� chu?i r?ng n?u ch?a set -->
+<c:choose>
+  <c:when test="${not empty headerHomeHref}">
+    <c:set var="homeHref" value="${headerHomeHref}" />
+  </c:when>
+  <c:otherwise>
+    <c:set var="homeHref" value="${pageContext.request.contextPath}/home" />
+  </c:otherwise>
+</c:choose>
+
+<c:url value="/login" var="loginUrl" />
+<c:url value="/auth?action=logout" var="logoutUrl" />
+
+<c:set var="currentUri" value="${pageContext.request.requestURI}" />
+<c:set var="isAuthPage"
+        value="${fn:contains(currentUri, '/login') or fn:contains(currentUri, '/register') or fn:contains(currentUri, '/forgot')}" />
+<c:set var="isLoggedIn" value="${not empty sessionScope.authUser}" />
+
+<!-- Mặc định headerModifier là chuỗi rỗng nếu chưa set -->
 <c:if test="${empty headerModifier}">
-  <c:set var="headerModifier" value=""/>
+  <c:set var="headerModifier" value="" />
+</c:if>
+
+<c:if test="${isLoggedIn}">
+  <c:set var="displayName"
+         value="${not empty sessionScope.authUser.fullName ? sessionScope.authUser.fullName :
+                 (not empty sessionScope.authUser.name ? sessionScope.authUser.name :
+                 (not empty sessionScope.authUser.username ? sessionScope.authUser.username : sessionScope.authUser.email))}" />
+  <c:set var="avatarInitial" value="U" />
+  <c:if test="${not empty displayName}">
+    <c:set var="avatarInitial" value="${fn:toUpperCase(fn:substring(displayName, 0, 1))}" />
+  </c:if>
 </c:if>
 
 <header class="layout__header ${headerModifier}">
-  <div class="layout__brand">
-    <a class="layout__logo" href="${homeHref}" title="${brandName}">${brandName}</a>
+  <div class="site-header__inner">
+    <div class="layout__brand site-header__brand">
+      <a class="layout__logo site-header__logo" href="${homeHref}" title="${brandName}">
+        <c:if test="${not empty headerLogoSrc}">
+          <img class="site-header__logo-image" src="${headerLogoSrc}" alt="${brandName}" loading="lazy" />
+        </c:if>
+        <span class="site-header__logo-text"><c:out value="${brandName}" /></span>
+      </a>
 
-    <c:if test="${not empty headerTitle or not empty headerSubtitle}">
-      <div class="layout__heading">
-        <c:if test="${not empty headerTitle}">
-          <h1><c:out value="${headerTitle}"/></h1>
-        </c:if>
-        <c:if test="${not empty headerSubtitle}">
-          <p class="subtitle"><c:out value="${headerSubtitle}"/></p>
-        </c:if>
+      <c:if test="${not empty headerTitle or not empty headerSubtitle}">
+        <div class="layout__heading site-header__heading">
+          <c:if test="${not empty headerTitle}">
+            <h1><c:out value="${headerTitle}" /></h1>
+          </c:if>
+          <c:if test="${not empty headerSubtitle}">
+            <p class="subtitle"><c:out value="${headerSubtitle}" /></p>
+          </c:if>
+        </div>
+      </c:if>
+    </div>
+
+    <c:if test="${not empty navItems}">
+      <nav class="menu menu--horizontal site-header__nav" aria-label="Chuyển hướng chính">
+        <c:forEach var="item" items="${navItems}">
+          <c:set var="itemClass" value="menu__item" />
+          <c:if test="${not empty item['modifier']}">
+            <c:set var="itemClass" value="${itemClass} ${item['modifier']}" />
+          </c:if>
+
+          <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
+            <c:if test="${not empty item['icon']}">
+              <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}" /></span>
+            </c:if>
+
+            <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}" />
+            <c:if test="${not empty textVal}">
+              <span class="menu__text"><c:out value="${textVal}" /></span>
+            </c:if>
+
+            <c:if test="${not empty item['srText']}">
+              <span class="sr-only"><c:out value="${item['srText']}" /></span>
+            </c:if>
+          </a>
+        </c:forEach>
+      </nav>
+    </c:if>
+
+    <c:if test="${isLoggedIn or (not isAuthPage)}">
+      <div class="site-header__actions">
+        <c:choose>
+          <c:when test="${isLoggedIn}">
+            <div class="site-header__user">
+              <span class="site-header__avatar" aria-hidden="true"><c:out value="${avatarInitial}" /></span>
+              <div class="site-header__user-info">
+                <span class="site-header__user-name"><c:out value="${displayName}" /></span>
+              </div>
+              <a class="button button--ghost site-header__logout" href="${logoutUrl}">Đăng xuất</a>
+            </div>
+          </c:when>
+          <c:otherwise>
+            <a class="button button--primary site-header__login" href="${loginUrl}">Đăng nhập</a>
+          </c:otherwise>
+        </c:choose>
       </div>
     </c:if>
   </div>
-
-  <c:if test="${not empty navItems}">
-    <nav class="menu menu--horizontal">
-      <c:forEach var="item" items="${navItems}">
-        <c:set var="itemClass" value="menu__item"/>
-        <c:if test="${not empty item['modifier']}">
-          <c:set var="itemClass" value="${itemClass} ${item['modifier']}"/>
-        </c:if>
-
-        <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
-          <c:if test="${not empty item['icon']}">
-            <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}"/></span>
-          </c:if>
-
-          <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}"/>
-          <c:if test="${not empty textVal}">
-            <span class="menu__text"><c:out value="${textVal}"/></span>
-          </c:if>
-
-          <c:if test="${not empty item['srText']}">
-            <span class="sr-only"><c:out value="${item['srText']}"/></span>
-          </c:if>
-        </a>
-      </c:forEach>
-    </nav>
-  </c:if>
 </header>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -51,34 +51,57 @@ code {
 }
 
 .auth-page {
-    max-width: 480px;
     width: 100%;
-    margin-inline: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
 }
 
-.layout--center .layout__content.auth-page {
+.layout--center .layout__content.auth-page,
+.layout--auth .layout__content.auth-page {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    min-height: calc(100vh - 14rem);
-    padding-block: clamp(2rem, 8vh, 4rem);
+    min-height: 100%;
+    padding: clamp(2rem, 8vh, 4rem) 1.5rem;
+    gap: 2rem;
 }
 
-.auth-page .form-card,
-.auth-page .guide-link,
-.auth-page .alert {
+.auth-page__inner {
+    width: min(100%, 400px);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.auth-page__header {
+    display: grid;
+    gap: 0.4rem;
+    text-align: center;
+}
+
+.auth-page__header h1 {
+    margin: 0;
+    font-size: clamp(1.6rem, 1.3rem + 1vw, 2.1rem);
+}
+
+.auth-page__header p {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.auth-page__alert {
     width: 100%;
+    margin: 0;
 }
 
 .auth-page .form-card {
-    max-width: 420px;
+    max-width: 400px;
     width: 100%;
-    margin-inline: auto;
+    margin: 0 auto;
+    padding: 2.25rem 2rem;
+}
+
+.auth-page__form {
+    width: 100%;
 }
 
 .auth-page .guide-link .button {
@@ -88,13 +111,8 @@ code {
 .layout__header,
 .layout__footer {
     background: var(--surface-color);
-    padding: 1.5rem 2rem;
+    padding: 1.25rem 2rem;
     box-shadow: 0 10px 30px var(--shadow-color);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
 }
 
 .layout__header {
@@ -103,56 +121,141 @@ code {
     z-index: 1000;
 }
 
+.layout__footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
 .layout__header--auth {
     box-shadow: 0 6px 18px rgba(15, 23, 42, 0.05);
     background: rgba(255, 255, 255, 0.94);
     border-bottom: 1px solid rgba(0, 91, 150, 0.08);
+    backdrop-filter: blur(6px);
 }
 
-.layout__header--auth .layout__brand {
-    margin-inline: auto;
+.site-header__inner {
+    width: min(100%, 1200px);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1.5rem;
 }
 
-.layout__brand {
+.layout__brand,
+.site-header__brand {
     display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 1rem;
 }
 
 .layout__logo {
-    font-weight: 800;
-    font-size: clamp(1.3rem, 2vw + 0.5rem, 1.7rem);
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
-    color: var(--primary-color);
-    text-decoration: none;
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.35rem 0.85rem;
+    font-weight: 700;
+    font-size: clamp(1.25rem, 1.05rem + 0.6vw, 1.5rem);
+    color: var(--primary-color);
+    text-decoration: none;
+    text-transform: none;
+    letter-spacing: normal;
+    line-height: 1.2;
+    padding: 0.25rem 0;
     border-radius: var(--radius-sm);
-    white-space: nowrap;
+    background: transparent;
+    border: none;
+    box-shadow: none;
     transition: var(--transition);
-    background: rgba(0, 91, 150, 0.06);
-    border: 1px solid rgba(0, 91, 150, 0.12);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .layout__logo:hover,
 .layout__logo:focus {
     color: var(--primary-color-dark);
     text-decoration: none;
-    background: rgba(0, 91, 150, 0.1);
-    transform: translateY(-1px);
+}
+
+.site-header__logo-image {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+}
+
+.site-header__logo-text {
+    white-space: nowrap;
+}
+
+.layout__heading {
+    display: grid;
+    gap: 0.35rem;
 }
 
 .layout__heading h1 {
     margin: 0;
 }
 
-.layout__heading {
+.site-header__heading {
     display: grid;
     gap: 0.35rem;
+}
+
+.site-header__nav {
+    justify-self: center;
+}
+
+.site-header__actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    justify-self: end;
+}
+
+.site-header__login,
+.site-header__logout {
+    white-space: nowrap;
+}
+
+.site-header__user {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.site-header__avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: rgba(0, 91, 150, 0.12);
+    color: var(--primary-color-dark);
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.site-header__user-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.site-header__user-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.layout__header--auth .site-header__inner {
+    grid-template-columns: auto;
+    justify-items: center;
+    gap: 1rem;
+}
+
+.layout__header--auth .site-header__actions {
+    justify-self: center;
 }
 
 .layout__header--split {
@@ -761,6 +864,30 @@ code {
 
 /* Responsive tweaks */
 @media (max-width: 768px) {
+    .site-header__inner {
+        grid-template-columns: 1fr;
+        justify-items: center;
+        gap: 1rem;
+        text-align: center;
+    }
+
+    .layout__brand,
+    .site-header__brand {
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .site-header__nav,
+    .site-header__actions {
+        justify-self: center;
+    }
+
+    .site-header__user {
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.5rem;
+    }
+
     .layout__content {
         padding: 1.5rem;
     }
@@ -768,6 +895,10 @@ code {
     .panel__header,
     .panel__body {
         padding: 1.25rem;
+    }
+
+    .auth-page .form-card {
+        padding: 2rem 1.5rem;
     }
 
     .search-bar {


### PR DESCRIPTION
## Summary
- streamline the shared header to support branded navigation, user menus, and hide the login button on auth pages
- restyle auth forms and supporting CSS so login/register cards stay centered with consistent spacing across viewports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5bb17dcc88320b5e5e5ee1a51899e