### PR TITLE
Add product type dropdown navigation and subtype filtering

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -8,25 +8,48 @@
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content">
     <section class="product-list">
-        <div class="product-list__header">
-            <h2>Khám phá sản phẩm</h2>
-            <p>Tìm kiếm, lọc theo shop và mua ngay những sản phẩm bạn cần.</p>
-        </div>
-        <c:set var="filterFormAction" value="${cPath}/products" />
-        <c:set var="filterIncludeSize" value="${true}" />
-        <c:set var="filterPageSize" value="${size}" />
-        <c:set var="filterQuery" value="${query}" />
-        <c:set var="filterType" value="${selectedType}" />
-        <c:set var="filterSubtype" value="${selectedSubtype}" />
-        <%@ include file="/WEB-INF/views/product/fragments/filter-form.jspf" %>
-        <div class="product-list__meta">
-            <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
-            <span>Trang ${page} / ${totalPages}</span>
-        </div>
-        <c:choose>
-            <c:when test="${not empty items}">
-                <div class="product-grid">
-                    <c:forEach var="p" items="${items}">
+        <div class="product-browser">
+            <aside class="product-browser__sidebar">
+                <form id="product-subtype-form" class="product-sidebar" method="get" action="${cPath}/products">
+                    <input type="hidden" name="type" value="${selectedType}" />
+                    <input type="hidden" name="page" value="1" />
+                    <input type="hidden" name="pageSize" value="${pageSize}" />
+                    <div class="product-sidebar__header">
+                        <h2 class="product-sidebar__title"><c:out value="${selectedTypeLabel}" /></h2>
+                        <p class="product-sidebar__subtitle">Chọn phân loại chi tiết để lọc kết quả.</p>
+                    </div>
+                    <div class="product-sidebar__group">
+                        <c:choose>
+                            <c:when test="${not empty subtypeOptions}">
+                                <c:forEach var="option" items="${subtypeOptions}">
+                                    <label class="product-sidebar__option">
+                                        <input type="checkbox" name="subtype" value="${option.code}"
+                                               <c:if test="${selectedSubtypes contains option.code}">checked</c:if> />
+                                        <span><c:out value="${option.label}" /></span>
+                                    </label>
+                                </c:forEach>
+                            </c:when>
+                            <c:otherwise>
+                                <p class="product-sidebar__empty">Không có phân loại chi tiết cho danh mục này.</p>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                    <button class="button button--primary product-sidebar__apply" type="submit">Áp dụng lọc</button>
+                </form>
+            </aside>
+            <div class="product-browser__content">
+                <header class="product-browser__header">
+                    <h2><c:out value="${selectedTypeLabel}" /></h2>
+                    <p class="product-browser__description">Có thể chọn nhiều phân loại cùng lúc để thu hẹp danh sách sản phẩm.</p>
+                </header>
+                <div class="product-list__meta">
+                    <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
+                    <span>Trang ${page} / ${totalPages}</span>
+                </div>
+                <c:choose>
+                    <c:when test="${not empty items}">
+                        <div class="product-grid">
+                            <c:forEach var="p" items="${items}">
                         <article class="product-card">
                             <div class="product-card__image">
                                 <c:choose>
@@ -82,66 +105,73 @@
                             </div>
                         </article>
                     </c:forEach>
-                </div>
-            </c:when>
-            <c:otherwise>
-                <div class="product-card product-card--empty">
-                    <p>Không tìm thấy sản phẩm phù hợp.</p>
-                </div>
-            </c:otherwise>
-        </c:choose>
-        <c:if test="${totalPages gt 1}">
-            <nav class="pagination" aria-label="Phân trang sản phẩm">
-                <c:url var="prevUrl" value="/products">
-                    <c:param name="page" value="${page - 1}" />
-                    <c:param name="size" value="${size}" />
-                    <c:if test="${not empty query}">
-                        <c:param name="q" value="${query}" />
-                    </c:if>
-                    <c:if test="${not empty selectedType}">
-                        <c:param name="type" value="${selectedType}" />
-                    </c:if>
-                    <c:if test="${not empty selectedSubtype}">
-                        <c:param name="subtype" value="${selectedSubtype}" />
-                    </c:if>
-                </c:url>
-                <c:url var="nextUrl" value="/products">
-                    <c:param name="page" value="${page + 1}" />
-                    <c:param name="size" value="${size}" />
-                    <c:if test="${not empty query}">
-                        <c:param name="q" value="${query}" />
-                    </c:if>
-                    <c:if test="${not empty selectedType}">
-                        <c:param name="type" value="${selectedType}" />
-                    </c:if>
-                    <c:if test="${not empty selectedSubtype}">
-                        <c:param name="subtype" value="${selectedSubtype}" />
-                    </c:if>
-                </c:url>
-                <span class="pagination__summary">Trang ${page} / ${totalPages}</span>
-                <a class="pagination__item ${page le 1 ? 'pagination__item--disabled' : ''}" href="${page le 1 ? '#' : prevUrl}" aria-disabled="${page le 1}">«</a>
-                <c:forEach var="i" begin="1" end="${totalPages}">
-                    <c:url var="pageUrl" value="/products">
-                        <c:param name="page" value="${i}" />
-                        <c:param name="size" value="${size}" />
-                        <c:if test="${not empty query}">
-                            <c:param name="q" value="${query}" />
-                        </c:if>
-                        <c:if test="${not empty selectedType}">
+                        </div>
+                    </c:when>
+                    <c:otherwise>
+                        <div class="product-card product-card--empty">
+                            <p>Không tìm thấy sản phẩm phù hợp.</p>
+                        </div>
+                    </c:otherwise>
+                </c:choose>
+                <c:if test="${totalPages gt 1}">
+                    <nav class="pagination" aria-label="Phân trang sản phẩm">
+                        <c:url var="prevUrl" value="/products">
                             <c:param name="type" value="${selectedType}" />
-                        </c:if>
-                        <c:if test="${not empty selectedSubtype}">
-                            <c:param name="subtype" value="${selectedSubtype}" />
-                        </c:if>
-                    </c:url>
-                    <a class="pagination__item ${i == page ? 'pagination__item--active' : ''}"
-                       href="${pageUrl}">${i}</a>
-                </c:forEach>
-                <a class="pagination__item ${page ge totalPages ? 'pagination__item--disabled' : ''}"
-                   href="${page ge totalPages ? '#' : nextUrl}" aria-disabled="${page ge totalPages}">»</a>
-            </nav>
-        </c:if>
+                            <c:param name="page" value="${page - 1}" />
+                            <c:param name="pageSize" value="${pageSize}" />
+                            <c:forEach var="subtype" items="${selectedSubtypes}">
+                                <c:param name="subtype" value="${subtype}" />
+                            </c:forEach>
+                        </c:url>
+                        <c:url var="nextUrl" value="/products">
+                            <c:param name="type" value="${selectedType}" />
+                            <c:param name="page" value="${page + 1}" />
+                            <c:param name="pageSize" value="${pageSize}" />
+                            <c:forEach var="subtype" items="${selectedSubtypes}">
+                                <c:param name="subtype" value="${subtype}" />
+                            </c:forEach>
+                        </c:url>
+                        <span class="pagination__summary">Trang ${page} / ${totalPages}</span>
+                        <a class="pagination__item ${page le 1 ? 'pagination__item--disabled' : ''}"
+                           href="${page le 1 ? '#' : prevUrl}" aria-disabled="${page le 1}">«</a>
+                        <c:forEach var="i" begin="1" end="${totalPages}">
+                            <c:url var="pageUrl" value="/products">
+                                <c:param name="type" value="${selectedType}" />
+                                <c:param name="page" value="${i}" />
+                                <c:param name="pageSize" value="${pageSize}" />
+                                <c:forEach var="subtype" items="${selectedSubtypes}">
+                                    <c:param name="subtype" value="${subtype}" />
+                                </c:forEach>
+                            </c:url>
+                            <a class="pagination__item ${i == page ? 'pagination__item--active' : ''}"
+                               href="${pageUrl}">${i}</a>
+                        </c:forEach>
+                        <a class="pagination__item ${page ge totalPages ? 'pagination__item--disabled' : ''}"
+                           href="${page ge totalPages ? '#' : nextUrl}" aria-disabled="${page ge totalPages}">»</a>
+                    </nav>
+                </c:if>
+            </div>
+        </div>
     </section>
 </main>
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<script>
+  (function() {
+    var form = document.getElementById('product-subtype-form');
+    if (!form || form.dataset.enhanced === 'true') {
+      return;
+    }
+    form.dataset.enhanced = 'true';
+    var checkboxes = form.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach(function(input) {
+      input.addEventListener('change', function() {
+        var pageInput = form.querySelector('input[name="page"]');
+        if (pageInput) {
+          pageInput.value = '1';
+        }
+        form.submit();
+      });
+    });
+  })();
+</script>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -71,28 +71,65 @@
 
     <c:if test="${not empty navItems}">
       <nav class="menu menu--horizontal site-header__nav" aria-label="Chuyển hướng chính">
+        <c:set var="navProductSelectId" value="site-nav-product-type" />
         <c:forEach var="item" items="${navItems}">
           <c:set var="itemClass" value="menu__item" />
           <c:if test="${not empty item['modifier']}">
             <c:set var="itemClass" value="${itemClass} ${item['modifier']}" />
           </c:if>
+          <c:choose>
+            <c:when test="${item['type'] == 'productDropdown'}">
+              <div class="${itemClass}">
+                <div class="menu__dropdown">
+                  <label class="menu__dropdown-label" for="${navProductSelectId}">Sản phẩm</label>
+                  <select id="${navProductSelectId}" class="menu__dropdown-select"
+                          data-base="${pageContext.request.contextPath}/products?type=">
+                    <option value="" disabled <c:if test="${empty item['currentType']}">selected</c:if>>Chọn loại</option>
+                    <c:forEach var="option" items="${item['options']}">
+                      <option value="${option.code}" <c:if test="${option.code == item['currentType']}">selected</c:if>>
+                        <c:out value="${option.label}" />
+                      </option>
+                    </c:forEach>
+                  </select>
+                </div>
+              </div>
+            </c:when>
+            <c:otherwise>
+              <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
+                <c:if test="${not empty item['icon']}">
+                  <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}" /></span>
+                </c:if>
 
-          <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
-            <c:if test="${not empty item['icon']}">
-              <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}" /></span>
-            </c:if>
+                <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}" />
+                <c:if test="${not empty textVal}">
+                  <span class="menu__text"><c:out value="${textVal}" /></span>
+                </c:if>
 
-            <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}" />
-            <c:if test="${not empty textVal}">
-              <span class="menu__text"><c:out value="${textVal}" /></span>
-            </c:if>
-
-            <c:if test="${not empty item['srText']}">
-              <span class="sr-only"><c:out value="${item['srText']}" /></span>
-            </c:if>
-          </a>
+                <c:if test="${not empty item['srText']}">
+                  <span class="sr-only"><c:out value="${item['srText']}" /></span>
+                </c:if>
+              </a>
+            </c:otherwise>
+          </c:choose>
         </c:forEach>
       </nav>
     </c:if>
   </div>
 </header>
+<script>
+  (function() {
+    var select = document.getElementById('site-nav-product-type');
+    if (!select || select.dataset.enhanced === 'true') {
+      return;
+    }
+    select.dataset.enhanced = 'true';
+    select.addEventListener('change', function() {
+      var value = select.value;
+      if (!value) {
+        return;
+      }
+      var base = select.dataset.base || '';
+      window.location.href = base + encodeURIComponent(value);
+    });
+  })();
+</script>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -379,6 +379,98 @@ justify-content: space-between;
     gap: 2rem;
 }
 
+.product-browser {
+    display: grid;
+    gap: 1.75rem;
+}
+
+@media (min-width: 960px) {
+    .product-browser {
+        grid-template-columns: minmax(240px, 280px) 1fr;
+        align-items: start;
+    }
+}
+
+.product-browser__content {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.product-browser__header {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.product-browser__header h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 1.3rem + 0.6vw, 2rem);
+}
+
+.product-browser__description {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.product-browser__sidebar {
+    align-self: start;
+}
+
+.product-sidebar {
+    background: var(--surface-color);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.product-sidebar__header {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.product-sidebar__title {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.product-sidebar__subtitle {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.product-sidebar__group {
+    display: grid;
+    gap: 0.6rem;
+}
+
+.product-sidebar__option {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--text-color);
+}
+
+.product-sidebar__option input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--primary-color);
+}
+
+.product-sidebar__empty {
+    margin: 0;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.product-sidebar__apply {
+    justify-self: start;
+}
+
 .product-list__header {
     text-align: center;
     display: grid;
@@ -835,6 +927,48 @@ padding: 0.6rem 1rem;
 
 .menu__item--ghost {
     color: var(--muted-color);
+}
+
+.menu__item--dropdown {
+    display: flex;
+    align-items: center;
+    padding: 0;
+}
+
+.menu__dropdown {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.35rem 0.5rem;
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.6);
+    position: relative;
+}
+
+.menu__dropdown-label {
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.menu__dropdown-select {
+    appearance: none;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    border-radius: var(--radius-sm);
+    padding: 0.4rem 2rem 0.4rem 0.75rem;
+    font-size: 0.95rem;
+    color: var(--text-color);
+    background: #fff;
+    cursor: pointer;
+    min-width: 180px;
+}
+
+.menu__dropdown::after {
+    content: "▾";
+    position: absolute;
+    right: 0.8rem;
+    font-size: 0.75rem;
+    color: var(--text-light);
+    pointer-events: none;
 }
 
 .menu__item--button,


### PR DESCRIPTION
## Summary
- add a product type dropdown entry to the shared navigation header
- support mandatory type selection with optional multi-subtype filters and pagination in the product list backend
- redesign the product list view with a sidebar filter UI and update styling to match the new layout

## Testing
- ant -f build.xml compile *(fails: ant: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fb1dd978308320ad99aa6440be030e