### PR TITLE
Fix variant-aware order pricing and validation

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -79,6 +79,7 @@ public class OrderController extends BaseController {
         Integer userId = (Integer) session.getAttribute("userId");
         int productId = parsePositiveInt(request.getParameter("productId"));
         int quantity = parsePositiveInt(request.getParameter("qty"));
+        String variantCode = normalize(request.getParameter("variantCode"));
         if (userId == null || productId <= 0 || quantity <= 0) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
@@ -88,7 +89,7 @@ public class OrderController extends BaseController {
                 .filter(s -> !s.isEmpty())
                 .orElse(UUID.randomUUID().toString());
         try {
-            int orderId = orderService.placeOrderPending(userId, productId, quantity, idemKeyParam);
+            int orderId = orderService.placeOrderPending(userId, productId, quantity, variantCode, idemKeyParam);
             String redirectUrl = request.getContextPath() + "/orders/detail?id=" + orderId;
             response.sendRedirect(redirectUrl);
         } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
## Summary
- ensure the buy-now controller forwards the selected variant code when placing an order
- update the order service to price and validate orders using the chosen variant data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fde046305c8320bc125fa31ac00083