### PR TITLE
Add local image placeholders and resolver

### DIFF
--- a/MMO_Trader_Market/src/java/units/ImageUrlResolver.java
+++ b/MMO_Trader_Market/src/java/units/ImageUrlResolver.java
@@ -1,0 +1,98 @@
+package units;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Utility methods that normalize image URLs used throughout the application.
+ * <p>
+ * The seed data that powers the demo references a mock CDN domain
+ * (cdn.mmo.local) which is not reachable in the local development
+ * environment. When such URLs are encountered we transparently replace them
+ * with local placeholder assets that live inside the {@code assets/img}
+ * directory of the web module.
+ */
+public final class ImageUrlResolver {
+
+    private static final String PLACEHOLDER_PRODUCT = "/assets/img/placeholders/product-placeholder.svg";
+    private static final String PLACEHOLDER_AVATAR = "/assets/img/placeholders/avatar-placeholder.svg";
+    private static final String PLACEHOLDER_DOCUMENT = "/assets/img/placeholders/document-placeholder.svg";
+    private static final String PLACEHOLDER_LOGO = "/assets/img/logo.svg";
+
+    private ImageUrlResolver() {
+    }
+
+    public static String resolveProductImage(String contextPath, String imageUrl) {
+        return resolve(contextPath, imageUrl, PLACEHOLDER_PRODUCT);
+    }
+
+    public static String resolveAvatarImage(String contextPath, String imageUrl) {
+        return resolve(contextPath, imageUrl, PLACEHOLDER_AVATAR);
+    }
+
+    public static String resolveDocumentImage(String contextPath, String imageUrl) {
+        return resolve(contextPath, imageUrl, PLACEHOLDER_DOCUMENT);
+    }
+
+    public static String resolveLogoImage(String contextPath, String imageUrl) {
+        return resolve(contextPath, imageUrl, PLACEHOLDER_LOGO);
+    }
+
+    private static String resolve(String contextPath, String candidate, String placeholder) {
+        String normalizedContext = normalizeContextPath(contextPath);
+        if (!hasText(candidate)) {
+            return normalizedContext + placeholder;
+        }
+
+        String trimmed = candidate.trim();
+        if (isDataUri(trimmed)) {
+            return trimmed;
+        }
+        if (isKnownOfflineHost(trimmed)) {
+            return normalizedContext + placeholder;
+        }
+        if (isAbsoluteUrl(trimmed)) {
+            return trimmed;
+        }
+        if (!trimmed.startsWith("/")) {
+            trimmed = "/" + trimmed;
+        }
+        return normalizedContext + trimmed;
+    }
+
+    private static boolean isKnownOfflineHost(String value) {
+        try {
+            URI uri = new URI(value);
+            String host = uri.getHost();
+            if (host == null) {
+                return false;
+            }
+            String normalized = host.toLowerCase(Locale.ROOT);
+            return Objects.equals(normalized, "cdn.mmo.local")
+                    || Objects.equals(normalized, "i.pravatar.cc");
+        } catch (URISyntaxException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    private static boolean isAbsoluteUrl(String value) {
+        return value.startsWith("http://") || value.startsWith("https://");
+    }
+
+    private static boolean isDataUri(String value) {
+        return value.regionMatches(true, 0, "data:", 0, 5);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String normalizeContextPath(String contextPath) {
+        if (contextPath == null || contextPath.isBlank() || "/".equals(contextPath)) {
+            return "";
+        }
+        return contextPath;
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/tld/mmo-functions.tld
+++ b/MMO_Trader_Market/web/WEB-INF/tld/mmo-functions.tld
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+        version="3.0">
+    <description>Reusable EL functions for MMO Trader Market.</description>
+    <display-name>MMO Trader Market Functions</display-name>
+    <tlib-version>1.0</tlib-version>
+    <short-name>mmo</short-name>
+    <uri>http://mmo.trader/tags/util</uri>
+
+    <function>
+        <description>Resolve a product image URL and fall back to a local placeholder when necessary.</description>
+        <name>resolveProductImage</name>
+        <function-class>units.ImageUrlResolver</function-class>
+        <function-signature>java.lang.String resolveProductImage(java.lang.String, java.lang.String)</function-signature>
+    </function>
+
+    <function>
+        <description>Resolve an avatar image URL with fallback support.</description>
+        <name>resolveAvatarImage</name>
+        <function-class>units.ImageUrlResolver</function-class>
+        <function-signature>java.lang.String resolveAvatarImage(java.lang.String, java.lang.String)</function-signature>
+    </function>
+
+    <function>
+        <description>Resolve a document/receipt/KYC image URL with fallback support.</description>
+        <name>resolveDocumentImage</name>
+        <function-class>units.ImageUrlResolver</function-class>
+        <function-signature>java.lang.String resolveDocumentImage(java.lang.String, java.lang.String)</function-signature>
+    </function>
+
+    <function>
+        <description>Resolve the logo image URL shown in the global header.</description>
+        <name>resolveLogoImage</name>
+        <function-class>units.ImageUrlResolver</function-class>
+        <function-signature>java.lang.String resolveLogoImage(java.lang.String, java.lang.String)</function-signature>
+    </function>
+</taglib>

--- a/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/kycs.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/kycs.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" %>
+<%@ taglib prefix="mmo" uri="http://mmo.trader/tags/util" %>
 <div class="container-fluid">
     <h4 class="mb-4">Danh sách KYC cần duyệt</h4>
     <table class="table table-bordered align-middle shadow-sm">
@@ -18,7 +19,9 @@
         <tbody>
         <tr>
             <td>12</td><td>Phạm Ngọc Anh</td><td>07920300xxx</td>
-            <td><img src="https://i.pravatar.cc/60" class="rounded" width="60"></td>
+            <td>
+                <img src="${mmo:resolveDocumentImage(pageContext.request.contextPath, null)}" class="rounded" width="60" alt="Ảnh giấy tờ" />
+            </td>
             <td>10/10/2025</td>
             <td><span class="badge bg-warning text-dark">Chờ duyệt</span></td>
             <td>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="mmo" uri="http://mmo.trader/tags/util" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <c:set var="cPath" value="${pageContext.request.contextPath}" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
@@ -11,19 +12,30 @@
         <div class="product-detail__gallery">
             <c:choose>
                 <c:when test="${empty galleryImages}">
+                    <div class="product-detail__main-image">
+                        <c:set var="placeholderImage"
+                               value="${mmo:resolveProductImage(pageContext.request.contextPath, null)}" />
+                        <img src="${placeholderImage}"
+                             alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" />
+                    </div>
                     <div class="product-detail__placeholder">Chưa có ảnh minh họa</div>
                 </c:when>
                 <c:otherwise>
                     <c:set var="mainImage" value="${galleryImages[0]}" />
+                    <c:set var="resolvedMainImage"
+                           value="${mmo:resolveProductImage(pageContext.request.contextPath, mainImage)}" />
                     <div class="product-detail__main-image">
-                        <img id="mainImage" src="${mainImage}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" />
+                        <img id="mainImage" src="${resolvedMainImage}"
+                             alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" />
                     </div>
                     <c:if test="${fn:length(galleryImages) gt 1}">
                         <ul class="product-detail__thumbnails">
                             <c:forEach var="image" items="${galleryImages}">
+                                <c:set var="resolvedThumbnail"
+                                       value="${mmo:resolveProductImage(pageContext.request.contextPath, image)}" />
                                 <li>
-                                    <button class="product-detail__thumbnail" type="button" data-image="${image}">
-                                        <img src="${image}" alt="Thumbnail sản phẩm" loading="lazy" />
+                                    <button class="product-detail__thumbnail" type="button" data-image="${resolvedThumbnail}">
+                                        <img src="${resolvedThumbnail}" alt="Thumbnail sản phẩm" loading="lazy" />
                                     </button>
                                 </li>
                             </c:forEach>
@@ -131,14 +143,10 @@
                 <c:forEach var="item" items="${similarProducts}">
                     <article class="product-card">
                         <div class="product-card__image">
-                            <c:choose>
-                                <c:when test="${not empty item.primaryImageUrl}">
-                                    <img src="${item.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(item.name)}" loading="lazy" />
-                                </c:when>
-                                <c:otherwise>
-                                    <div class="product-card__placeholder">Không có ảnh</div>
-                                </c:otherwise>
-                            </c:choose>
+                            <c:set var="similarImage"
+                                   value="${mmo:resolveProductImage(pageContext.request.contextPath, item.primaryImageUrl)}" />
+                            <img src="${similarImage}"
+                                 alt="Ảnh sản phẩm ${fn:escapeXml(item.name)}" loading="lazy" />
                         </div>
                         <div class="product-card__body">
                             <h4 class="product-card__title"><c:out value="${item.name}" /></h4>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="mmo" uri="http://mmo.trader/tags/util" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
@@ -95,14 +96,10 @@
                     <c:forEach var="product" items="${featuredProducts}">
                         <article class="product-card product-card--featured">
                             <div class="product-card__image">
-                                <c:choose>
-                                    <c:when test="${not empty product.primaryImageUrl}">
-                                        <img src="${product.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
+                                <c:set var="productImage"
+                                        value="${mmo:resolveProductImage(pageContext.request.contextPath, product.primaryImageUrl)}" />
+                                <img src="${productImage}"
+                                     alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
                             </div>
                             <div class="product-card__body">
                                 <header class="product-card__header">

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -2,6 +2,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="mmo" uri="http://mmo.trader/tags/util" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <c:set var="cPath" value="${pageContext.request.contextPath}" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
@@ -29,14 +30,10 @@
                     <c:forEach var="p" items="${items}">
                         <article class="product-card">
                             <div class="product-card__image">
-                                <c:choose>
-                                    <c:when test="${not empty p.primaryImageUrl}">
-                                        <img src="${p.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
+                                <c:set var="productImage"
+                                       value="${mmo:resolveProductImage(pageContext.request.contextPath, p.primaryImageUrl)}" />
+                                <img src="${productImage}"
+                                     alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
                             </div>
                             <div class="product-card__body">
                                 <h3 class="product-card__title"><c:out value="${p.name}" /></h3>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -1,5 +1,6 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<%@ taglib prefix="mmo" uri="http://mmo.trader/tags/util" %>
 
 <c:choose>
   <c:when test="${not empty headerBrandName}">
@@ -51,9 +52,8 @@
   <div class="site-header__inner">
     <div class="layout__brand site-header__brand">
       <a class="layout__logo site-header__logo" href="${homeHref}" title="${brandName}">
-        <c:if test="${not empty headerLogoSrc}">
-          <img class="site-header__logo-image" src="${headerLogoSrc}" alt="${brandName}" loading="lazy" />
-        </c:if>
+        <c:set var="logoSrc" value="${mmo:resolveLogoImage(pageContext.request.contextPath, headerLogoSrc)}" />
+        <img class="site-header__logo-image" src="${logoSrc}" alt="${brandName}" loading="lazy" />
         <span class="site-header__logo-text"><c:out value="${brandName}" /></span>
       </a>
 

--- a/MMO_Trader_Market/web/assets/img/logo.svg
+++ b/MMO_Trader_Market/web/assets/img/logo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 48" width="200" height="48">
+  <defs>
+    <linearGradient id="logoGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4338ca" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="48" rx="12" fill="#111827" />
+  <text x="56" y="30" fill="url(#logoGradient)" font-family="'Segoe UI', 'Helvetica Neue', Arial" font-size="26" font-weight="700">MMO</text>
+  <text x="56" y="44" fill="#9ca3af" font-family="'Segoe UI', 'Helvetica Neue', Arial" font-size="12">Trader Market</text>
+  <g transform="translate(156,12)" fill="none" stroke="#0ea5e9" stroke-width="2">
+    <path d="M0 22l8-12 6 8 10-18 8 14" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="32" cy="6" r="4" fill="#0ea5e9" />
+  </g>
+</svg>

--- a/MMO_Trader_Market/web/assets/img/placeholders/avatar-placeholder.svg
+++ b/MMO_Trader_Market/web/assets/img/placeholders/avatar-placeholder.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160" width="160" height="160">
+  <defs>
+    <linearGradient id="avatarGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#10b981" />
+      <stop offset="100%" stop-color="#14b8a6" />
+    </linearGradient>
+  </defs>
+  <rect width="160" height="160" rx="40" fill="url(#avatarGradient)" />
+  <g fill="#ecfdf5" transform="translate(0,-4)">
+    <circle cx="80" cy="72" r="28" />
+    <path d="M40 136c8-26 32-36 40-36s32 10 40 36" />
+  </g>
+  <text x="80" y="150" fill="#ecfdf5" font-family="'Segoe UI', 'Helvetica Neue', Arial" font-size="18" text-anchor="middle" opacity="0.65">Avatar</text>
+</svg>

--- a/MMO_Trader_Market/web/assets/img/placeholders/document-placeholder.svg
+++ b/MMO_Trader_Market/web/assets/img/placeholders/document-placeholder.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 260" width="200" height="260">
+  <defs>
+    <linearGradient id="docGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#8b5cf6" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="260" rx="24" fill="#eef2ff" />
+  <path d="M48 32h88l32 32v164a20 20 0 0 1-20 20H48a20 20 0 0 1-20-20V52a20 20 0 0 1 20-20z" fill="#fff" />
+  <path d="M136 32v32h32" fill="#c7d2fe" />
+  <g stroke="#4f46e5" stroke-linecap="round" stroke-width="6" opacity="0.75">
+    <line x1="60" y1="112" x2="140" y2="112" />
+    <line x1="60" y1="140" x2="140" y2="140" />
+    <line x1="60" y1="168" x2="112" y2="168" />
+  </g>
+  <rect x="72" y="200" width="56" height="28" rx="14" fill="url(#docGradient)" opacity="0.85" />
+  <text x="100" y="218" text-anchor="middle" font-family="'Segoe UI', 'Helvetica Neue', Arial" font-size="16" fill="#fff">KYC</text>
+</svg>

--- a/MMO_Trader_Market/web/assets/img/placeholders/product-placeholder.svg
+++ b/MMO_Trader_Market/web/assets/img/placeholders/product-placeholder.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 240" width="320" height="240">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4f46e5" />
+      <stop offset="100%" stop-color="#06b6d4" />
+    </linearGradient>
+  </defs>
+  <rect width="320" height="240" fill="url(#g)" rx="24" />
+  <g fill="#ffffff" text-anchor="middle" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif">
+    <text x="160" y="120" font-size="42" font-weight="600">MMO</text>
+    <text x="160" y="156" font-size="22" opacity="0.85">Product Preview</text>
+  </g>
+  <circle cx="50" cy="50" r="12" fill="#ffffff" opacity="0.25" />
+  <circle cx="275" cy="190" r="18" fill="#ffffff" opacity="0.18" />
+  <rect x="220" y="36" width="48" height="16" rx="8" fill="#ffffff" opacity="0.2" />
+  <rect x="44" y="186" width="96" height="12" rx="6" fill="#ffffff" opacity="0.2" />
+</svg>

--- a/MMO_Trader_Market/web/assets/img/user-placeholder.svg
+++ b/MMO_Trader_Market/web/assets/img/user-placeholder.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" width="96" height="96">
+  <defs>
+    <linearGradient id="userGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="24" fill="url(#userGradient)" />
+  <circle cx="48" cy="38" r="18" fill="#e0f2fe" />
+  <path d="M20 84c6-18 20-26 28-26s22 8 28 26" fill="#e0f2fe" />
+  <text x="48" y="88" text-anchor="middle" font-family="'Segoe UI', 'Helvetica Neue', Arial" font-size="10" fill="#0f172a" opacity="0.6">User</text>
+</svg>


### PR DESCRIPTION
## Summary
- add an `ImageUrlResolver` utility and expose it as a JSP function library so offline CDN URLs fall back to local assets
- update product- and header-related JSPs to use the resolver for consistent image rendering
- add SVG logo and placeholder assets for products, avatars, documents, and user profiles

## Testing
- not run (JSP project)


------
https://chatgpt.com/codex/tasks/task_e_68f9980cb2e483208344438c0f58905d