### PR TITLE
Simplify featured products implementation

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -12,6 +12,7 @@ import model.view.CustomerProfileView;
 import model.view.MarketplaceSummary;
 import model.view.product.ProductSummaryView;
 import service.HomepageService;
+import service.ProductService;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ public class HomepageController extends BaseController {
     private static final long serialVersionUID = 1L;
 
     private final HomepageService homepageService = new HomepageService();
+    private final ProductService productService = new ProductService();
 
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
@@ -40,6 +42,9 @@ public class HomepageController extends BaseController {
 
         populateHomepageData(request);
 
+        List<ProductSummaryView> featured = productService.getFeatured(6);
+        request.setAttribute("featured", featured);
+
         request.setAttribute("query", "");
         request.setAttribute("selectedType", "");
         request.setAttribute("selectedSubtype", "");
@@ -50,9 +55,6 @@ public class HomepageController extends BaseController {
     private void populateHomepageData(HttpServletRequest request) {
         MarketplaceSummary summary = homepageService.loadMarketplaceSummary();
         request.setAttribute("summary", summary);
-
-        List<ProductSummaryView> featuredProducts = homepageService.loadFeaturedProducts();
-        request.setAttribute("featuredProducts", featuredProducts);
 
         List<Shops> shops = homepageService.loadActiveShops();
         request.setAttribute("shops", shops);

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -12,7 +12,6 @@ import model.view.ConversationMessageView;
 import model.view.CustomerProfileView;
 import model.view.MarketplaceSummary;
 import model.view.product.ProductCategorySummary;
-import model.view.product.ProductSummaryView;
 import model.view.product.ProductTypeOption;
 import model.OrderStatus;
 
@@ -33,10 +32,6 @@ public class HomepageService {
     private final BuyerDAO buyerDAO = new BuyerDAO();
     private final ConversationMessageDAO conversationMessageDAO = new ConversationMessageDAO();
     private final SystemConfigDAO systemConfigDAO = new SystemConfigDAO();
-
-    public List<ProductSummaryView> loadFeaturedProducts() {
-        return productService.getHomepageHighlights();
-    }
 
     public List<Shops> loadActiveShops() {
         return shopDAO.findActive(SHOP_LIMIT);

--- a/MMO_Trader_Market/src/java/service/ProductService.java
+++ b/MMO_Trader_Market/src/java/service/ProductService.java
@@ -84,6 +84,17 @@ public class ProductService {
         return rows.stream().map(this::toSummaryView).toList();
     }
 
+    public List<ProductSummaryView> getFeatured(int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("Giới hạn sản phẩm nổi bật phải lớn hơn 0");
+        }
+        int resolvedLimit = Math.max(limit, 1);
+        return productDAO.findTopAvailable(resolvedLimit).stream()
+                .limit(resolvedLimit)
+                .map(this::toSummaryView)
+                .toList();
+    }
+
     public List<ProductCategorySummary> getHomepageCategories() {
         Map<String, Long> counts = productDAO.countAvailableByType();
         List<ProductCategorySummary> summaries = new ArrayList<>();

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -123,63 +123,65 @@
             <span class="panel__tag">Dữ liệu trực tiếp</span>
         </div>
 
-        <div class="landing__products">
-            <c:choose>
-                <c:when test="${empty featuredProducts}">
-                    <p>Chưa có dữ liệu.</p>
-                </c:when>
-                <c:otherwise>
-                    <c:forEach var="product" items="${featuredProducts}">
-                        <article class="product-card product-card--featured">
-                            <div class="product-card__image">
-                                <c:choose>
-                                    <c:when test="${not empty product.primaryImageUrl}">
-                                        <img src="${product.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
-                            </div>
-                            <div class="product-card__body">
-                                <header class="product-card__header">
-                                    <h4><c:out value="${product.name}" /></h4>
-                                </header>
-                                <p class="product-card__meta">
-                                    <span><c:out value="${product.productTypeLabel}" /> • <c:out value="${product.productSubtypeLabel}" /></span>
-                                    <span>Shop: <strong><c:out value="${product.shopName}" /></strong></span>
-                                </p>
-                                <p class="product-card__description"><c:out value="${product.shortDescription}" /></p>
-                                <p class="product-card__price">
+        <c:choose>
+            <c:when test="${empty featured}">
+                <div class="featured-carousel__empty">Chưa có dữ liệu.</div>
+            </c:when>
+            <c:otherwise>
+                <div class="featured-carousel">
+                    <div class="featured-carousel__list" id="featuredCarousel">
+                        <c:forEach var="product" items="${featured}">
+                            <article class="product-card featured-card">
+                                <div class="featured-card__image">
                                     <c:choose>
-                                        <c:when test="${product.minPrice eq product.maxPrice}">
-                                            Giá
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                        <c:when test="${not empty product.primaryImageUrl}">
+                                            <img src="${product.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
                                         </c:when>
                                         <c:otherwise>
-                                            Giá từ
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                            –
-                                            <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                            <div class="featured-card__placeholder">Không có ảnh</div>
                                         </c:otherwise>
                                     </c:choose>
-                                </p>
-                                <ul class="product-card__meta product-card__meta--stats">
-                                    <li>Tồn kho: <strong><c:out value="${product.inventoryCount}" /></strong></li>
-                                    <li>Đã bán: <strong><c:out value="${product.soldCount}" /></strong></li>
-                                </ul>
-                                <footer class="product-card__footer">
-                                    <c:url var="detailUrl" value="/product/detail">
-                                        <c:param name="id" value="${product.id}" />
-                                    </c:url>
-                                    <a class="button button--primary" href="${detailUrl}">Xem chi tiết</a>
-                                </footer>
-                            </div>
-                        </article>
-                    </c:forEach>
-                </c:otherwise>
-            </c:choose>
-        </div>
+                                </div>
+                                <div class="featured-card__body">
+                                    <h4 class="featured-card__title"><c:out value="${product.name}" /></h4>
+                                    <p class="featured-card__description"><c:out value="${product.shortDescription}" /></p>
+                                    <p class="featured-card__price">
+                                        <c:choose>
+                                            <c:when test="${product.hasValidPrice()}">
+                                                <c:choose>
+                                                    <c:when test="${product.hasPriceRange()}">
+                                                        Giá từ
+                                                        <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                        –
+                                                        <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                    </c:when>
+                                                    <c:otherwise>
+                                                        Giá
+                                                        <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                    </c:otherwise>
+                                                </c:choose>
+                                            </c:when>
+                                            <c:otherwise>
+                                                Giá đang cập nhật
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </p>
+                                    <p class="featured-card__shop">Shop: <strong><c:out value="${product.shopName}" /></strong></p>
+                                    <p class="featured-card__inventory">Còn: <strong><c:out value="${product.inventoryCount}" default="0" /></strong></p>
+                                    <footer class="featured-card__footer">
+                                        <c:url var="detailUrl" value="/product/detail">
+                                            <c:param name="id" value="${product.id}" />
+                                        </c:url>
+                                        <a class="button button--primary" href="${detailUrl}">Xem chi tiết</a>
+                                    </footer>
+                                </div>
+                            </article>
+                        </c:forEach>
+                    </div>
+                    <button type="button" class="featured-carousel__next" id="btnFeaturedNext" aria-label="Cuộn sang phải">&gt;</button>
+                </div>
+            </c:otherwise>
+        </c:choose>
     </section>
 
     <section class="panel landing__section landing__grid">
@@ -297,6 +299,17 @@
         </c:choose>
     </section>
 
+    <script>
+        (function () {
+            const container = document.querySelector('#featuredCarousel');
+            const nextButton = document.querySelector('#btnFeaturedNext');
+            if (container && nextButton) {
+                nextButton.addEventListener('click', function () {
+                    container.scrollBy({left: container.clientWidth, behavior: 'smooth'});
+                });
+            }
+        })();
+    </script>
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -1257,6 +1257,141 @@ justify-content: center;
     padding: 1.5rem 2rem 2rem;
 }
 
+.featured-carousel {
+    position: relative;
+    padding: 1.5rem 2rem 2rem;
+}
+
+.featured-carousel__empty {
+    padding: 1.5rem 2rem 2rem;
+    color: var(--text-light);
+}
+
+.featured-carousel__list {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(280px, 1fr);
+    gap: 1.5rem;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    scroll-behavior: smooth;
+    padding-bottom: 0.75rem;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(15, 23, 42, 0.2) transparent;
+}
+
+.featured-carousel__list::-webkit-scrollbar {
+    height: 8px;
+}
+
+.featured-carousel__list::-webkit-scrollbar-thumb {
+    background: rgba(15, 23, 42, 0.2);
+    border-radius: 999px;
+}
+
+.featured-carousel__list::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.featured-carousel__next {
+    position: absolute;
+    top: 50%;
+    right: 2rem;
+    transform: translateY(-50%);
+    border: none;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: rgba(15, 23, 42, 0.85);
+    color: #fff;
+    font-size: 1.5rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease;
+}
+
+.featured-carousel__next:hover,
+.featured-carousel__next:focus {
+    background: rgba(15, 23, 42, 0.95);
+}
+
+.featured-card {
+    scroll-snap-align: start;
+    width: min(320px, 100%);
+    display: grid;
+    gap: 1rem;
+}
+
+.featured-card__image {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: rgba(15, 23, 42, 0.08);
+}
+
+.featured-card__image img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.featured-card__placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted-color);
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.05);
+}
+
+.featured-card__body {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.featured-card__title {
+    margin: 0;
+    font-size: 1.1rem;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.featured-card__description {
+    margin: 0;
+    color: var(--text-light);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.featured-card__price {
+    margin: 0;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.featured-card__shop,
+.featured-card__inventory {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.featured-card__footer {
+    display: flex;
+    justify-content: flex-start;
+}
+
 .wallet {
     display: grid;
     gap: 2rem;


### PR DESCRIPTION
## Summary
- reuse the existing product summary view for the homepage featured carousel and remove redundant projections
- fetch featured products through ProductService#getFeatured using the existing top-available DAO query
- update the homepage JSP to use ProductSummaryView helpers when rendering price ranges

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68f8af1bb4748320a27e63be92c03b60