### PR TITLE
Fix product image paths and add asset storage directory

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
@@ -15,15 +15,40 @@
                 </c:when>
                 <c:otherwise>
                     <c:set var="mainImage" value="${galleryImages[0]}" />
+                    <c:choose>
+                        <c:when test="${fn:startsWith(mainImage, 'http://')
+                            or fn:startsWith(mainImage, 'https://')
+                            or fn:startsWith(mainImage, '//')
+                            or fn:startsWith(mainImage, 'data:')
+                            or fn:startsWith(mainImage, cPath)}">
+                            <c:set var="mainImageUrl" value="${mainImage}" />
+                        </c:when>
+                        <c:otherwise>
+                            <c:url var="mainImageUrl" value="${mainImage}" />
+                        </c:otherwise>
+                    </c:choose>
                     <div class="product-detail__main-image">
-                        <img id="mainImage" src="${mainImage}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" />
+                        <img id="mainImage" src="${mainImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" />
                     </div>
                     <c:if test="${fn:length(galleryImages) gt 1}">
                         <ul class="product-detail__thumbnails">
                             <c:forEach var="image" items="${galleryImages}">
+                                <c:set var="thumbnailSource" value="${image}" />
+                                <c:choose>
+                                    <c:when test="${fn:startsWith(thumbnailSource, 'http://')
+                                        or fn:startsWith(thumbnailSource, 'https://')
+                                        or fn:startsWith(thumbnailSource, '//')
+                                        or fn:startsWith(thumbnailSource, 'data:')
+                                        or fn:startsWith(thumbnailSource, cPath)}">
+                                        <c:set var="thumbnailUrl" value="${thumbnailSource}" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:url var="thumbnailUrl" value="${thumbnailSource}" />
+                                    </c:otherwise>
+                                </c:choose>
                                 <li>
-                                    <button class="product-detail__thumbnail" type="button" data-image="${image}">
-                                        <img src="${image}" alt="Thumbnail sản phẩm" loading="lazy" />
+                                    <button class="product-detail__thumbnail" type="button" data-image="${thumbnailUrl}">
+                                        <img src="${thumbnailUrl}" alt="Thumbnail sản phẩm" loading="lazy" />
                                     </button>
                                 </li>
                             </c:forEach>
@@ -133,7 +158,20 @@
                         <div class="product-card__image">
                             <c:choose>
                                 <c:when test="${not empty item.primaryImageUrl}">
-                                    <img src="${item.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(item.name)}" loading="lazy" />
+                                    <c:set var="relatedImageSource" value="${item.primaryImageUrl}" />
+                                    <c:choose>
+                                        <c:when test="${fn:startsWith(relatedImageSource, 'http://')
+                                            or fn:startsWith(relatedImageSource, 'https://')
+                                            or fn:startsWith(relatedImageSource, '//')
+                                            or fn:startsWith(relatedImageSource, 'data:')
+                                            or fn:startsWith(relatedImageSource, cPath)}">
+                                            <c:set var="relatedImageUrl" value="${relatedImageSource}" />
+                                        </c:when>
+                                        <c:otherwise>
+                                            <c:url var="relatedImageUrl" value="${relatedImageSource}" />
+                                        </c:otherwise>
+                                    </c:choose>
+                                    <img src="${relatedImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(item.name)}" loading="lazy" />
                                 </c:when>
                                 <c:otherwise>
                                     <div class="product-card__placeholder">Không có ảnh</div>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -3,6 +3,7 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <fmt:setLocale value="vi_VN" scope="request" />
+<c:set var="cPath" value="${pageContext.request.contextPath}" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content landing">
@@ -97,7 +98,20 @@
                             <div class="product-card__image">
                                 <c:choose>
                                     <c:when test="${not empty product.primaryImageUrl}">
-                                        <img src="${product.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
+                                        <c:set var="featuredImageSource" value="${product.primaryImageUrl}" />
+                                        <c:choose>
+                                            <c:when test="${fn:startsWith(featuredImageSource, 'http://')
+                                                or fn:startsWith(featuredImageSource, 'https://')
+                                                or fn:startsWith(featuredImageSource, '//')
+                                                or fn:startsWith(featuredImageSource, 'data:')
+                                                or fn:startsWith(featuredImageSource, cPath)}">
+                                                <c:set var="featuredImageUrl" value="${featuredImageSource}" />
+                                            </c:when>
+                                            <c:otherwise>
+                                                <c:url var="featuredImageUrl" value="${featuredImageSource}" />
+                                            </c:otherwise>
+                                        </c:choose>
+                                        <img src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
                                     </c:when>
                                     <c:otherwise>
                                         <div class="product-card__placeholder">Không có ảnh</div>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -31,7 +31,20 @@
                             <div class="product-card__image">
                                 <c:choose>
                                     <c:when test="${not empty p.primaryImageUrl}">
-                                        <img src="${p.primaryImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
+                                        <c:set var="productImageSource" value="${p.primaryImageUrl}" />
+                                        <c:choose>
+                                            <c:when test="${fn:startsWith(productImageSource, 'http://')
+                                                or fn:startsWith(productImageSource, 'https://')
+                                                or fn:startsWith(productImageSource, '//')
+                                                or fn:startsWith(productImageSource, 'data:')
+                                                or fn:startsWith(productImageSource, cPath)}">
+                                                <c:set var="productImageUrl" value="${productImageSource}" />
+                                            </c:when>
+                                            <c:otherwise>
+                                                <c:url var="productImageUrl" value="${productImageSource}" />
+                                            </c:otherwise>
+                                        </c:choose>
+                                        <img src="${productImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
                                     </c:when>
                                     <c:otherwise>
                                         <div class="product-card__placeholder">Không có ảnh</div>

--- a/MMO_Trader_Market/web/assets/images/products/.gitkeep
+++ b/MMO_Trader_Market/web/assets/images/products/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to keep the product images directory under version control.


### PR DESCRIPTION
## Summary
- normalize product image URLs returned by the product service so database values map to the new assets directory while still allowing absolute links
- update product detail, list, and home JSP views to resolve image sources relative to the application context
- add an assets/images/products directory (with a placeholder file) for storing product images inside the project

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f9ac6f52808320901b72cb86fb5dc8