### PR TITLE
Implement wallet deduction when processing buyer orders

### DIFF
--- a/MMO_Trader_Market/src/java/dao/user/WalletsDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/WalletsDAO.java
@@ -2,16 +2,18 @@ package dao.user;
 
 import dao.connect.DBConnect;
 import model.Wallets;
-import java.sql.*;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-// import model.Users;  // KHÔNG cần
-// import model.User;   // KHÔNG cần
 
 public class WalletsDAO {
-
-    // Nếu chỉ lưu userId (Integer) trong Wallets thì không cần UserDAO ở đây
-    // private final UserDAO udao = new UserDAO();
 
     private static final String COL_ID = "id";
     private static final String COL_USER_ID = "user_id";
@@ -33,18 +35,7 @@ public class WalletsDAO {
 
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    Wallets wallet = new Wallets();
-                    wallet.setId(rs.getInt(COL_ID));
-                    wallet.setUserId(rs.getInt(COL_USER_ID));                // Integer
-                    wallet.setBalance(rs.getBigDecimal(COL_BALANCE));        // BigDecimal
-                    wallet.setStatus(rs.getBoolean(COL_STATUS));             // Boolean
-
-                    Timestamp c = rs.getTimestamp(COL_CREATED_AT);           // java.sql.Timestamp extends java.util.Date
-                    Timestamp u = rs.getTimestamp(COL_UPDATED_AT);
-                    wallet.setCreatedAt(c);
-                    wallet.setUpdatedAt(u);
-
-                    return wallet;
+                    return mapRow(rs);
                 }
             }
         } catch (SQLException e) {
@@ -66,23 +57,54 @@ public class WalletsDAO {
 
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    Wallets wallet = new Wallets();
-                    wallet.setId(rs.getInt(COL_ID));
-                    wallet.setUserId(rs.getInt(COL_USER_ID));                // Integer
-                    wallet.setBalance(rs.getBigDecimal(COL_BALANCE));        // BigDecimal
-                    wallet.setStatus(rs.getBoolean(COL_STATUS));             // Boolean
-
-                    Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    Timestamp u = rs.getTimestamp(COL_UPDATED_AT);
-wallet.setCreatedAt(c);
-                    wallet.setUpdatedAt(u);
-
-                    return wallet;
+                    return mapRow(rs);
                 }
             }
         } catch (SQLException e) {
             Logger.getLogger(WalletsDAO.class.getName()).log(Level.SEVERE, "Lỗi DB", e);
         }
         return null;
+    }
+
+    public Wallets lockWalletForUpdate(Connection connection, int userId) throws SQLException {
+        // Sử dụng SELECT ... FOR UPDATE để khóa bản ghi ví trong suốt giao dịch.
+        final String sql = "SELECT * FROM wallets WHERE user_id = ? FOR UPDATE";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return mapRow(rs);
+                }
+            }
+        }
+        return null;
+    }
+
+    public boolean updateBalance(Connection connection, int walletId, BigDecimal newBalance) throws SQLException {
+        // Cập nhật số dư và mốc thời gian chỉnh sửa để phản ánh giao dịch mới nhất.
+        final String sql = "UPDATE wallets SET balance = ?, updated_at = NOW() WHERE id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setBigDecimal(1, newBalance);
+            ps.setInt(2, walletId);
+            return ps.executeUpdate() > 0;
+        }
+    }
+
+    private Wallets mapRow(ResultSet rs) throws SQLException {
+        Wallets wallet = new Wallets();
+        wallet.setId(rs.getInt(COL_ID));
+        wallet.setUserId(rs.getInt(COL_USER_ID));
+        wallet.setBalance(rs.getBigDecimal(COL_BALANCE));
+        boolean statusValue = rs.getBoolean(COL_STATUS);
+        wallet.setStatus(rs.wasNull() ? null : statusValue);
+        Timestamp created = rs.getTimestamp(COL_CREATED_AT);
+        if (created != null) {
+            wallet.setCreatedAt(new Date(created.getTime()));
+        }
+        Timestamp updated = rs.getTimestamp(COL_UPDATED_AT);
+        if (updated != null) {
+            wallet.setUpdatedAt(new Date(updated.getTime()));
+        }
+        return wallet;
     }
 }

--- a/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
+++ b/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
@@ -3,6 +3,8 @@ package queue.memory;
 import dao.order.CredentialDAO;
 import dao.order.OrderDAO;
 import dao.product.ProductDAO;
+import dao.user.WalletTransactionDAO;
+import dao.user.WalletsDAO;
 import queue.OrderMessage;
 import queue.OrderQueueProducer;
 import queue.OrderWorker;
@@ -38,12 +40,16 @@ public final class InMemoryOrderQueue implements OrderQueueProducer {
         return INSTANCE;
     }
 
-    public static synchronized void ensureWorkerInitialized(OrderDAO orderDAO, ProductDAO productDAO, CredentialDAO credentialDAO) {
+    public static synchronized void ensureWorkerInitialized(OrderDAO orderDAO, ProductDAO productDAO,
+            CredentialDAO credentialDAO, WalletsDAO walletsDAO, WalletTransactionDAO walletTransactionDAO) {
+        // Khởi tạo worker duy nhất cho hàng đợi, đảm bảo có đủ DAO phục vụ xử lý ví và đơn hàng.
         if (INSTANCE.worker == null) {
             Objects.requireNonNull(orderDAO, "orderDAO");
             Objects.requireNonNull(productDAO, "productDAO");
             Objects.requireNonNull(credentialDAO, "credentialDAO");
-            INSTANCE.worker = new AsyncOrderWorker(orderDAO, productDAO, credentialDAO);
+            Objects.requireNonNull(walletsDAO, "walletsDAO");
+            Objects.requireNonNull(walletTransactionDAO, "walletTransactionDAO");
+            INSTANCE.worker = new AsyncOrderWorker(orderDAO, productDAO, credentialDAO, walletsDAO, walletTransactionDAO);
         }
     }
 

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -3,6 +3,8 @@ package service;
 import dao.order.CredentialDAO;
 import dao.order.OrderDAO;
 import dao.product.ProductDAO;
+import dao.user.WalletTransactionDAO;
+import dao.user.WalletsDAO;
 import model.OrderStatus;
 import model.Orders;
 import model.PaginatedResult;
@@ -34,19 +36,30 @@ public class OrderService {
     private final OrderDAO orderDAO;
     private final ProductDAO productDAO;
     private final CredentialDAO credentialDAO;
+    private final WalletsDAO walletsDAO;
+    private final WalletTransactionDAO walletTransactionDAO;
     private final OrderQueueProducer queueProducer;
 
     public OrderService() {
-        this(new OrderDAO(), new ProductDAO(), new CredentialDAO(), InMemoryOrderQueue.getInstance());
+        this(new OrderDAO(), new ProductDAO(), new CredentialDAO(), new WalletsDAO(),
+                new WalletTransactionDAO(), InMemoryOrderQueue.getInstance());
     }
 
     public OrderService(OrderDAO orderDAO, ProductDAO productDAO, CredentialDAO credentialDAO,
             OrderQueueProducer queueProducer) {
+        this(orderDAO, productDAO, credentialDAO, new WalletsDAO(), new WalletTransactionDAO(), queueProducer);
+    }
+
+    public OrderService(OrderDAO orderDAO, ProductDAO productDAO, CredentialDAO credentialDAO,
+            WalletsDAO walletsDAO, WalletTransactionDAO walletTransactionDAO, OrderQueueProducer queueProducer) {
         this.orderDAO = Objects.requireNonNull(orderDAO, "orderDAO");
         this.productDAO = Objects.requireNonNull(productDAO, "productDAO");
         this.credentialDAO = Objects.requireNonNull(credentialDAO, "credentialDAO");
+        this.walletsDAO = Objects.requireNonNull(walletsDAO, "walletsDAO");
+        this.walletTransactionDAO = Objects.requireNonNull(walletTransactionDAO, "walletTransactionDAO");
         this.queueProducer = Objects.requireNonNull(queueProducer, "queueProducer");
-        InMemoryOrderQueue.ensureWorkerInitialized(orderDAO, productDAO, credentialDAO);
+        // Đảm bảo worker bất đồng bộ được cấu hình với đầy đủ DAO khi service được khởi tạo.
+        InMemoryOrderQueue.ensureWorkerInitialized(orderDAO, productDAO, credentialDAO, walletsDAO, walletTransactionDAO);
     }
 
     public int placeOrderPending(int userId, int productId, int quantity) {


### PR DESCRIPTION
## Summary
- ensure the in-memory order worker charges the buyer wallet before finalising an order and logs the payment transaction
- extend wallet DAOs with transactional helpers for locking, updating balances, and recording transactions
- initialise the queue worker with wallet dependencies so purchase flows deduct funds safely
- bổ sung chú thích tiếng Việt mô tả chi tiết từng bước xử lý đơn và giao dịch ví để dễ bảo trì

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9ab3645b88320b8d5c81c48f98867