### PR TITLE
Add homepage product discovery filter and refresh listings

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -40,6 +40,10 @@ public class HomepageController extends BaseController {
 
         populateHomepageData(request);
 
+        request.setAttribute("query", "");
+        request.setAttribute("selectedType", "");
+        request.setAttribute("selectedSubtype", "");
+
         forward(request, response, "product/home");
     }
 
@@ -66,6 +70,7 @@ public class HomepageController extends BaseController {
         request.setAttribute("systemNotes", systemNotes);
 
         request.setAttribute("faqs", buildFaqEntries());
+        request.setAttribute("typeOptions", homepageService.loadFilterTypeOptions());
     }
 
     private Map<String, String> buildShopIconMap() {

--- a/MMO_Trader_Market/src/java/controller/product/ProductListController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductListController.java
@@ -42,7 +42,7 @@ public class ProductListController extends BaseController {
 
         request.setAttribute("pageTitle", "Sản phẩm");
         request.setAttribute("headerTitle", "Kho sản phẩm");
-        request.setAttribute("headerSubtitle", "Tìm kiếm và mua ngay các tài nguyên số");
+        request.setAttribute("headerSubtitle", "Tìm kiếm, lọc theo shop và mua ngay những sản phẩm bạn cần.");
         request.setAttribute("items", result.getItems());
         request.setAttribute("totalItems", result.getTotalItems());
         request.setAttribute("page", result.getPage());

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -13,6 +13,7 @@ import model.view.CustomerProfileView;
 import model.view.MarketplaceSummary;
 import model.view.product.ProductCategorySummary;
 import model.view.product.ProductSummaryView;
+import model.view.product.ProductTypeOption;
 import model.OrderStatus;
 
 import java.time.LocalDate;
@@ -64,6 +65,10 @@ public class HomepageService {
 
     public List<SystemConfigs> loadSystemNotes() {
         return systemConfigDAO.findAll();
+    }
+
+    public List<ProductTypeOption> loadFilterTypeOptions() {
+        return productService.getTypeOptions();
     }
 
     private CustomerProfileView buildProfile(Users buyer) {

--- a/MMO_Trader_Market/src/java/service/ProductService.java
+++ b/MMO_Trader_Market/src/java/service/ProductService.java
@@ -41,10 +41,10 @@ public class ProductService {
 
     static {
         Map<String, String> typeLabels = new LinkedHashMap<>();
-        typeLabels.put("EMAIL", "Email");
-        typeLabels.put("SOCIAL", "Mạng xã hội");
-        typeLabels.put("SOFTWARE", "Phần mềm");
-        typeLabels.put("GAME", "Game");
+        typeLabels.put("EMAIL", "Tài khoản Mail");
+        typeLabels.put("SOCIAL", "Tài khoản MXH");
+        typeLabels.put("SOFTWARE", "Tài khoản phần mềm");
+        typeLabels.put("GAME", "Tài khoản Game");
         typeLabels.put("OTHER", "Khác");
         TYPE_LABELS = Collections.unmodifiableMap(typeLabels);
 
@@ -59,22 +59,16 @@ public class ProductService {
 
         List<ProductTypeOption> options = new ArrayList<>();
         options.add(new ProductTypeOption("EMAIL", TYPE_LABELS.get("EMAIL"),
-                List.of(new ProductSubtypeOption("GMAIL", SUBTYPE_LABELS.get("GMAIL")) )));
+                List.of(new ProductSubtypeOption("GMAIL", SUBTYPE_LABELS.get("GMAIL")))));
         options.add(new ProductTypeOption("SOCIAL", TYPE_LABELS.get("SOCIAL"),
                 List.of(
                         new ProductSubtypeOption("FACEBOOK", SUBTYPE_LABELS.get("FACEBOOK")),
                         new ProductSubtypeOption("TIKTOK", SUBTYPE_LABELS.get("TIKTOK"))
                 )));
         options.add(new ProductTypeOption("SOFTWARE", TYPE_LABELS.get("SOFTWARE"),
-                List.of(
-                        new ProductSubtypeOption("CANVA", SUBTYPE_LABELS.get("CANVA")),
-                        new ProductSubtypeOption("OTHER", SUBTYPE_LABELS.get("OTHER"))
-                )));
+                List.of(new ProductSubtypeOption("CANVA", SUBTYPE_LABELS.get("CANVA")))));
         options.add(new ProductTypeOption("GAME", TYPE_LABELS.get("GAME"),
-                List.of(
-                        new ProductSubtypeOption("VALORANT", SUBTYPE_LABELS.get("VALORANT")),
-                        new ProductSubtypeOption("OTHER", SUBTYPE_LABELS.get("OTHER"))
-                )));
+                List.of(new ProductSubtypeOption("VALORANT", SUBTYPE_LABELS.get("VALORANT")))));
         options.add(new ProductTypeOption("OTHER", TYPE_LABELS.get("OTHER"),
                 List.of(new ProductSubtypeOption("OTHER", SUBTYPE_LABELS.get("OTHER")))));
         TYPE_OPTIONS = List.copyOf(options);

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -62,8 +62,6 @@ public final class NavigationBuilder {
     }
 
     private static void addBaseItems(List<Map<String, String>> items, String contextPath, String currentPath) {
-        items.add(createNavItem(contextPath + "/products", "Danh sách sản phẩm",
-                isActive(currentPath, "/products")));
         items.add(createNavItem(contextPath + "/home#product-types", "Loại sản phẩm", false));
         items.add(createNavItem(contextPath + "/home#faq", "FAQ", false));
     }

--- a/MMO_Trader_Market/web/WEB-INF/views/product/fragments/filter-form.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/fragments/filter-form.jspf
@@ -1,0 +1,129 @@
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
+<c:set var="filterFormId" value="${empty filterFormId ? 'product-filter-form' : filterFormId}" />
+<c:url value="/products" var="defaultFilterAction" />
+<c:set var="filterActionValue" value="${empty filterFormAction ? defaultFilterAction : filterFormAction}" />
+
+<c:set var="filterQueryCandidate" value="${not empty filterQuery ? filterQuery : query}" />
+<c:set var="filterQueryValue" value="${empty filterQueryCandidate ? '' : filterQueryCandidate}" />
+<c:set var="filterTypeCandidate" value="${not empty filterType ? filterType : selectedType}" />
+<c:set var="filterTypeValue" value="${empty filterTypeCandidate ? '' : filterTypeCandidate}" />
+<c:set var="filterSubtypeCandidate" value="${not empty filterSubtype ? filterSubtype : selectedSubtype}" />
+<c:set var="filterSubtypeValue" value="${empty filterSubtypeCandidate ? '' : filterSubtypeCandidate}" />
+<c:set var="filterPageSizeCandidate" value="${not empty filterPageSize ? filterPageSize : size}" />
+<c:set var="filterPageSizeValue" value="${empty filterPageSizeCandidate ? 12 : filterPageSizeCandidate}" />
+<c:set var="filterIncludeSizeValue" value="${filterIncludeSize == true or filterIncludeSize == 'true'}" />
+
+<c:set var="queryInputId" value="${filterFormId}-q" />
+<c:set var="typeInputId" value="${filterFormId}-type" />
+<c:set var="subtypeInputId" value="${filterFormId}-subtype" />
+
+<form id="${filterFormId}" class="product-filters" method="get" action="${filterActionValue}">
+  <div class="product-filters__group">
+    <label class="product-filters__label" for="${queryInputId}">Tên sản phẩm</label>
+    <input class="product-filters__input" type="search" id="${queryInputId}" name="q"
+           placeholder="Nhập tên sản phẩm..." value="${fn:escapeXml(filterQueryValue)}" />
+  </div>
+  <div class="product-filters__group">
+    <label class="product-filters__label" for="${typeInputId}">Loại sản phẩm</label>
+    <select class="product-filters__select" id="${typeInputId}" name="type">
+      <option value="">Tất cả</option>
+      <c:forEach var="code" items="${fn:split('EMAIL,SOCIAL,SOFTWARE,GAME', ',')}">
+        <c:set var="typeLabel" value="" />
+        <c:forEach var="option" items="${typeOptions}">
+          <c:if test="${option.code == code}">
+            <c:set var="typeLabel" value="${option.label}" />
+          </c:if>
+        </c:forEach>
+        <c:if test="${not empty typeLabel}">
+          <option value="${code}" <c:if test="${code == filterTypeValue}">selected</c:if>>
+            <c:out value="${typeLabel}" />
+          </option>
+        </c:if>
+      </c:forEach>
+      <c:if test="${filterTypeValue == 'OTHER'}">
+        <option value="OTHER" selected>Khác</option>
+      </c:if>
+    </select>
+  </div>
+  <div class="product-filters__group">
+    <label class="product-filters__label" for="${subtypeInputId}">Phân loại chi tiết</label>
+    <select class="product-filters__select" id="${subtypeInputId}" name="subtype"
+            data-initial="${fn:escapeXml(filterSubtypeValue)}">
+      <option value="">Tất cả</option>
+    </select>
+  </div>
+  <input type="hidden" name="page" value="1" />
+  <c:if test="${filterIncludeSizeValue}">
+    <input type="hidden" name="size" value="${filterPageSizeValue}" />
+  </c:if>
+  <button class="button button--primary" type="submit">Áp dụng</button>
+</form>
+
+<script>
+  (function() {
+    var form = document.getElementById('${filterFormId}');
+    if (!form) {
+      return;
+    }
+    var typeSelect = form.querySelector('select[name="type"]');
+    var subtypeSelect = form.querySelector('select[name="subtype"]');
+    if (!typeSelect || !subtypeSelect) {
+      return;
+    }
+
+    var initialSubtype = subtypeSelect.dataset.initial || '';
+    var SUBTYPE_OPTIONS = {
+      DEFAULT: [{ code: '', label: 'Tất cả' }],
+      EMAIL: [
+        { code: '', label: 'Tất cả' },
+        { code: 'GMAIL', label: 'Gmail' }
+      ],
+      SOCIAL: [
+        { code: '', label: 'Tất cả' },
+        { code: 'FACEBOOK', label: 'Facebook' },
+        { code: 'TIKTOK', label: 'TikTok' }
+      ],
+      SOFTWARE: [
+        { code: '', label: 'Tất cả' },
+        { code: 'CANVA', label: 'Canva' }
+      ],
+      GAME: [
+        { code: '', label: 'Tất cả' },
+        { code: 'VALORANT', label: 'Valorant' }
+      ]
+    };
+
+    function resolveKey(value) {
+      if (!value) {
+        return 'DEFAULT';
+      }
+      var upper = value.toUpperCase();
+      return SUBTYPE_OPTIONS[upper] ? upper : 'DEFAULT';
+    }
+
+    function renderSubtypeOptions(typeValue, selectedValue) {
+      var key = resolveKey(typeValue);
+      var options = SUBTYPE_OPTIONS[key] || SUBTYPE_OPTIONS.DEFAULT;
+      while (subtypeSelect.firstChild) {
+        subtypeSelect.removeChild(subtypeSelect.firstChild);
+      }
+      options.forEach(function(option) {
+        var opt = document.createElement('option');
+        opt.value = option.code;
+        opt.textContent = option.label;
+        if (option.code === selectedValue) {
+          opt.selected = true;
+        }
+        subtypeSelect.appendChild(opt);
+      });
+    }
+
+    renderSubtypeOptions(typeSelect.value, initialSubtype);
+
+    typeSelect.addEventListener('change', function() {
+      renderSubtypeOptions(typeSelect.value, '');
+    });
+  })();
+</script>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -65,6 +65,18 @@
 
     <section class="panel landing__section">
         <div class="panel__header">
+            <h3 class="panel__title">Khám phá sản phẩm</h3>
+            <p class="panel__subtitle">Tìm kiếm, lọc theo shop và mua ngay những sản phẩm bạn cần.</p>
+        </div>
+        <c:set var="filterIncludeSize" value="${false}" />
+        <c:set var="filterQuery" value="${query}" />
+        <c:set var="filterType" value="${selectedType}" />
+        <c:set var="filterSubtype" value="${selectedSubtype}" />
+        <%@ include file="/WEB-INF/views/product/fragments/filter-form.jspf" %>
+    </section>
+
+    <section class="panel landing__section">
+        <div class="panel__header">
             <h3 class="panel__title">Shop nổi bật</h3>
         </div>
         <c:choose>
@@ -91,7 +103,7 @@
 
     <section class="panel landing__section">
         <div class="panel__header">
-            <h3 class="panel__title">Sản phẩm gợi ý</h3>
+            <h3 class="panel__title">Sản phẩm nổi bật</h3>
             <span class="panel__tag">Dữ liệu trực tiếp</span>
         </div>
 
@@ -125,9 +137,11 @@
                                 <p class="product-card__price">
                                     <c:choose>
                                         <c:when test="${product.minPrice eq product.maxPrice}">
+                                            Giá
                                             <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
                                         </c:when>
                                         <c:otherwise>
+                                            Giá từ
                                             <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
                                             –
                                             <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -12,44 +12,13 @@
             <h2>Khám phá sản phẩm</h2>
             <p>Tìm kiếm, lọc theo shop và mua ngay những sản phẩm bạn cần.</p>
         </div>
-        <form class="product-filters" method="get" action="${cPath}/products">
-            <div class="product-filters__group">
-                <label class="sr-only" for="q">Từ khóa</label>
-                <input class="product-filters__input" type="search" id="q" name="q"
-                       placeholder="Nhập tên sản phẩm..." value="${fn:escapeXml(query)}" />
-            </div>
-            <div class="product-filters__group">
-                <label class="sr-only" for="type">Danh mục</label>
-                <select class="product-filters__select" id="type" name="type">
-                    <option value="">Tất cả danh mục</option>
-                    <c:forEach var="type" items="${typeOptions}">
-                        <c:set var="code" value="${type.code}" />
-                        <option value="${code}" <c:if test="${code == selectedType}">selected</c:if>>
-                            <c:out value="${type.label}" />
-                        </option>
-                    </c:forEach>
-                </select>
-            </div>
-            <div class="product-filters__group">
-                <label class="sr-only" for="subtype">Phân loại</label>
-                <select class="product-filters__select" id="subtype" name="subtype">
-                    <option value="">
-                        <c:choose>
-                            <c:when test="${empty selectedType}">Chọn danh mục trước</c:when>
-                            <c:otherwise>Tất cả phân loại</c:otherwise>
-                        </c:choose>
-                    </option>
-                    <c:forEach var="subtype" items="${subtypeOptions}">
-                        <c:set var="subCode" value="${subtype.code}" />
-                        <option value="${subCode}" <c:if test="${subCode == selectedSubtype}">selected</c:if>>
-                            <c:out value="${subtype.label}" />
-                        </option>
-                    </c:forEach>
-                </select>
-            </div>
-            <input type="hidden" name="size" value="${size}" />
-            <button class="button button--primary" type="submit">Áp dụng</button>
-        </form>
+        <c:set var="filterFormAction" value="${cPath}/products" />
+        <c:set var="filterIncludeSize" value="${true}" />
+        <c:set var="filterPageSize" value="${size}" />
+        <c:set var="filterQuery" value="${query}" />
+        <c:set var="filterType" value="${selectedType}" />
+        <c:set var="filterSubtype" value="${selectedSubtype}" />
+        <%@ include file="/WEB-INF/views/product/fragments/filter-form.jspf" %>
         <div class="product-list__meta">
             <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
             <span>Trang ${page} / ${totalPages}</span>
@@ -79,9 +48,11 @@
                                 <p class="product-card__price">
                                     <c:choose>
                                         <c:when test="${p.minPrice eq p.maxPrice}">
+                                            Giá
                                             <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
                                         </c:when>
                                         <c:otherwise>
+                                            Giá từ
                                             <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
                                             –
                                             <fmt:formatNumber value="${p.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />

--- a/MMO_Trader_Market/web/WEB-INF/views/wallet/wallet.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/wallet/wallet.jsp
@@ -17,11 +17,6 @@
     List<Map<String, String>> navItems = new ArrayList<>();
     String contextPath = request.getContextPath();
 
-    Map<String, String> productLink = new HashMap<>();
-    productLink.put("href", contextPath + "/products");
-    productLink.put("label", "Danh sách sản phẩm");
-    navItems.add(productLink);
-
     Map<String, String> guideLink = new HashMap<>();
     guideLink.put("href", contextPath + "/styleguide");
     guideLink.put("label", "Thư viện giao diện");


### PR DESCRIPTION
## Summary
- add a shared product discovery form with dynamic subtype options and reuse it on the home and listing pages
- localize product type labels and update listing/home sections to show the required Vietnamese copy and price ranges
- remove the menu link to the product list while exposing filter metadata from the controllers/services

## Testing
- not run (JSP project)


------
https://chatgpt.com/codex/tasks/task_e_68f780ed567c8320a38e48bbe73385ee