### PR TITLE
Redirect admin users to new admin dashboard

### DIFF
--- a/MMO_Trader_Market/src/java/controller/BaseController.java
+++ b/MMO_Trader_Market/src/java/controller/BaseController.java
@@ -3,9 +3,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 
 import units.NavigationBuilder;
+import units.RoleHomeResolver;
 
 /**
  * Base servlet that provides convenience helpers for forwarding to JSP views.
@@ -19,6 +21,26 @@ public abstract class BaseController extends HttpServlet {
         ensureNavigation(request);
         String jsp = ViewResolver.resolve(view);
         request.getRequestDispatcher(jsp).forward(request, response);
+    }
+
+    /**
+     * Redirects administrators to the dedicated admin dashboard.
+     *
+     * @return {@code true} if the response has been committed due to a redirect
+     */
+    protected boolean redirectAdminHome(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            return false;
+        }
+
+        Integer roleId = (Integer) session.getAttribute("userRole");
+        if (roleId != null && roleId == 1) {
+            response.sendRedirect(request.getContextPath() + RoleHomeResolver.ADMIN_HOME);
+            return true;
+        }
+        return false;
     }
 
     private void ensureNavigation(HttpServletRequest request) {

--- a/MMO_Trader_Market/src/java/controller/dashboard/DashboardController.java
+++ b/MMO_Trader_Market/src/java/controller/dashboard/DashboardController.java
@@ -21,6 +21,9 @@ public class DashboardController extends BaseController {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        if (redirectAdminHome(request, response)) {
+            return;
+        }
         request.setAttribute("products", productService.homepageHighlights());
         forward(request, response, "dashboard/index");
     }

--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -33,6 +33,9 @@ public class HomepageController extends BaseController {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        if (redirectAdminHome(request, response)) {
+            return;
+        }
         request.setAttribute("pageTitle", "Chợ tài khoản MMO - Trang chủ");
         request.setAttribute("bodyClass", "layout layout--landing");
 //        request.setAttribute("headerTitle", "MMO Trader Market");

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -29,8 +29,8 @@ public final class NavigationBuilder {
         Integer roleId = session == null ? null : (Integer) session.getAttribute("userRole");
 
         if (isAdminRole(roleId)) {
-            items.add(createNavItem(contextPath + "/dashboard", "Dashboard",
-                    isActive(currentPath, "/dashboard")));
+            items.add(createNavItem(contextPath + RoleHomeResolver.ADMIN_HOME, "Dashboard",
+                    isActive(currentPath, RoleHomeResolver.ADMIN_HOME)));
             items.add(createNavItem(contextPath + "/orders", "Quản lý đơn hàng",
                     isActive(currentPath, "/orders")));
         }
@@ -140,6 +140,6 @@ public final class NavigationBuilder {
     }
 
     private static boolean isAdminRole(Integer roleId) {
-        return roleId != null && roleId != 3;
+        return roleId != null && roleId == 1;
     }
 }

--- a/MMO_Trader_Market/src/java/units/RoleHomeResolver.java
+++ b/MMO_Trader_Market/src/java/units/RoleHomeResolver.java
@@ -4,7 +4,7 @@ import model.Users;
 
 public final class RoleHomeResolver {
 
-    private static final String ADMIN_HOME = "/dashboard";
+    public static final String ADMIN_HOME = "/admin";
     private static final String SELLER_HOME = "/products";
     private static final String BUYER_HOME = "/home";
 
@@ -12,10 +12,11 @@ public final class RoleHomeResolver {
     }
 
     public static String resolve(Users user) {
-        if (user == null || user.getRoleId() == null) {
+        Integer roleId = user == null ? null : user.getRoleId();
+        if (roleId == null) {
             return ADMIN_HOME;
         }
-        switch (user.getRoleId()) {
+        switch (roleId) {
             case 1:
                 return ADMIN_HOME;
             case 2:


### PR DESCRIPTION
## Summary
- redirect authenticated admins away from the public home and dashboard pages to the admin area
- point navigation and role resolution utilities at the new /admin dashboard path
- centralize the admin redirect helper in the base controller for reuse

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f9b16e1d588320bbc6905ce3842077