### PR TITLE
Enhance order checkout for variant-specific fulfillment

### DIFF
--- a/DB_v1.sql
+++ b/DB_v1.sql
@@ -96,6 +96,7 @@ CREATE TABLE `product_credentials` (
   `product_id` int NOT NULL,
   `order_id` int DEFAULT NULL,
   `encrypted_value` text NOT NULL,
+  `variant_code` varchar(100) DEFAULT NULL,
   `is_sold` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
@@ -159,10 +160,13 @@ CREATE TABLE `orders` (
   `id` int NOT NULL AUTO_INCREMENT,
   `buyer_id` int NOT NULL,
   `product_id` int NOT NULL,
+  `quantity` int NOT NULL DEFAULT '1',
+  `unit_price` decimal(18,4) NOT NULL,
   `payment_transaction_id` int DEFAULT NULL,
   `total_amount` decimal(18,4) NOT NULL,
   `status` enum('Pending','Processing','Completed','Failed','Refunded','Disputed') NOT NULL,
   `idempotency_key` varchar(36) DEFAULT NULL UNIQUE,
+  `variant_code` varchar(100) DEFAULT NULL,
   `hold_until` timestamp NULL DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -471,10 +475,10 @@ VALUES
  '2024-01-18 10:00:00','2024-01-28 08:00:00');
 
 -- Credentials (ví dụ ràng buộc với đơn)
-INSERT INTO `product_credentials` (`id`,`product_id`,`order_id`,`encrypted_value`,`is_sold`,`created_at`) VALUES
- (1,1001,5001,'ENCRYPTED-CODE-001',1,'2024-01-20 12:05:00'),
- (2,1001,NULL,'ENCRYPTED-CODE-002',0,'2024-01-21 10:20:00'),
- (3,1002,NULL,'ENCRYPTED-CODE-201',0,'2024-01-26 08:30:00');
+INSERT INTO `product_credentials` (`id`,`product_id`,`order_id`,`encrypted_value`,`variant_code`,`is_sold`,`created_at`) VALUES
+ (1,1001,5001,'ENCRYPTED-CODE-001','gmail-basic-1m',1,'2024-01-20 12:05:00'),
+ (2,1001,NULL,'ENCRYPTED-CODE-002','gmail-premium-12m',0,'2024-01-21 10:20:00'),
+ (3,1002,NULL,'ENCRYPTED-CODE-201','sp-12m',0,'2024-01-26 08:30:00');
 
 -- Wallets
 INSERT INTO `wallets` (`id`,`user_id`,`balance`,`status`,`created_at`,`updated_at`) VALUES
@@ -493,9 +497,9 @@ INSERT INTO `wallet_transactions` (`id`,`wallet_id`,`related_entity_id`,`transac
  (4,2,1,'Withdrawal',-120000.0000,450000.0000,330000.0000,'Rút tiền về Vietcombank','2024-01-26 09:40:00');
 
 -- Orders (ví dụ Completed + Disputed)
-INSERT INTO `orders` (`id`,`buyer_id`,`product_id`,`payment_transaction_id`,`total_amount`,`status`,`idempotency_key`,`hold_until`,`created_at`,`updated_at`) VALUES
- (5001,3,1001,2,250000.0000,'Completed','ORDER-5001-KEY','2024-01-23 12:00:00','2024-01-20 10:45:00','2024-01-20 12:05:00'),
- (5002,3,1002,NULL,185000.0000,'Disputed','ORDER-5002-KEY','2024-02-01 00:00:00','2024-01-26 09:00:00','2024-01-27 08:10:00');
+INSERT INTO `orders` (`id`,`buyer_id`,`product_id`,`quantity`,`unit_price`,`payment_transaction_id`,`total_amount`,`status`,`variant_code`,`idempotency_key`,`hold_until`,`created_at`,`updated_at`) VALUES
+ (5001,3,1001,1,250000.0000,2,250000.0000,'Completed','gmail-basic-1m','ORDER-5001-KEY','2024-01-23 12:00:00','2024-01-20 10:45:00','2024-01-20 12:05:00'),
+ (5002,3,1002,1,185000.0000,NULL,185000.0000,'Disputed','sp-12m','ORDER-5002-KEY','2024-02-01 00:00:00','2024-01-26 09:00:00','2024-01-27 08:10:00');
 
 -- Withdrawals
 INSERT INTO `withdrawal_rejection_reasons` (`id`,`reason_code`,`description`,`is_active`) VALUES

--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -79,6 +79,7 @@ public class OrderController extends BaseController {
         Integer userId = (Integer) session.getAttribute("userId");
         int productId = parsePositiveInt(request.getParameter("productId"));
         int quantity = parsePositiveInt(request.getParameter("qty"));
+        String variantCode = normalize(request.getParameter("variantCode"));
         if (userId == null || productId <= 0 || quantity <= 0) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
@@ -88,7 +89,7 @@ public class OrderController extends BaseController {
                 .filter(s -> !s.isEmpty())
                 .orElse(UUID.randomUUID().toString());
         try {
-            int orderId = orderService.placeOrderPending(userId, productId, quantity, idemKeyParam);
+            int orderId = orderService.placeOrderPending(userId, productId, quantity, variantCode, idemKeyParam);
             String redirectUrl = request.getContextPath() + "/orders/detail?id=" + orderId;
             response.sendRedirect(redirectUrl);
         } catch (IllegalArgumentException ex) {

--- a/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
@@ -19,8 +19,12 @@ public class CredentialDAO extends BaseDAO {
     private static final Logger LOGGER = Logger.getLogger(CredentialDAO.class.getName());
 
     public List<Integer> pickFreeCredentialIds(int productId, int qty) {
+        return pickFreeCredentialIds(productId, qty, null);
+    }
+
+    public List<Integer> pickFreeCredentialIds(int productId, int qty, String variantCode) {
         try (Connection connection = getConnection()) {
-            return pickFreeCredentialIds(connection, productId, qty);
+            return pickFreeCredentialIds(connection, productId, qty, variantCode);
         } catch (SQLException ex) {
             LOGGER.log(Level.SEVERE, "Không thể khóa credentials", ex);
             return List.of();
@@ -28,12 +32,26 @@ public class CredentialDAO extends BaseDAO {
     }
 
     public List<Integer> pickFreeCredentialIds(Connection connection, int productId, int qty) throws SQLException {
-        final String sql = "SELECT id FROM product_credentials WHERE product_id = ? AND is_sold = 0 "
-                + "ORDER BY id ASC LIMIT ? FOR UPDATE";
+        return pickFreeCredentialIds(connection, productId, qty, null);
+    }
+
+    public List<Integer> pickFreeCredentialIds(Connection connection, int productId, int qty, String variantCode) throws SQLException {
+        String normalized = normalizeVariantCode(variantCode);
+        StringBuilder sql = new StringBuilder("SELECT id FROM product_credentials WHERE product_id = ? AND is_sold = 0");
+        if (normalized == null) {
+            sql.append(" AND variant_code IS NULL");
+        } else {
+            sql.append(" AND LOWER(variant_code) = ?");
+        }
+        sql.append(" ORDER BY id ASC LIMIT ? FOR UPDATE");
         List<Integer> ids = new ArrayList<>();
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setInt(1, productId);
-            statement.setInt(2, qty);
+        try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            int index = 1;
+            statement.setInt(index++, productId);
+            if (normalized != null) {
+                statement.setString(index++, normalized);
+            }
+            statement.setInt(index, qty);
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
                     ids.add(rs.getInt("id"));
@@ -50,6 +68,34 @@ public class CredentialDAO extends BaseDAO {
         try (Connection connection = getConnection();
              PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, productId);
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    int total = rs.getInt("total");
+                    int available = rs.getInt("available");
+                    if (rs.wasNull()) {
+                        available = 0;
+                    }
+                    return new CredentialAvailability(total, available);
+                }
+            }
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể thống kê credential khả dụng", ex);
+        }
+        return new CredentialAvailability(0, 0);
+    }
+
+    public CredentialAvailability fetchAvailability(int productId, String variantCode) {
+        String normalized = normalizeVariantCode(variantCode);
+        if (normalized == null) {
+            return fetchAvailability(productId);
+        }
+        final String sql = "SELECT COUNT(*) AS total, "
+                + "SUM(CASE WHEN is_sold = 0 THEN 1 ELSE 0 END) AS available "
+                + "FROM product_credentials WHERE product_id = ? AND LOWER(variant_code) = ?";
+        try (Connection connection = getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, productId);
+            statement.setString(2, normalized);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {
                     int total = rs.getInt("total");
@@ -107,5 +153,16 @@ public class CredentialDAO extends BaseDAO {
     }
 
     public record CredentialAvailability(int total, int available) {
+    }
+
+    private String normalizeVariantCode(String variantCode) {
+        if (variantCode == null) {
+            return null;
+        }
+        String trimmed = variantCode.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed.toLowerCase(java.util.Locale.ROOT);
     }
 }

--- a/MMO_Trader_Market/src/java/dao/order/OrderDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/OrderDAO.java
@@ -35,19 +35,29 @@ public class OrderDAO extends BaseDAO {
      *
      * @param buyerId  mã người mua
      * @param productId mã sản phẩm
-     * @param qty       số lượng đặt mua
-     * @param total     tổng tiền
-     * @param idemKey   khóa idempotent để tránh tạo trùng
+     * @param qty         số lượng đặt mua
+     * @param unitPrice   đơn giá tại thời điểm đặt
+     * @param total       tổng tiền
+     * @param variantCode mã biến thể (có thể null)
+     * @param idemKey     khóa idempotent để tránh tạo trùng
      * @return mã đơn hàng vừa tạo
      */
-    public int createPending(int buyerId, int productId, int qty, BigDecimal total, String idemKey) {
-        final String sql = "INSERT INTO orders (buyer_id, product_id, total_amount, status, idempotency_key, created_at, updated_at) "
-                + "VALUES (?, ?, ?, 'Pending', ?, NOW(), NOW())";
+    public int createPending(int buyerId, int productId, int qty, BigDecimal unitPrice, BigDecimal total,
+            String variantCode, String idemKey) {
+        final String sql = "INSERT INTO orders (buyer_id, product_id, quantity, unit_price, total_amount, status, variant_code, idempotency_key, created_at, updated_at) "
+                + "VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, NOW(), NOW())";
         try (Connection connection = getConnection(); PreparedStatement statement = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
             statement.setInt(1, buyerId);
             statement.setInt(2, productId);
-            statement.setBigDecimal(3, total);
-            statement.setString(4, idemKey);
+            statement.setInt(3, qty);
+            statement.setBigDecimal(4, unitPrice);
+            statement.setBigDecimal(5, total);
+            if (variantCode == null || variantCode.isBlank()) {
+                statement.setNull(6, java.sql.Types.VARCHAR);
+            } else {
+                statement.setString(6, variantCode);
+            }
+            statement.setString(7, idemKey);
             statement.executeUpdate();
             try (ResultSet keys = statement.getGeneratedKeys()) {
                 if (keys.next()) {
@@ -68,8 +78,8 @@ public class OrderDAO extends BaseDAO {
      * @return thông tin đơn kèm sản phẩm nếu tìm thấy
      */
     public Optional<OrderDetailView> findByIdForUser(int orderId, int userId) {
-        final String sql = "SELECT o.id, o.buyer_id, o.product_id, o.total_amount, o.status, o.created_at, o.updated_at, "
-                + "o.payment_transaction_id, o.idempotency_key, o.hold_until, "
+        final String sql = "SELECT o.id, o.buyer_id, o.product_id, o.quantity, o.unit_price, o.total_amount, o.status, "
+                + "o.created_at, o.updated_at, o.payment_transaction_id, o.idempotency_key, o.hold_until, o.variant_code, "
                 + "p.id AS p_id, p.shop_id, p.product_type AS p_product_type, p.product_subtype AS p_product_subtype, "
                 + "p.name, p.short_description AS p_short_description, p.description, p.price, p.primary_image_url AS p_primary_image_url, "
                 + "p.gallery_json AS p_gallery_json, p.inventory_count, p.sold_count AS p_sold_count, p.status AS p_status, "
@@ -142,8 +152,8 @@ public class OrderDAO extends BaseDAO {
      * @return {@link Optional} chứa đơn hàng nếu tồn tại
      */
     public Optional<Orders> findById(int orderId) {
-        final String sql = "SELECT id, buyer_id, product_id, payment_transaction_id, total_amount, status, idempotency_key, "
-                + "hold_until, created_at, updated_at FROM orders WHERE id = ? LIMIT 1";
+        final String sql = "SELECT id, buyer_id, product_id, quantity, unit_price, payment_transaction_id, total_amount, status, "
+                + "variant_code, idempotency_key, hold_until, created_at, updated_at FROM orders WHERE id = ? LIMIT 1";
         try (Connection connection = getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, orderId);
             try (ResultSet rs = statement.executeQuery()) {
@@ -164,8 +174,8 @@ public class OrderDAO extends BaseDAO {
      * @return {@link Optional} chứa đơn hàng nếu có
      */
     public Optional<Orders> findByIdemKey(String idemKey) {
-        final String sql = "SELECT id, buyer_id, product_id, payment_transaction_id, total_amount, status, idempotency_key, "
-                + "hold_until, created_at, updated_at FROM orders WHERE idempotency_key = ? LIMIT 1";
+        final String sql = "SELECT id, buyer_id, product_id, quantity, unit_price, payment_transaction_id, total_amount, status, "
+                + "variant_code, idempotency_key, hold_until, created_at, updated_at FROM orders WHERE idempotency_key = ? LIMIT 1";
         try (Connection connection = getConnection(); PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, idemKey);
             try (ResultSet rs = statement.executeQuery()) {
@@ -381,10 +391,14 @@ public class OrderDAO extends BaseDAO {
         order.setId(rs.getInt("id"));
         order.setBuyerId(rs.getInt("buyer_id"));
         order.setProductId(rs.getInt("product_id"));
+        int qty = rs.getInt("quantity");
+        order.setQuantity(rs.wasNull() ? null : qty);
+        order.setUnitPrice(rs.getBigDecimal("unit_price"));
         order.setPaymentTransactionId(rs.getObject("payment_transaction_id") == null
                 ? null : rs.getInt("payment_transaction_id"));
         order.setTotalAmount(rs.getBigDecimal("total_amount"));
         order.setStatus(rs.getString("status"));
+        order.setVariantCode(rs.getString("variant_code"));
         order.setIdempotencyKey(rs.getString("idempotency_key"));
         order.setHoldUntil(rs.getTimestamp("hold_until"));
         order.setCreatedAt(rs.getTimestamp("created_at"));

--- a/MMO_Trader_Market/src/java/dao/product/ProductDAO.java
+++ b/MMO_Trader_Market/src/java/dao/product/ProductDAO.java
@@ -385,16 +385,37 @@ public class ProductDAO extends BaseDAO {
      * @throws SQLException khi truy vấn lỗi
      */
     public int lockInventoryForUpdate(Connection connection, int productId) throws SQLException {
-        final String sql = "SELECT inventory_count FROM products WHERE id = ? FOR UPDATE";
+        ProductInventoryLock lock = lockProductForUpdate(connection, productId);
+        return lock.inventoryCount() == null ? 0 : lock.inventoryCount();
+    }
+
+    public ProductInventoryLock lockProductForUpdate(Connection connection, int productId) throws SQLException {
+        final String sql = "SELECT inventory_count, variant_schema, variants_json FROM products WHERE id = ? FOR UPDATE";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, productId);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {
-                    return rs.getInt("inventory_count");
+                    Integer inventory = (Integer) rs.getObject("inventory_count");
+                    String schema = rs.getString("variant_schema");
+                    String variants = rs.getString("variants_json");
+                    return new ProductInventoryLock(inventory, schema, variants);
                 }
             }
         }
-        return 0;
+        return new ProductInventoryLock(0, null, null);
+    }
+
+    public void updateVariantsJson(Connection connection, int productId, String variantsJson) throws SQLException {
+        final String sql = "UPDATE products SET variants_json = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            if (variantsJson == null) {
+                statement.setNull(1, java.sql.Types.VARCHAR);
+            } else {
+                statement.setString(1, variantsJson);
+            }
+            statement.setInt(2, productId);
+            statement.executeUpdate();
+        }
     }
 
     /**
@@ -628,6 +649,9 @@ public class ProductDAO extends BaseDAO {
             product.setUpdatedAt(new java.util.Date(updatedAt.getTime()));
         }
         return product;
+    }
+
+    public record ProductInventoryLock(Integer inventoryCount, String variantSchema, String variantsJson) {
     }
 }
 

--- a/MMO_Trader_Market/src/java/model/Orders.java
+++ b/MMO_Trader_Market/src/java/model/Orders.java
@@ -13,6 +13,12 @@ public class Orders {
 
     private Integer paymentTransactionId;
 
+    private Integer quantity;
+
+    private BigDecimal unitPrice;
+
+    private String variantCode;
+
     private BigDecimal totalAmount;
 
     private String status;
@@ -55,6 +61,30 @@ public class Orders {
 
     public void setPaymentTransactionId(Integer paymentTransactionId) {
         this.paymentTransactionId = paymentTransactionId;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public BigDecimal getUnitPrice() {
+        return unitPrice;
+    }
+
+    public void setUnitPrice(BigDecimal unitPrice) {
+        this.unitPrice = unitPrice;
+    }
+
+    public String getVariantCode() {
+        return variantCode;
+    }
+
+    public void setVariantCode(String variantCode) {
+        this.variantCode = variantCode;
     }
     public BigDecimal getTotalAmount() {
         return totalAmount;

--- a/MMO_Trader_Market/src/java/model/product/ProductVariantOption.java
+++ b/MMO_Trader_Market/src/java/model/product/ProductVariantOption.java
@@ -47,8 +47,16 @@ public class ProductVariantOption {
         return inventoryCount;
     }
 
+    public void setInventoryCount(Integer inventoryCount) {
+        this.inventoryCount = inventoryCount;
+    }
+
     public String getStatus() {
         return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 
     public boolean isAvailable() {

--- a/MMO_Trader_Market/src/java/queue/OrderMessage.java
+++ b/MMO_Trader_Market/src/java/queue/OrderMessage.java
@@ -3,5 +3,5 @@ package queue;
 /**
  * Immutable message describing an order to be processed asynchronously.
  */
-public record OrderMessage(int orderId, String idempotencyKey, int productId, int qty) {
+public record OrderMessage(int orderId, String idempotencyKey, int productId, int qty, String variantCode) {
 }

--- a/MMO_Trader_Market/src/java/queue/OrderQueueProducer.java
+++ b/MMO_Trader_Market/src/java/queue/OrderQueueProducer.java
@@ -1,5 +1,5 @@
 package queue;
 
 public interface OrderQueueProducer {
-    void publish(int orderId, String idemKey, int productId, int qty);
+    void publish(int orderId, String idemKey, int productId, int qty, String variantCode);
 }

--- a/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
+++ b/MMO_Trader_Market/src/java/queue/memory/InMemoryOrderQueue.java
@@ -54,8 +54,8 @@ public final class InMemoryOrderQueue implements OrderQueueProducer {
     }
 
     @Override
-    public void publish(int orderId, String idemKey, int productId, int qty) {
-        queue.offer(new OrderMessage(orderId, idemKey, productId, qty));
+    public void publish(int orderId, String idemKey, int productId, int qty, String variantCode) {
+        queue.offer(new OrderMessage(orderId, idemKey, productId, qty, variantCode));
     }
 
     private void dispatchLoop() {

--- a/MMO_Trader_Market/src/java/service/util/ProductVariantUtils.java
+++ b/MMO_Trader_Market/src/java/service/util/ProductVariantUtils.java
@@ -1,0 +1,118 @@
+package service.util;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import model.Products;
+import model.product.ProductVariantOption;
+
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Utility helpers for working with product variants stored as JSON definitions.
+ */
+public final class ProductVariantUtils {
+
+    private static final Gson GSON = new Gson();
+    private static final Type VARIANT_LIST_TYPE = new TypeToken<List<ProductVariantOption>>() { }.getType();
+
+    private ProductVariantUtils() {
+    }
+
+    public static String normalizeCode(String variantCode) {
+        if (variantCode == null) {
+            return null;
+        }
+        String trimmed = variantCode.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        return trimmed.toLowerCase(Locale.ROOT);
+    }
+
+    public static boolean hasVariants(String variantSchema) {
+        return variantSchema != null && !"NONE".equalsIgnoreCase(variantSchema);
+    }
+
+    public static List<ProductVariantOption> parseVariants(String variantSchema, String variantsJson) {
+        if (!hasVariants(variantSchema) || variantsJson == null || variantsJson.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<ProductVariantOption> variants = GSON.fromJson(variantsJson, VARIANT_LIST_TYPE);
+            if (variants == null || variants.isEmpty()) {
+                return Collections.emptyList();
+            }
+            List<ProductVariantOption> cleaned = new ArrayList<>();
+            for (ProductVariantOption option : variants) {
+                if (option != null && option.getVariantCode() != null && !option.getVariantCode().isBlank()) {
+                    cleaned.add(option);
+                }
+            }
+            return cleaned;
+        } catch (JsonSyntaxException ex) {
+            return Collections.emptyList();
+        }
+    }
+
+    public static Optional<ProductVariantOption> findVariant(List<ProductVariantOption> variants, String normalizedCode) {
+        if (normalizedCode == null || variants == null || variants.isEmpty()) {
+            return Optional.empty();
+        }
+        return variants.stream()
+                .filter(Objects::nonNull)
+                .filter(variant -> {
+                    String code = variant.getVariantCode();
+                    if (code == null) {
+                        return false;
+                    }
+                    return normalizedCode.equalsIgnoreCase(code.trim());
+                })
+                .findFirst();
+    }
+
+    public static BigDecimal resolveUnitPrice(Products product, Optional<ProductVariantOption> variantOpt) {
+        if (variantOpt.isPresent()) {
+            BigDecimal price = variantOpt.get().getPrice();
+            if (price == null) {
+                throw new IllegalArgumentException("Không thể xác định giá sản phẩm.");
+            }
+            return price;
+        }
+        BigDecimal basePrice = product.getPrice();
+        if (basePrice == null) {
+            throw new IllegalArgumentException("Không thể xác định giá sản phẩm.");
+        }
+        return basePrice;
+    }
+
+    public static void decreaseInventory(ProductVariantOption variant, int quantity) {
+        if (variant == null || quantity <= 0) {
+            return;
+        }
+        Integer current = variant.getInventoryCount();
+        if (current == null) {
+            throw new IllegalStateException("Biến thể sản phẩm không đủ tồn kho.");
+        }
+        if (current < quantity) {
+            throw new IllegalStateException("Biến thể sản phẩm không đủ tồn kho.");
+        }
+        int remaining = current - quantity;
+        variant.setInventoryCount(Math.max(remaining, 0));
+    }
+
+    public static String toJson(List<ProductVariantOption> variants) {
+        if (variants == null || variants.isEmpty()) {
+            return "[]";
+        }
+        return GSON.toJson(variants, VARIANT_LIST_TYPE);
+    }
+}
+

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -16,6 +16,17 @@
                     <ul class="definition-list">
                         <li><span>Mã đơn:</span> #<c:out value="${order.id}" /></li>
                         <li><span>Sản phẩm:</span> <c:out value="${product.name}" /></li>
+                        <c:if test="${not empty order.variantCode}">
+                            <li><span>Biến thể:</span> <c:out value="${order.variantCode}" /></li>
+                        </c:if>
+                        <c:if test="${order.quantity ne null}">
+                            <li><span>Số lượng:</span> <c:out value="${order.quantity}" /></li>
+                        </c:if>
+                        <c:if test="${order.unitPrice ne null}">
+                            <li><span>Đơn giá:</span>
+                                <fmt:formatNumber value="${order.unitPrice}" type="currency" currencySymbol="" /> đ
+                            </li>
+                        </c:if>
                         <li><span>Tổng tiền:</span>
                             <fmt:formatNumber value="${order.totalAmount}" type="currency" currencySymbol="" /> đ
                         </li>


### PR DESCRIPTION
## Summary
- add variant-aware pricing, inventory validation, and metadata storage during order placement
- filter credentials and queue messages by variant and update worker logic to adjust per-variant availability
- extend schema/models for quantity, unit price, and variant code while surfacing variant details in order views

## Testing
- not run (ant unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68fde046305c8320bc125fa31ac00083