### PR TITLE
Fix auth header alignment and center auth forms

### DIFF
--- a/MMO_Trader_Market/build/web/assets/css/main.css
+++ b/MMO_Trader_Market/build/web/assets/css/main.css
@@ -51,37 +51,60 @@ code {
 }
 
 .auth-page {
-    max-width: 480px;
     width: 100%;
-    margin-inline: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem;
 }
 
-.layout--center .layout__content.auth-page {
+.layout--center .layout__content.auth-page,
+.layout--auth .layout__content.auth-page {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    min-height: calc(100vh - 14rem);
-    padding-block: clamp(2rem, 8vh, 4rem);
-}
-
-.auth-page .form-card,
-.auth-page .guide-link,
-.auth-page .alert {
-    width: 100%;
-}
-
-.auth-page .form-card {
-    max-width: 420px;
-    width: 100%;
-    margin-inline: auto;
+    min-height: 100%;
+    padding: clamp(2rem, 8vh, 4rem) 1.5rem;
+    gap: 2rem;
 }
 
 .auth-page .guide-link .button {
+    width: 100%;
+}
+
+.auth-page__inner {
+    width: min(100%, 400px);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.auth-page__header {
+    display: grid;
+    gap: 0.4rem;
+    text-align: center;
+}
+
+.auth-page__header h1 {
+    margin: 0;
+    font-size: clamp(1.6rem, 1.3rem + 1vw, 2.1rem);
+}
+
+.auth-page__header p {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.auth-page__alert {
+    width: 100%;
+    margin: 0;
+}
+
+.auth-page .form-card {
+    max-width: 400px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.25rem 2rem;
+}
+
+.auth-page__form {
     width: 100%;
 }
 
@@ -110,40 +133,160 @@ code {
 }
 
 .layout__header--auth .layout__brand {
-    margin-inline: auto;
+    margin-inline: 0;
 }
 
-.layout__brand {
+.site-header__inner {
+    width: min(100%, 1200px);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1.5rem;
+}
+
+.layout__brand,
+.site-header__brand {
     display: flex;
     align-items: center;
-    gap: 1.25rem;
+    gap: 1rem;
 }
 
 .layout__logo {
-    font-weight: 800;
-    font-size: clamp(1.3rem, 2vw + 0.5rem, 1.7rem);
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
-    color: var(--primary-color);
-    text-decoration: none;
     display: inline-flex;
     align-items: center;
     gap: 0.75rem;
-    padding: 0.35rem 0.85rem;
+    font-weight: 700;
+    font-size: clamp(1.25rem, 1.05rem + 0.6vw, 1.5rem);
+    color: var(--primary-color);
+    text-decoration: none;
+    text-transform: none;
+    letter-spacing: normal;
+    line-height: 1.2;
+    padding: 0.25rem 0;
     border-radius: var(--radius-sm);
-    white-space: nowrap;
+    background: transparent;
+    border: none;
+    box-shadow: none;
     transition: var(--transition);
-    background: rgba(0, 91, 150, 0.06);
-    border: 1px solid rgba(0, 91, 150, 0.12);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
 .layout__logo:hover,
 .layout__logo:focus {
     color: var(--primary-color-dark);
     text-decoration: none;
-    background: rgba(0, 91, 150, 0.1);
-    transform: translateY(-1px);
+}
+
+.site-header__logo-image {
+    width: 32px;
+    height: 32px;
+    object-fit: contain;
+}
+
+.site-header__logo-text {
+    white-space: nowrap;
+}
+
+.layout__heading,
+.site-header__heading {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.layout__heading h1 {
+    margin: 0;
+}
+
+.site-header__nav {
+    justify-self: center;
+}
+
+.site-header__actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    justify-self: end;
+}
+
+.site-header__login,
+.site-header__logout {
+    white-space: nowrap;
+}
+
+.site-header__user {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.35rem 0.5rem 0.35rem 0.35rem;
+    border-radius: 999px;
+    background: rgba(0, 91, 150, 0.05);
+}
+
+.site-header__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(0, 91, 150, 0.16);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.site-header__user-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.site-header__user-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.layout__header--auth .site-header__inner {
+    grid-template-columns: auto 1fr auto;
+    gap: 1.25rem;
+}
+
+.layout__header--auth .site-header__brand {
+    justify-self: start;
+}
+
+.layout__header--auth .site-header__actions {
+    justify-self: end;
+}
+
+.layout__brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.layout__logo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    font-weight: 700;
+    font-size: clamp(1.25rem, 1.05rem + 0.6vw, 1.5rem);
+    color: var(--primary-color);
+    text-decoration: none;
+    text-transform: none;
+    letter-spacing: normal;
+    line-height: 1.2;
+    padding: 0.25rem 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    transition: var(--transition);
+}
+
+.layout__logo:hover,
+.layout__logo:focus {
+    color: var(--primary-color-dark);
+    text-decoration: none;
 }
 
 .layout__heading h1 {

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -24,7 +24,11 @@
 
 <c:set var="currentUri" value="${pageContext.request.requestURI}" />
 <c:set var="isAuthPage"
-        value="${fn:contains(currentUri, '/login') or fn:contains(currentUri, '/register') or fn:contains(currentUri, '/forgot')}" />
+        value="${fn:contains(currentUri, '/auth')
+                or fn:contains(currentUri, '/login')
+                or fn:contains(currentUri, '/register')
+                or fn:contains(currentUri, '/forgot')
+                or fn:contains(currentUri, '/reset-password')}" />
 <c:set var="isLoggedIn" value="${not empty sessionScope.authUser}" />
 
 <!-- Mặc định headerModifier là chuỗi rỗng nếu chưa set -->

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -249,13 +249,16 @@ code {
 }
 
 .layout__header--auth .site-header__inner {
-    grid-template-columns: auto;
-    justify-items: center;
-    gap: 1rem;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.25rem;
+}
+
+.layout__header--auth .site-header__brand {
+    justify-self: start;
 }
 
 .layout__header--auth .site-header__actions {
-    justify-self: center;
+    justify-self: end;
 }
 
 .layout__header--split {


### PR DESCRIPTION
## Summary
- center the authentication page layout and card using shared spacing utilities
- restore three-column header grid on auth pages so action buttons stay aligned to the right
- add missing site header styles to the built CSS bundle to avoid overrides

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f5be8d57288320aa58ff6b205d5fa0