### PR TITLE
Implement product type dropdown navigation and subtype filters

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/ProductListController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductListController.java
@@ -12,13 +12,16 @@ import model.view.product.ProductTypeOption;
 import service.ProductService;
 
 import java.io.IOException;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Điều phối luồng "Danh sách sản phẩm" trên marketplace công khai.
  * <p>
- * - Liệt kê sản phẩm theo danh mục với phân trang và bộ lọc cơ bản.
- * - Hỗ trợ tìm kiếm theo từ khóa, loại sản phẩm, phân nhóm con.
+ * - Liệt kê sản phẩm theo từng loại chính với phân trang phía server.
+ * - Hỗ trợ lọc theo nhiều phân loại con của cùng một loại sản phẩm.
  * - Chuẩn hóa tham số đầu vào để đảm bảo trải nghiệm duyệt sản phẩm mượt mà.
  *
  * @version 1.0 27/05/2024
@@ -36,29 +39,48 @@ public class ProductListController extends BaseController {
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        String keyword = normalize(request.getParameter("q"));
-        String productType = normalize(request.getParameter("type"));
-        String productSubtype = normalize(request.getParameter("subtype"));
-        int page = parsePositiveIntOrDefault(request.getParameter("page"), DEFAULT_PAGE);
-        int size = parsePositiveIntOrDefault(request.getParameter("size"), DEFAULT_SIZE);
-
-        PagedResult<ProductSummaryView> result = productService.searchPublicProducts(
-                productType, productSubtype, keyword, page, size);
         List<ProductTypeOption> typeOptions = productService.getTypeOptions();
-        List<ProductSubtypeOption> subtypeOptions = productService.getSubtypeOptions(productType);
+        String requestedType = request.getParameter("type");
+        String normalizedType = productService.normalizeTypeCode(requestedType);
+        if (normalizedType == null) {
+            Optional<String> fallbackType = typeOptions.stream()
+                    .map(ProductTypeOption::getCode)
+                    .findFirst();
+            if (fallbackType.isPresent()) {
+                response.sendRedirect(request.getContextPath() + "/products?type=" + fallbackType.get());
+                return;
+            }
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
 
-        request.setAttribute("pageTitle", "Sản phẩm");
+        int page = parsePositiveIntOrDefault(request.getParameter("page"), DEFAULT_PAGE);
+        int size = parsePositiveIntOrDefault(resolveSizeParam(request), DEFAULT_SIZE);
+
+        List<String> subtypeFilters = productService.normalizeSubtypeCodes(normalizedType,
+                request.getParameterValues("subtype"));
+        Set<String> selectedSubtypeSet = new LinkedHashSet<>(subtypeFilters);
+
+        PagedResult<ProductSummaryView> result = productService.browseByType(normalizedType, subtypeFilters, page, size);
+        List<ProductSubtypeOption> subtypeOptions = productService.getSubtypeOptions(normalizedType);
+        String currentTypeLabel = typeOptions.stream()
+                .filter(option -> option.getCode().equals(normalizedType))
+                .map(ProductTypeOption::getLabel)
+                .findFirst()
+                .orElse(productService.getTypeLabel(normalizedType));
+
+        request.setAttribute("pageTitle", currentTypeLabel + " - Sản phẩm");
         request.setAttribute("items", result.getItems());
         request.setAttribute("totalItems", result.getTotalItems());
         request.setAttribute("page", result.getPage());
         request.setAttribute("currentPage", result.getPage());
-        request.setAttribute("size", result.getSize());
+        request.setAttribute("pageSize", result.getSize());
         request.setAttribute("totalPages", result.getTotalPages());
-        request.setAttribute("query", keyword == null ? "" : keyword);
-        request.setAttribute("selectedType", productType);
-        request.setAttribute("selectedSubtype", productSubtype);
+        request.setAttribute("selectedType", normalizedType);
+        request.setAttribute("selectedSubtypes", selectedSubtypeSet);
         request.setAttribute("typeOptions", typeOptions);
         request.setAttribute("subtypeOptions", subtypeOptions);
+        request.setAttribute("currentTypeLabel", currentTypeLabel);
 
         forward(request, response, "product/list");
     }
@@ -75,11 +97,11 @@ public class ProductListController extends BaseController {
         }
     }
 
-    private String normalize(String value) {
-        if (value == null) {
-            return null;
+    private String resolveSizeParam(HttpServletRequest request) {
+        String pageSizeParam = request.getParameter("pageSize");
+        if (pageSizeParam != null && !pageSizeParam.isBlank()) {
+            return pageSizeParam;
         }
-        String trimmed = value.trim();
-        return trimmed.isEmpty() ? null : trimmed;
+        return request.getParameter("size");
     }
 }

--- a/MMO_Trader_Market/src/java/service/ProductService.java
+++ b/MMO_Trader_Market/src/java/service/ProductService.java
@@ -19,13 +19,16 @@ import model.view.product.ProductTypeOption;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Contains business logic related to products.
@@ -95,22 +98,24 @@ public class ProductService {
         return summaries;
     }
 
-    public PagedResult<ProductSummaryView> searchPublicProducts(String productType, String productSubtype,
-            String keyword, int page, int size) {
+    public PagedResult<ProductSummaryView> browseByType(String productType, List<String> productSubtypes,
+            int page, int size) {
         int safePage = Math.max(page, 1);
         int safeSize = Math.max(size, 1);
-        String normalizedKeyword = normalize(keyword);
         String normalizedType = normalizeFilter(productType);
-        String normalizedSubtype = normalizeSubtype(normalizedType, productSubtype);
+        if (normalizedType == null) {
+            throw new IllegalArgumentException("Loại sản phẩm không hợp lệ");
+        }
+        List<String> normalizedSubtypes = normalizeSubtypeList(normalizedType, productSubtypes);
 
-        long totalItems = productDAO.countAvailable(normalizedKeyword, normalizedType, normalizedSubtype);
+        long totalItems = productDAO.countAvailableByType(normalizedType, normalizedSubtypes);
         int totalPages = totalItems == 0 ? 1 : (int) Math.ceil((double) totalItems / safeSize);
         int currentPage = Math.min(safePage, totalPages);
         int offset = (currentPage - 1) * safeSize;
 
         List<ProductSummaryView> items = totalItems == 0
                 ? List.of()
-                : productDAO.findAvailablePaged(normalizedKeyword, normalizedType, normalizedSubtype, safeSize, offset)
+                : productDAO.findAvailableByType(normalizedType, normalizedSubtypes, safeSize, offset)
                 .stream()
                 .map(this::toSummaryView)
                 .toList();
@@ -181,6 +186,25 @@ public class ProductService {
                 .findFirst()
                 .map(ProductTypeOption::getSubtypes)
                 .orElse(List.of());
+    }
+
+    public String normalizeTypeCode(String value) {
+        return normalizeFilter(value);
+    }
+
+    public List<String> normalizeSubtypeCodes(String productType, String[] values) {
+        if (values == null || values.length == 0) {
+            return List.of();
+        }
+        String normalizedType = normalizeFilter(productType);
+        if (normalizedType == null) {
+            return List.of();
+        }
+        return normalizeSubtypeList(normalizedType, Arrays.asList(values));
+    }
+
+    public String getTypeLabel(String typeCode) {
+        return resolveTypeLabel(typeCode);
     }
 
     public List<Products> homepageHighlights() {
@@ -379,6 +403,20 @@ public class ProductService {
                 .flatMap(option -> option.getSubtypes().stream())
                 .anyMatch(option -> option.getCode().equals(upper));
         return exists ? upper : null;
+    }
+
+    private List<String> normalizeSubtypeList(String type, List<String> subtypes) {
+        if (subtypes == null || subtypes.isEmpty()) {
+            return List.of();
+        }
+        Set<String> normalized = new LinkedHashSet<>();
+        for (String value : subtypes) {
+            String resolved = normalizeSubtype(type, value);
+            if (resolved != null) {
+                normalized.add(resolved);
+            }
+        }
+        return normalized.isEmpty() ? List.of() : List.copyOf(normalized);
     }
 
     private boolean hasVariants(String variantSchema) {

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -3,6 +3,9 @@ package units;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 
+import model.view.product.ProductTypeOption;
+import service.ProductService;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,11 +20,13 @@ public final class NavigationBuilder {
     private static final String ICON_CLASS = "menu__item--icon";
     private static final String BUTTON_CLASS = "menu__item--button";
 
+    private static final ProductService PRODUCT_SERVICE = new ProductService();
+
     private NavigationBuilder() {
     }
 
-    public static List<Map<String, String>> build(HttpServletRequest request) {
-        List<Map<String, String>> items = new ArrayList<>();
+    public static List<Map<String, Object>> build(HttpServletRequest request) {
+        List<Map<String, Object>> items = new ArrayList<>();
         String contextPath = request.getContextPath();
         String currentPath = resolveCurrentPath(request);
 
@@ -35,7 +40,7 @@ public final class NavigationBuilder {
                     isActive(currentPath, "/orders")));
         }
 
-        addBaseItems(items, contextPath, currentPath);
+        addBaseItems(items, request, contextPath, currentPath);
 
         if (roleId == null) {
             if (shouldDisplayAuthCta(currentPath)) {
@@ -61,17 +66,23 @@ public final class NavigationBuilder {
         return items;
     }
 
-    private static void addBaseItems(List<Map<String, String>> items, String contextPath, String currentPath) {
-        items.add(createNavItem(contextPath + "/home#product-types", "Loại sản phẩm", false));
+    private static void addBaseItems(List<Map<String, Object>> items, HttpServletRequest request,
+            String contextPath, String currentPath) {
+        Map<String, Object> productItem = buildProductDropdown(request, contextPath, currentPath);
+        if (productItem != null) {
+            items.add(productItem);
+        } else {
+            items.add(createNavItem(contextPath + "/products", "Sản phẩm", isActive(currentPath, "/products")));
+        }
         items.add(createNavItem(contextPath + "/home#faq", "FAQ", false));
     }
 
-    private static Map<String, String> createNavItem(String href, String text, boolean active) {
+    private static Map<String, Object> createNavItem(String href, String text, boolean active) {
         return createNavItem(href, text, active, null);
     }
 
-    private static Map<String, String> createNavItem(String href, String text, boolean active, String extraClasses) {
-        Map<String, String> item = new HashMap<>();
+    private static Map<String, Object> createNavItem(String href, String text, boolean active, String extraClasses) {
+        Map<String, Object> item = new HashMap<>();
         item.put("href", href);
         item.put("text", text);
         item.put("label", text);
@@ -83,18 +94,18 @@ public final class NavigationBuilder {
         return item;
     }
 
-    private static Map<String, String> createIconItem(String href, String icon, String text,
+    private static Map<String, Object> createIconItem(String href, String icon, String text,
             boolean highlight, boolean active) {
         String extraClasses = ICON_CLASS + (highlight ? " " + BUTTON_CLASS : "");
-        Map<String, String> item = createNavItem(href, text, active, extraClasses);
+        Map<String, Object> item = createNavItem(href, text, active, extraClasses);
         item.put("icon", icon);
         item.put("srText", text);
         return item;
     }
 
-    private static Map<String, String> createLogoutItem(String contextPath) {
-        Map<String, String> item = createNavItem(contextPath + "/auth?action=logout", "Đăng xuất", false);
-        String existingModifier = item.get("modifier");
+    private static Map<String, Object> createLogoutItem(String contextPath) {
+        Map<String, Object> item = createNavItem(contextPath + "/auth?action=logout", "Đăng xuất", false);
+        String existingModifier = (String) item.get("modifier");
         StringBuilder modifierBuilder = new StringBuilder();
         if (existingModifier != null && !existingModifier.isBlank()) {
             modifierBuilder.append(existingModifier.trim()).append(' ');
@@ -102,6 +113,44 @@ public final class NavigationBuilder {
         modifierBuilder.append("menu__item--danger menu__item--logout");
         item.put("modifier", modifierBuilder.toString());
         return item;
+    }
+
+    private static Map<String, Object> buildProductDropdown(HttpServletRequest request, String contextPath,
+            String currentPath) {
+        List<ProductTypeOption> typeOptions = PRODUCT_SERVICE.getTypeOptions();
+        if (typeOptions.isEmpty()) {
+            return null;
+        }
+        String requestedType = request.getParameter("type");
+        String normalizedType = PRODUCT_SERVICE.normalizeTypeCode(requestedType);
+        if (normalizedType == null) {
+            normalizedType = typeOptions.get(0).getCode();
+        }
+        boolean active = isActive(currentPath, "/products");
+        String fallbackHref = contextPath + "/products?type=" + typeOptions.get(0).getCode();
+        String selectedLabel = typeOptions.get(0).getLabel();
+
+        List<Map<String, Object>> children = new ArrayList<>();
+        for (ProductTypeOption option : typeOptions) {
+            Map<String, Object> child = new HashMap<>();
+            child.put("href", contextPath + "/products?type=" + option.getCode());
+            child.put("text", option.getLabel());
+            child.put("label", option.getLabel());
+            child.put("code", option.getCode());
+            boolean childActive = active && option.getCode().equalsIgnoreCase(normalizedType);
+            child.put("active", childActive);
+            children.add(child);
+            if (option.getCode().equalsIgnoreCase(normalizedType)) {
+                fallbackHref = contextPath + "/products?type=" + option.getCode();
+                selectedLabel = option.getLabel();
+            }
+        }
+
+        Map<String, Object> dropdown = createNavItem(fallbackHref, "Sản phẩm", active);
+        dropdown.put("dropdown", true);
+        dropdown.put("children", children);
+        dropdown.put("selectedLabel", selectedLabel);
+        return dropdown;
     }
 
     private static boolean isActive(String currentPath, String path) {

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -7,140 +7,157 @@
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content">
-    <section class="product-list">
-        <div class="product-list__header">
-            <h2>Khám phá sản phẩm</h2>
-            <p>Tìm kiếm, lọc theo shop và mua ngay những sản phẩm bạn cần.</p>
+    <section class="product-browse">
+        <div class="product-browse__header">
+            <h2><c:out value="${currentTypeLabel}" /></h2>
+            <p>Lọc theo phân loại chi tiết để tìm sản phẩm phù hợp nhất với nhu cầu của bạn.</p>
         </div>
-        <c:set var="filterFormAction" value="${cPath}/products" />
-        <c:set var="filterIncludeSize" value="${true}" />
-        <c:set var="filterPageSize" value="${size}" />
-        <c:set var="filterQuery" value="${query}" />
-        <c:set var="filterType" value="${selectedType}" />
-        <c:set var="filterSubtype" value="${selectedSubtype}" />
-        <%@ include file="/WEB-INF/views/product/fragments/filter-form.jspf" %>
-        <div class="product-list__meta">
-            <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
-            <span>Trang ${page} / ${totalPages}</span>
-        </div>
-        <c:choose>
-            <c:when test="${not empty items}">
-                <div class="product-grid">
-                    <c:forEach var="p" items="${items}">
-                        <article class="product-card">
-                            <div class="product-card__image">
-                                <c:choose>
-                                    <c:when test="${not empty p.primaryImageUrl}">
-                                        <c:set var="productImageSource" value="${p.primaryImageUrl}" />
+        <div class="product-browse__layout">
+            <aside class="product-browse__sidebar">
+                <form class="product-filter-sidebar" method="get" action="${cPath}/products">
+                    <input type="hidden" name="type" value="${selectedType}" />
+                    <input type="hidden" name="page" value="1" />
+                    <input type="hidden" name="pageSize" value="${pageSize}" />
+                    <h3 class="product-filter-sidebar__title">Phân loại chi tiết</h3>
+                    <div class="product-filter-sidebar__group">
+                        <c:choose>
+                            <c:when test="${not empty subtypeOptions}">
+                                <c:forEach var="option" items="${subtypeOptions}">
+                                    <label class="product-filter-sidebar__option">
+                                        <input type="checkbox" name="subtype" value="${option.code}"
+                                               <c:if test="${selectedSubtypes contains option.code}">checked</c:if>
+                                               onchange="this.form.submit()" />
+                                        <span><c:out value="${option.label}" /></span>
+                                    </label>
+                                </c:forEach>
+                            </c:when>
+                            <c:otherwise>
+                                <p class="product-filter-sidebar__empty">Không có phân loại chi tiết cho danh mục này.</p>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                    <noscript>
+                        <button class="button button--primary button--block" type="submit">Áp dụng bộ lọc</button>
+                    </noscript>
+                </form>
+            </aside>
+            <div class="product-browse__results">
+                <div class="product-list__meta product-browse__meta">
+                    <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
+                    <span>Trang ${page} / ${totalPages}</span>
+                </div>
+                <c:choose>
+                    <c:when test="${not empty items}">
+                        <div class="product-grid">
+                            <c:forEach var="p" items="${items}">
+                                <article class="product-card">
+                                    <div class="product-card__image">
                                         <c:choose>
-                                            <c:when test="${fn:startsWith(productImageSource, 'http://')
-                                                or fn:startsWith(productImageSource, 'https://')
-                                                or fn:startsWith(productImageSource, '//')
-                                                or fn:startsWith(productImageSource, 'data:')
-                                                or fn:startsWith(productImageSource, cPath)}">
-                                                <c:set var="productImageUrl" value="${productImageSource}" />
+                                            <c:when test="${not empty p.primaryImageUrl}">
+                                                <c:set var="productImageSource" value="${p.primaryImageUrl}" />
+                                                <c:choose>
+                                                    <c:when test="${fn:startsWith(productImageSource, 'http://')
+                                                        or fn:startsWith(productImageSource, 'https://')
+                                                        or fn:startsWith(productImageSource, '//')
+                                                        or fn:startsWith(productImageSource, 'data:')
+                                                        or fn:startsWith(productImageSource, cPath)}">
+                                                        <c:set var="productImageUrl" value="${productImageSource}" />
+                                                    </c:when>
+                                                    <c:otherwise>
+                                                        <c:url var="productImageUrl" value="${productImageSource}" />
+                                                    </c:otherwise>
+                                                </c:choose>
+                                                <img src="${productImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
                                             </c:when>
                                             <c:otherwise>
-                                                <c:url var="productImageUrl" value="${productImageSource}" />
+                                                <div class="product-card__placeholder">Không có ảnh</div>
                                             </c:otherwise>
                                         </c:choose>
-                                        <img src="${productImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(p.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
-                            </div>
-                            <div class="product-card__body">
-                                <h3 class="product-card__title"><c:out value="${p.name}" /></h3>
-                                <p class="product-card__meta">
-                                    <span><c:out value="${p.productTypeLabel}" /> • <c:out value="${p.productSubtypeLabel}" /></span>
-                                    <span>Shop: <strong><c:out value="${p.shopName}" /></strong></span>
-                                </p>
-                                <p class="product-card__description"><c:out value="${p.shortDescription}" /></p>
-                                <p class="product-card__price">
-                                    <c:choose>
-                                        <c:when test="${p.minPrice eq p.maxPrice}">
-                                            Giá
-                                            <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:when>
-                                        <c:otherwise>
-                                            Giá từ
-                                            <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                            –
-                                            <fmt:formatNumber value="${p.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:otherwise>
-                                    </c:choose>
-                                </p>
-                                <ul class="product-card__meta product-card__meta--stats">
-                                    <li>Tồn kho: <strong><c:out value="${p.inventoryCount}" /></strong></li>
-                                    <li>Đã bán: <strong><c:out value="${p.soldCount}" /></strong></li>
-                                </ul>
-                                <div class="product-card__actions">
-                                    <a class="button button--primary" href="${cPath}/product/detail?id=${p.id}">Xem chi tiết</a>
-                                </div>
-                            </div>
-                        </article>
-                    </c:forEach>
-                </div>
-            </c:when>
-            <c:otherwise>
-                <div class="product-card product-card--empty">
-                    <p>Không tìm thấy sản phẩm phù hợp.</p>
-                </div>
-            </c:otherwise>
-        </c:choose>
-        <c:if test="${totalPages gt 1}">
-            <nav class="pagination" aria-label="Phân trang sản phẩm">
-                <c:url var="prevUrl" value="/products">
-                    <c:param name="page" value="${page - 1}" />
-                    <c:param name="size" value="${size}" />
-                    <c:if test="${not empty query}">
-                        <c:param name="q" value="${query}" />
-                    </c:if>
-                    <c:if test="${not empty selectedType}">
-                        <c:param name="type" value="${selectedType}" />
-                    </c:if>
-                    <c:if test="${not empty selectedSubtype}">
-                        <c:param name="subtype" value="${selectedSubtype}" />
-                    </c:if>
-                </c:url>
-                <c:url var="nextUrl" value="/products">
-                    <c:param name="page" value="${page + 1}" />
-                    <c:param name="size" value="${size}" />
-                    <c:if test="${not empty query}">
-                        <c:param name="q" value="${query}" />
-                    </c:if>
-                    <c:if test="${not empty selectedType}">
-                        <c:param name="type" value="${selectedType}" />
-                    </c:if>
-                    <c:if test="${not empty selectedSubtype}">
-                        <c:param name="subtype" value="${selectedSubtype}" />
-                    </c:if>
-                </c:url>
-                <span class="pagination__summary">Trang ${page} / ${totalPages}</span>
-                <a class="pagination__item ${page le 1 ? 'pagination__item--disabled' : ''}" href="${page le 1 ? '#' : prevUrl}" aria-disabled="${page le 1}">«</a>
-                <c:forEach var="i" begin="1" end="${totalPages}">
-                    <c:url var="pageUrl" value="/products">
-                        <c:param name="page" value="${i}" />
-                        <c:param name="size" value="${size}" />
-                        <c:if test="${not empty query}">
-                            <c:param name="q" value="${query}" />
-                        </c:if>
-                        <c:if test="${not empty selectedType}">
-                            <c:param name="type" value="${selectedType}" />
-                        </c:if>
-                        <c:if test="${not empty selectedSubtype}">
-                            <c:param name="subtype" value="${selectedSubtype}" />
-                        </c:if>
-                    </c:url>
-                    <a class="pagination__item ${i == page ? 'pagination__item--active' : ''}"
-                       href="${pageUrl}">${i}</a>
-                </c:forEach>
-                <a class="pagination__item ${page ge totalPages ? 'pagination__item--disabled' : ''}"
-                   href="${page ge totalPages ? '#' : nextUrl}" aria-disabled="${page ge totalPages}">»</a>
-            </nav>
-        </c:if>
+                                    </div>
+                                    <div class="product-card__body">
+                                        <h3 class="product-card__title"><c:out value="${p.name}" /></h3>
+                                        <p class="product-card__meta">
+                                            <span><c:out value="${p.productTypeLabel}" /> • <c:out value="${p.productSubtypeLabel}" /></span>
+                                            <span>Shop: <strong><c:out value="${p.shopName}" /></strong></span>
+                                        </p>
+                                        <p class="product-card__description"><c:out value="${p.shortDescription}" /></p>
+                                        <p class="product-card__price">
+                                            <c:choose>
+                                                <c:when test="${p.minPrice eq p.maxPrice}">
+                                                    Giá
+                                                    <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                </c:when>
+                                                <c:otherwise>
+                                                    Giá từ
+                                                    <fmt:formatNumber value="${p.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                    –
+                                                    <fmt:formatNumber value="${p.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                                </c:otherwise>
+                                            </c:choose>
+                                        </p>
+                                        <ul class="product-card__meta product-card__meta--stats">
+                                            <li>Tồn kho: <strong><c:out value="${p.inventoryCount}" /></strong></li>
+                                            <li>Đã bán: <strong><c:out value="${p.soldCount}" /></strong></li>
+                                        </ul>
+                                        <div class="product-card__actions">
+                                            <a class="button button--primary" href="${cPath}/product/detail?id=${p.id}">Xem chi tiết</a>
+                                        </div>
+                                    </div>
+                                </article>
+                            </c:forEach>
+                        </div>
+                    </c:when>
+                    <c:otherwise>
+                        <div class="product-card product-card--empty">
+                            <p>Không tìm thấy sản phẩm phù hợp.</p>
+                        </div>
+                    </c:otherwise>
+                </c:choose>
+                <c:if test="${totalPages gt 1}">
+                    <nav class="pagination" aria-label="Phân trang sản phẩm">
+                        <c:url var="prevUrl" value="/products">
+                            <c:param name="page" value="${page - 1}" />
+                            <c:param name="pageSize" value="${pageSize}" />
+                            <c:if test="${not empty selectedType}">
+                                <c:param name="type" value="${selectedType}" />
+                            </c:if>
+                            <c:forEach var="code" items="${selectedSubtypes}">
+                                <c:param name="subtype" value="${code}" />
+                            </c:forEach>
+                        </c:url>
+                        <c:url var="nextUrl" value="/products">
+                            <c:param name="page" value="${page + 1}" />
+                            <c:param name="pageSize" value="${pageSize}" />
+                            <c:if test="${not empty selectedType}">
+                                <c:param name="type" value="${selectedType}" />
+                            </c:if>
+                            <c:forEach var="code" items="${selectedSubtypes}">
+                                <c:param name="subtype" value="${code}" />
+                            </c:forEach>
+                        </c:url>
+                        <span class="pagination__summary">Trang ${page} / ${totalPages}</span>
+                        <a class="pagination__item ${page le 1 ? 'pagination__item--disabled' : ''}"
+                           href="${page le 1 ? '#' : prevUrl}" aria-disabled="${page le 1}">«</a>
+                        <c:forEach var="i" begin="1" end="${totalPages}">
+                            <c:url var="pageUrl" value="/products">
+                                <c:param name="page" value="${i}" />
+                                <c:param name="pageSize" value="${pageSize}" />
+                                <c:if test="${not empty selectedType}">
+                                    <c:param name="type" value="${selectedType}" />
+                                </c:if>
+                                <c:forEach var="code" items="${selectedSubtypes}">
+                                    <c:param name="subtype" value="${code}" />
+                                </c:forEach>
+                            </c:url>
+                            <a class="pagination__item ${i == page ? 'pagination__item--active' : ''}"
+                               href="${pageUrl}">${i}</a>
+                        </c:forEach>
+                        <a class="pagination__item ${page ge totalPages ? 'pagination__item--disabled' : ''}"
+                           href="${page ge totalPages ? '#' : nextUrl}" aria-disabled="${page ge totalPages}">»</a>
+                    </nav>
+                </c:if>
+            </div>
+        </div>
     </section>
 </main>
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -76,21 +76,46 @@
           <c:if test="${not empty item['modifier']}">
             <c:set var="itemClass" value="${itemClass} ${item['modifier']}" />
           </c:if>
+          <c:choose>
+            <c:when test="${item['dropdown']}">
+              <c:set var="dropdownClass" value="${itemClass} menu__item--dropdown" />
+              <c:set var="selectedLabel" value="${empty item['selectedLabel'] ? item['text'] : item['selectedLabel']}" />
+              <div class="${dropdownClass}">
+                <button class="menu__dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">
+                  <span class="menu__text"><c:out value="${empty item['text'] ? item['label'] : item['text']}" /></span>
+                  <span class="menu__dropdown-current"><c:out value="${selectedLabel}" /></span>
+                  <span class="menu__dropdown-icon" aria-hidden="true">▾</span>
+                </button>
+                <div class="menu__dropdown-panel">
+                  <c:forEach var="child" items="${item['children']}">
+                    <c:set var="childClass" value="menu__dropdown-item" />
+                    <c:if test="${child['active']}">
+                      <c:set var="childClass" value="${childClass} menu__dropdown-item--active" />
+                    </c:if>
+                    <a class="${childClass}" href="${empty child['href'] ? '#' : child['href']}">
+                      <c:out value="${empty child['text'] ? child['label'] : child['text']}" />
+                    </a>
+                  </c:forEach>
+                </div>
+              </div>
+            </c:when>
+            <c:otherwise>
+              <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
+                <c:if test="${not empty item['icon']}">
+                  <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}" /></span>
+                </c:if>
 
-          <a class="${itemClass}" href="${empty item['href'] ? '#' : item['href']}">
-            <c:if test="${not empty item['icon']}">
-              <span class="menu__icon" aria-hidden="true"><c:out value="${item['icon']}" /></span>
-            </c:if>
+                <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}" />
+                <c:if test="${not empty textVal}">
+                  <span class="menu__text"><c:out value="${textVal}" /></span>
+                </c:if>
 
-            <c:set var="textVal" value="${empty item['text'] ? item['label'] : item['text']}" />
-            <c:if test="${not empty textVal}">
-              <span class="menu__text"><c:out value="${textVal}" /></span>
-            </c:if>
-
-            <c:if test="${not empty item['srText']}">
-              <span class="sr-only"><c:out value="${item['srText']}" /></span>
-            </c:if>
-          </a>
+                <c:if test="${not empty item['srText']}">
+                  <span class="sr-only"><c:out value="${item['srText']}" /></span>
+                </c:if>
+              </a>
+            </c:otherwise>
+          </c:choose>
         </c:forEach>
       </nav>
     </c:if>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -379,20 +379,96 @@ justify-content: space-between;
     gap: 2rem;
 }
 
-.product-list__header {
+.product-browse {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.product-browse__header {
     text-align: center;
     display: grid;
     gap: 0.4rem;
 }
 
-.product-list__header h2 {
+.product-browse__header h2 {
     margin: 0;
     font-size: clamp(1.6rem, 1.4rem + 0.8vw, 2.1rem);
 }
 
-.product-list__header p {
+.product-browse__header p {
     margin: 0;
     color: var(--text-light);
+}
+
+.product-browse__layout {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.product-browse__sidebar {
+    align-self: start;
+}
+
+.product-filter-sidebar {
+    background: var(--surface-color);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 1rem;
+}
+
+.product-filter-sidebar__title {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: var(--text-color);
+}
+
+.product-filter-sidebar__group {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.product-filter-sidebar__option {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-weight: 500;
+    color: var(--text-color);
+}
+
+.product-filter-sidebar__option input[type="checkbox"] {
+    width: 1.05rem;
+    height: 1.05rem;
+}
+
+.product-filter-sidebar__empty {
+    margin: 0;
+    color: var(--text-light);
+    font-style: italic;
+}
+
+.product-browse__results {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.product-browse__meta {
+    justify-content: space-between;
+}
+
+@media (min-width: 992px) {
+    .product-browse__layout {
+        grid-template-columns: minmax(220px, 260px) 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .product-filter-sidebar {
+        padding: 1.25rem;
+    }
 }
 
 .product-filters {
@@ -760,6 +836,10 @@ border-radius: var(--radius-sm);
     background: rgba(192, 57, 43, 0.18);
 }
 
+.button--block {
+    width: 100%;
+}
+
 /* Alerts */
 .alert {
     padding: 0.85rem 1rem;
@@ -843,6 +923,95 @@ padding: 0.6rem 1rem;
     background: var(--primary-color);
     color: #fff;
     box-shadow: 0 12px 30px rgba(0, 91, 150, 0.25);
+}
+
+.menu__item--dropdown {
+    position: relative;
+}
+
+.menu__dropdown-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.6rem 1rem;
+    border-radius: var(--radius-sm);
+    border: none;
+    background: transparent;
+    color: var(--primary-color);
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.menu__dropdown-toggle:focus {
+    outline: 2px solid rgba(0, 91, 150, 0.25);
+    outline-offset: 2px;
+}
+
+.menu__item--dropdown .menu__dropdown-toggle:hover,
+.menu__item--dropdown .menu__dropdown-toggle:focus-visible,
+.menu__item--dropdown.menu__item--active .menu__dropdown-toggle {
+    background: rgba(0, 91, 150, 0.12);
+}
+
+.menu__dropdown-current {
+    font-size: 0.8rem;
+    color: var(--text-light);
+}
+
+.menu__dropdown-icon {
+    font-size: 0.65rem;
+    color: var(--text-light);
+}
+
+.menu__dropdown-panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    left: 0;
+    min-width: 230px;
+    background: var(--surface-color);
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.18);
+    padding: 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-8px);
+    transition: var(--transition);
+    z-index: 20;
+}
+
+.menu__item--dropdown:hover .menu__dropdown-panel,
+.menu__item--dropdown:focus-within .menu__dropdown-panel {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.menu__dropdown-item {
+    display: block;
+    padding: 0.55rem 0.75rem;
+    border-radius: var(--radius-sm);
+    text-decoration: none;
+    color: var(--text-color);
+    font-weight: 500;
+    transition: var(--transition);
+}
+
+.menu__dropdown-item:hover,
+.menu__dropdown-item:focus {
+    background: rgba(0, 91, 150, 0.12);
+    color: var(--primary-color);
+}
+
+.menu__dropdown-item--active {
+    background: rgba(0, 91, 150, 0.12);
+    color: var(--primary-color);
+    font-weight: 600;
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- replace the header product link with a dropdown that loads product types dynamically and links to the filtered listing
- rework the public product list flow to require a type, accept multi-select subtype filters, and provide server-side pagination helpers
- redesign the product listing page with a sidebar filter experience and matching CSS updates

## Testing
- mvn -q -DskipTests compile *(fails: MissingProjectException – repository does not contain a Maven POM)*

------
https://chatgpt.com/codex/tasks/task_e_68fb3ba76858832083723adc47f44a44