### PR TITLE
Improve product search filters and FAQ navigation

### DIFF
--- a/MMO_Trader_Market/src/java/controller/guide/FaqController.java
+++ b/MMO_Trader_Market/src/java/controller/guide/FaqController.java
@@ -1,0 +1,25 @@
+package controller.guide;
+
+import controller.BaseController;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+/**
+ * Renders the standalone FAQ page with the existing JSP content.
+ */
+@WebServlet(name = "FaqController", urlPatterns = {"/faq"})
+public class FaqController extends BaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute("pageTitle", "Câu hỏi thường gặp");
+        forward(request, response, "faq");
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/product/ProductListController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductListController.java
@@ -57,11 +57,18 @@ public class ProductListController extends BaseController {
         int page = parsePositiveIntOrDefault(request.getParameter("page"), DEFAULT_PAGE);
         int size = parsePositiveIntOrDefault(resolveSizeParam(request), DEFAULT_SIZE);
 
+        String rawKeyword = request.getParameter("keyword");
+        String normalizedKeyword = rawKeyword == null ? null : rawKeyword.trim();
+        if (normalizedKeyword != null && normalizedKeyword.isBlank()) {
+            normalizedKeyword = null;
+        }
+
         List<String> subtypeFilters = productService.normalizeSubtypeCodes(normalizedType,
                 request.getParameterValues("subtype"));
         Set<String> selectedSubtypeSet = new LinkedHashSet<>(subtypeFilters);
 
-        PagedResult<ProductSummaryView> result = productService.browseByType(normalizedType, subtypeFilters, page, size);
+        PagedResult<ProductSummaryView> result = productService.browseByType(normalizedType, subtypeFilters,
+                normalizedKeyword, page, size);
         List<ProductSubtypeOption> subtypeOptions = productService.getSubtypeOptions(normalizedType);
         String currentTypeLabel = typeOptions.stream()
                 .filter(option -> option.getCode().equals(normalizedType))
@@ -78,6 +85,7 @@ public class ProductListController extends BaseController {
         request.setAttribute("totalPages", result.getTotalPages());
         request.setAttribute("selectedType", normalizedType);
         request.setAttribute("selectedSubtypes", selectedSubtypeSet);
+        request.setAttribute("keyword", normalizedKeyword == null ? "" : normalizedKeyword);
         request.setAttribute("typeOptions", typeOptions);
         request.setAttribute("subtypeOptions", subtypeOptions);
         request.setAttribute("currentTypeLabel", currentTypeLabel);

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -74,7 +74,7 @@ public final class NavigationBuilder {
         } else {
             items.add(createNavItem(contextPath + "/products", "Sản phẩm", isActive(currentPath, "/products")));
         }
-        items.add(createNavItem(contextPath + "/home#faq", "FAQ", false));
+        items.add(createNavItem(contextPath + "/faq", "FAQ", isActive(currentPath, "/faq")));
     }
 
     private static Map<String, Object> createNavItem(String href, String text, boolean active) {

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -90,8 +90,8 @@
                 </c:when>
                 <c:otherwise>
                     <c:forEach var="product" items="${featuredProducts}">
-                        <article class="product-card product-card--featured">
-                            <div class="product-card__image">
+                        <article class="product-card product-card--featured product-card--grid">
+                            <div class="product-card__image product-card__media">
                                 <c:choose>
                                     <c:when test="${not empty product.primaryImageUrl}">
                                         <c:set var="featuredImageSource" value="${product.primaryImageUrl}" />
@@ -107,14 +107,14 @@
                                                 <c:url var="featuredImageUrl" value="${featuredImageSource}" />
                                             </c:otherwise>
                                         </c:choose>
-                                        <img src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
+                                        <img class="product-card__img" src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
                                     </c:when>
                                     <c:otherwise>
                                         <div class="product-card__placeholder">Không có ảnh</div>
                                     </c:otherwise>
                                 </c:choose>
                             </div>
-                            <div class="product-card__body">
+                            <div class="product-card__body product-card__body--stack">
                                 <header class="product-card__header">
                                     <h4><c:out value="${product.name}" /></h4>
                                 </header>
@@ -145,7 +145,9 @@
                                     <c:url var="detailUrl" value="/product/detail">
                                         <c:param name="id" value="${product.id}" />
                                     </c:url>
-                                    <a class="button button--primary" href="${detailUrl}">Xem chi tiết</a>
+                                    <div class="product-card__actions product-card__actions--justify">
+                                        <a class="button button--primary product-card__cta" href="${detailUrl}">Xem chi tiết</a>
+                                    </div>
                                 </footer>
                             </div>
                         </article>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -5,7 +5,7 @@
 <fmt:setLocale value="vi_VN" scope="request" />
 <c:set var="cPath" value="${pageContext.request.contextPath}" />
 <c:set var="type" value="${not empty param.type ? param.type : (not empty selectedType ? selectedType : '')}" />
-<c:set var="keyword" value="${not empty param.keyword ? param.keyword : (not empty keyword ? keyword : '')}" />
+<c:set var="keyword" value="${not empty requestScope.keyword ? requestScope.keyword : (not empty param.keyword ? param.keyword : '')}" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content">
@@ -140,13 +140,13 @@
                     </c:if>
                     <nav class="pagination">
                         <a class="page-btn ${page==1?'disabled':''}"
-                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&page=${page==1 ? page : page-1}">&laquo;</a>
+                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${page==1 ? page : page-1}">&laquo;</a>
                         <c:forEach var="p" begin="1" end="${totalPages}">
                             <a class="page-num ${p==page?'active':''}"
-                               href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&page=${p}">${p}</a>
+                               href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${p}">${p}</a>
                         </c:forEach>
                         <a class="page-btn ${page==totalPages?'disabled':''}"
-                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&page=${page==totalPages ? page : page+1}">&raquo;</a>
+                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${page==totalPages ? page : page+1}">&raquo;</a>
                     </nav>
                 </c:if>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated /faq controller so the navigation entry opens the FAQ page directly
- unify featured product card markup with the list grid so media, CTA, and layout stay consistent
- extend product browsing to support keyword filtering across name, description, and shop, return dynamic subtype options, and keep filter params in pagination links

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68fe022517a483208d3790616e36bb25