### PR TITLE
Implement asynchronous buyer order processing

### DIFF
--- a/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
@@ -1,0 +1,85 @@
+package dao.order;
+
+import dao.BaseDAO;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * DAO for product_credentials table.
+ */
+public class CredentialDAO extends BaseDAO {
+
+    private static final Logger LOGGER = Logger.getLogger(CredentialDAO.class.getName());
+
+    public List<Integer> pickFreeCredentialIds(int productId, int qty) {
+        try (Connection connection = getConnection()) {
+            return pickFreeCredentialIds(connection, productId, qty);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể khóa credentials", ex);
+            return List.of();
+        }
+    }
+
+    public List<Integer> pickFreeCredentialIds(Connection connection, int productId, int qty) throws SQLException {
+        final String sql = "SELECT id FROM product_credentials WHERE product_id = ? AND is_sold = 0 "
+                + "ORDER BY id ASC LIMIT ? FOR UPDATE";
+        List<Integer> ids = new ArrayList<>();
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, productId);
+            statement.setInt(2, qty);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    ids.add(rs.getInt("id"));
+                }
+            }
+        }
+        return ids;
+    }
+
+    public void markCredentialsSold(int orderId, List<Integer> ids) {
+        try (Connection connection = getConnection()) {
+            markCredentialsSold(connection, orderId, ids);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể cập nhật credentials", ex);
+        }
+    }
+
+    public void markCredentialsSold(Connection connection, int orderId, List<Integer> ids) throws SQLException {
+        if (ids.isEmpty()) {
+            return;
+        }
+        final String sql = "UPDATE product_credentials SET is_sold = 1, order_id = ? WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (Integer id : ids) {
+                statement.setInt(1, orderId);
+                statement.setInt(2, id);
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+    }
+
+    public List<String> findPlainCredentialsByOrder(int orderId) {
+        final String sql = "SELECT encrypted_value FROM product_credentials WHERE order_id = ? ORDER BY id ASC";
+        List<String> results = new ArrayList<>();
+        try (Connection connection = getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, orderId);
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    results.add(rs.getString("encrypted_value"));
+                }
+            }
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể tải credentials của đơn hàng", ex);
+        }
+        return results;
+    }
+}

--- a/MMO_Trader_Market/src/java/model/view/OrderDetailView.java
+++ b/MMO_Trader_Market/src/java/model/view/OrderDetailView.java
@@ -1,0 +1,12 @@
+package model.view;
+
+import model.Orders;
+import model.Products;
+
+import java.util.List;
+
+/**
+ * Aggregated detail of an order with its product and credential list.
+ */
+public record OrderDetailView(Orders order, Products product, List<String> credentials) {
+}

--- a/MMO_Trader_Market/src/java/model/view/OrderRow.java
+++ b/MMO_Trader_Market/src/java/model/view/OrderRow.java
@@ -1,0 +1,10 @@
+package model.view;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * Lightweight view model for order listing rows.
+ */
+public record OrderRow(int id, String productName, BigDecimal totalAmount, String status, Date createdAt) {
+}

--- a/MMO_Trader_Market/src/java/queue/OrderMessage.java
+++ b/MMO_Trader_Market/src/java/queue/OrderMessage.java
@@ -1,0 +1,7 @@
+package queue;
+
+/**
+ * Immutable message describing an order to be processed asynchronously.
+ */
+public record OrderMessage(int orderId, String idempotencyKey, int productId, int qty) {
+}

--- a/MMO_Trader_Market/src/java/queue/OrderQueueProducer.java
+++ b/MMO_Trader_Market/src/java/queue/OrderQueueProducer.java
@@ -1,0 +1,5 @@
+package queue;
+
+public interface OrderQueueProducer {
+    void publish(int orderId, String idemKey, int productId, int qty);
+}

--- a/MMO_Trader_Market/src/java/queue/OrderWorker.java
+++ b/MMO_Trader_Market/src/java/queue/OrderWorker.java
@@ -1,0 +1,5 @@
+package queue;
+
+public interface OrderWorker {
+    void handle(OrderMessage msg);
+}

--- a/MMO_Trader_Market/src/java/queue/memory/AsyncOrderWorker.java
+++ b/MMO_Trader_Market/src/java/queue/memory/AsyncOrderWorker.java
@@ -1,0 +1,119 @@
+package queue.memory;
+
+import dao.order.CredentialDAO;
+import dao.order.OrderDAO;
+import dao.product.ProductDAO;
+import model.OrderStatus;
+import model.Orders;
+import queue.OrderMessage;
+import queue.OrderWorker;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AsyncOrderWorker implements OrderWorker {
+
+    private static final Logger LOGGER = Logger.getLogger(AsyncOrderWorker.class.getName());
+    private static final int[] RETRY_DELAYS = {5, 15, 30};
+
+    private final OrderDAO orderDAO;
+    private final ProductDAO productDAO;
+    private final CredentialDAO credentialDAO;
+
+    public AsyncOrderWorker(OrderDAO orderDAO, ProductDAO productDAO, CredentialDAO credentialDAO) {
+        this.orderDAO = orderDAO;
+        this.productDAO = productDAO;
+        this.credentialDAO = credentialDAO;
+    }
+
+    @Override
+    public void handle(OrderMessage msg) {
+        for (int attempt = 0; attempt < RETRY_DELAYS.length; attempt++) {
+            try {
+                processMessage(msg);
+                return;
+            } catch (SQLException ex) {
+                LOGGER.log(Level.WARNING, "Lỗi xử lý đơn hàng {0} ở lần thử {1}", new Object[]{msg.orderId(), attempt + 1});
+                if (attempt >= RETRY_DELAYS.length - 1) {
+                    markFailed(msg.orderId());
+                    return;
+                }
+                sleepSeconds(RETRY_DELAYS[attempt]);
+            } catch (RuntimeException ex) {
+                LOGGER.log(Level.SEVERE, "Lỗi không mong muốn khi xử lý đơn hàng " + msg.orderId(), ex);
+                markFailed(msg.orderId());
+                return;
+            }
+        }
+    }
+
+    private void processMessage(OrderMessage msg) throws SQLException {
+        Optional<Orders> optionalOrder = orderDAO.findById(msg.orderId());
+        if (optionalOrder.isEmpty()) {
+            LOGGER.log(Level.WARNING, "Bỏ qua đơn hàng {0} vì không tồn tại", msg.orderId());
+            return;
+        }
+        Orders order = optionalOrder.get();
+        if (isTerminal(order.getStatus())) {
+            return;
+        }
+        try (Connection connection = orderDAO.openConnection()) {
+            connection.setAutoCommit(false);
+            try {
+                orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.PROCESSING);
+                int inventory = productDAO.lockInventoryForUpdate(connection, msg.productId());
+                if (inventory < msg.qty()) {
+                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
+                    connection.commit();
+                    return;
+                }
+                List<Integer> credentialIds = credentialDAO.pickFreeCredentialIds(connection, msg.productId(), msg.qty());
+                if (credentialIds.size() < msg.qty()) {
+                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
+                    connection.commit();
+                    return;
+                }
+                boolean decremented = productDAO.decrementInventory(connection, msg.productId(), msg.qty());
+                if (!decremented) {
+                    throw new SQLException("Không thể trừ tồn kho");
+                }
+                credentialDAO.markCredentialsSold(connection, msg.orderId(), credentialIds);
+                orderDAO.insertInventoryLog(connection, msg.productId(), msg.orderId(), -msg.qty(), "Sale");
+                orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.COMPLETED);
+                connection.commit();
+            } catch (SQLException ex) {
+                connection.rollback();
+                throw ex;
+            } finally {
+                connection.setAutoCommit(true);
+            }
+        }
+    }
+
+    private void markFailed(int orderId) {
+        boolean updated = orderDAO.setStatus(orderId, OrderStatus.FAILED.toDatabaseValue());
+        if (!updated) {
+            LOGGER.log(Level.SEVERE, "Không thể đánh dấu đơn hàng {0} thất bại", orderId);
+        }
+    }
+
+    private void sleepSeconds(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private boolean isTerminal(String status) {
+        if (status == null) {
+            return false;
+        }
+        OrderStatus current = OrderStatus.fromDatabaseValue(status);
+        return current == OrderStatus.COMPLETED || current == OrderStatus.FAILED;
+    }
+}

--- a/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
+++ b/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
@@ -1,0 +1,78 @@
+package queue.memory;
+
+import dao.order.CredentialDAO;
+import dao.order.OrderDAO;
+import dao.product.ProductDAO;
+import queue.OrderMessage;
+import queue.OrderQueueProducer;
+import queue.OrderWorker;
+
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class InMemoryOrderQueue implements OrderQueueProducer {
+
+    private static final Logger LOGGER = Logger.getLogger(InMemoryOrderQueue.class.getName());
+    private static final InMemoryOrderQueue INSTANCE = new InMemoryOrderQueue();
+
+    private final BlockingQueue<OrderMessage> queue = new LinkedBlockingQueue<>();
+    private final ExecutorService dispatcher = Executors.newSingleThreadExecutor(r -> {
+        Thread thread = new Thread(r, "order-queue-dispatcher");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private volatile OrderWorker worker;
+
+    private InMemoryOrderQueue() {
+        dispatcher.submit(this::dispatchLoop);
+    }
+
+    public static InMemoryOrderQueue getInstance() {
+        return INSTANCE;
+    }
+
+    public static synchronized void ensureWorkerInitialized(OrderDAO orderDAO, ProductDAO productDAO, CredentialDAO credentialDAO) {
+        if (INSTANCE.worker == null) {
+            Objects.requireNonNull(orderDAO, "orderDAO");
+            Objects.requireNonNull(productDAO, "productDAO");
+            Objects.requireNonNull(credentialDAO, "credentialDAO");
+            INSTANCE.worker = new AsyncOrderWorker(orderDAO, productDAO, credentialDAO);
+        }
+    }
+
+    @Override
+    public void publish(int orderId, String idemKey, int productId, int qty) {
+        queue.offer(new OrderMessage(orderId, idemKey, productId, qty));
+    }
+
+    private void dispatchLoop() {
+        try {
+            while (!Thread.currentThread().isInterrupted()) {
+                OrderMessage message = queue.poll(5, TimeUnit.SECONDS);
+                if (message == null) {
+                    continue;
+                }
+                OrderWorker current = worker;
+                if (current == null) {
+                    queue.offer(message);
+                    Thread.sleep(1000);
+                    continue;
+                }
+                try {
+                    current.handle(message);
+                } catch (RuntimeException ex) {
+                    LOGGER.log(Level.SEVERE, "Lỗi xử lý thông điệp đơn hàng", ex);
+                }
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -1,0 +1,63 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Chi tiết đơn hàng #<c:out value="${order.id}" /></h2>
+        </div>
+        <div class="panel__body">
+            <div class="grid grid--two-columns">
+                <div class="card">
+                    <h3 class="card__title">Thông tin đơn</h3>
+                    <ul class="definition-list">
+                        <li><span>Mã đơn:</span> #<c:out value="${order.id}" /></li>
+                        <li><span>Sản phẩm:</span> <c:out value="${product.name}" /></li>
+                        <li><span>Tổng tiền:</span>
+                            <fmt:formatNumber value="${order.totalAmount}" type="currency" currencySymbol="" /> đ
+                        </li>
+                        <li><span>Trạng thái:</span> <c:out value="${statusLabel}" /></li>
+                        <li><span>Ngày tạo:</span>
+                            <fmt:formatDate value="${order.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                        </li>
+                    </ul>
+                </div>
+                <div class="card">
+                    <h3 class="card__title">Sản phẩm</h3>
+                    <p><strong>Tên:</strong> <c:out value="${product.name}" /></p>
+                    <p><strong>Mô tả:</strong> <c:out value="${product.description}" /></p>
+                    <p><strong>Tồn kho hiện tại:</strong> <c:out value="${product.inventoryCount}" /></p>
+                </div>
+            </div>
+            <div class="panel panel--nested">
+                <div class="panel__header">
+                    <h3 class="panel__title">Thông tin bàn giao</h3>
+                </div>
+                <div class="panel__body">
+                    <c:choose>
+                        <c:when test="${order.status eq 'Completed'}">
+                            <c:if test="${not empty credentials}">
+                                <ul class="list">
+                                    <c:forEach var="cred" items="${credentials}">
+                                        <li><c:out value="${cred}" /></li>
+                                    </c:forEach>
+                                </ul>
+                            </c:if>
+                            <c:if test="${empty credentials}">
+                                <p class="empty">Đơn hàng đã hoàn thành nhưng chưa có dữ liệu bàn giao.</p>
+                            </c:if>
+                        </c:when>
+                        <c:otherwise>
+                            <p class="empty">Đơn đang được xử lý, vui lòng chờ...</p>
+                        </c:otherwise>
+                    </c:choose>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/order/my.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/my.jsp
@@ -1,0 +1,99 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Lịch sử mua hàng</h2>
+            <form class="panel__filters" method="get" action="${pageContext.request.contextPath}/orders/my">
+                <label class="form-field">
+                    <span class="form-field__label">Trạng thái</span>
+                    <select class="form-field__input" name="status">
+                        <option value="">Tất cả</option>
+                        <c:forEach var="entry" items="${statusOptions}">
+                            <c:set var="statusKey" value="${entry.key}" />
+                            <option value="${statusKey}" <c:if test="${statusKey eq status}">selected</c:if>>
+                                <c:out value="${entry.value}" />
+                            </option>
+                        </c:forEach>
+                    </select>
+                </label>
+                <label class="form-field">
+                    <span class="form-field__label">Mỗi trang</span>
+                    <input class="form-field__input" type="number" min="1" name="size" value="${size}" />
+                </label>
+                <button class="button button--primary" type="submit">Lọc</button>
+            </form>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not empty items}">
+                    <table class="table table--interactive">
+                        <thead>
+                        <tr>
+                            <th>Mã đơn</th>
+                            <th>Sản phẩm</th>
+                            <th>Tổng tiền</th>
+                            <th>Trạng thái</th>
+                            <th>Ngày tạo</th>
+                            <th class="table__actions">Chi tiết</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <c:forEach var="item" items="${items}">
+                            <tr>
+                                <td>#<c:out value="${item.id}" /></td>
+                                <td><c:out value="${item.productName}" /></td>
+                                <td>
+                                    <fmt:formatNumber value="${item.totalAmount}" type="currency" currencySymbol="" /> đ
+                                </td>
+                                <td><c:out value="${statusLabels[item.status]}" /></td>
+                                <td>
+                                    <fmt:formatDate value="${item.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                                </td>
+                                <td class="table__actions">
+                                    <c:url var="detailUrl" value="/orders/detail">
+                                        <c:param name="id" value="${item.id}" />
+                                    </c:url>
+                                    <a class="button button--ghost" href="${detailUrl}">Xem</a>
+                                </td>
+                            </tr>
+                        </c:forEach>
+                        </tbody>
+                    </table>
+                </c:when>
+                <c:otherwise>
+                    <p class="empty">Bạn chưa có đơn hàng nào.</p>
+                </c:otherwise>
+            </c:choose>
+            <c:if test="${totalPages > 1}">
+                <nav class="pagination" aria-label="Phân trang đơn hàng">
+                    <c:forEach var="pageNumber" begin="1" end="${totalPages}">
+                        <c:url var="pageUrl" value="/orders/my">
+                            <c:param name="page" value="${pageNumber}" />
+                            <c:if test="${not empty status}">
+                                <c:param name="status" value="${status}" />
+                            </c:if>
+                            <c:param name="size" value="${size}" />
+                        </c:url>
+                        <c:choose>
+                            <c:when test="${pageNumber == page}">
+                                <span class="pagination__item pagination__item--active" aria-current="page">
+                                    ${pageNumber}
+                                </span>
+                            </c:when>
+                            <c:otherwise>
+                                <a class="pagination__item" href="${pageUrl}">${pageNumber}</a>
+                            </c:otherwise>
+                        </c:choose>
+                    </c:forEach>
+                </nav>
+            </c:if>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/docs/order-processing.md
+++ b/docs/order-processing.md
@@ -1,0 +1,13 @@
+# Order Processing Flow
+
+Sơ đồ trạng thái đơn hàng:
+
+```
+Pending → Processing → (Completed | Failed) → (Refunded | Disputed)
+```
+
+Các trạng thái chính được áp dụng cho tất cả đơn hàng của người mua. Luồng xử lý bất đồng bộ đảm bảo đơn mới tạo sẽ chuyển từ `Pending` sang `Processing`, sau đó:
+
+- Nếu bàn giao thành công: cập nhật `Completed` và gắn thông tin credential.
+- Nếu gặp lỗi (hết hàng, lỗi hệ thống sau 3 lần retry): chuyển sang `Failed`.
+- Sau khi hoàn thành, có thể tiếp tục tiến tới `Refunded` hoặc `Disputed` tùy theo quy trình chăm sóc khách hàng.

--- a/docs/sql/order_indexes.sql
+++ b/docs/sql/order_indexes.sql
@@ -1,0 +1,4 @@
+-- Recommended indexes for buyer order queries
+CREATE INDEX idx_orders_buyer_id_status ON orders(buyer_id, status);
+CREATE INDEX idx_products_status ON products(status);
+CREATE INDEX idx_credentials_product_sold ON product_credentials(product_id, is_sold);


### PR DESCRIPTION
## Summary
- replace buyer order controller flow with buy-now, history, and detail endpoints wired to new order service methods
- add DAO methods and in-memory queue worker to process orders asynchronously with idempotency, inventory updates, and credential assignment
- build new JSP pages for order history and detail plus supporting documentation and index scripts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f5bf99d71c8320a5e4a621eda50784