### PR TITLE
Remove obsolete variant parsing helpers from OrderService

### DIFF
--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -1,8 +1,5 @@
 package service;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 import dao.order.CredentialDAO;
 import dao.order.OrderDAO;
 import dao.product.ProductDAO;
@@ -20,12 +17,9 @@ import queue.OrderQueueProducer;
 import queue.memory.InMemoryOrderQueue;
 import service.util.ProductVariantUtils;
 
-import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -218,55 +212,6 @@ public class OrderService {
     private boolean isOrderActive(String status) {
         OrderStatus orderStatus = OrderStatus.fromDatabaseValue(status);
         return orderStatus == OrderStatus.PENDING || orderStatus == OrderStatus.PROCESSING;
-    }
-
-    private Optional<ProductVariantOption> findVariantOption(Products product, String variantCode) {
-        List<ProductVariantOption> variants = parseVariants(product.getVariantSchema(), product.getVariantsJson());
-        if (variants.isEmpty()) {
-            return Optional.empty();
-        }
-        String target = variantCode.toLowerCase(Locale.ROOT);
-        return variants.stream()
-                .filter(Objects::nonNull)
-                .filter(ProductVariantOption::isAvailable)
-                .filter(variant -> {
-                    String code = variant.getVariantCode();
-                    return code != null && code.toLowerCase(Locale.ROOT).equals(target);
-                })
-                .findFirst();
-    }
-
-    private List<ProductVariantOption> parseVariants(String variantSchema, String variantsJson) {
-        if (!hasVariants(variantSchema) || variantsJson == null || variantsJson.isBlank()) {
-            return List.of();
-        }
-        try {
-            List<ProductVariantOption> variants = gson.fromJson(variantsJson, variantListType);
-            if (variants == null || variants.isEmpty()) {
-                return List.of();
-            }
-            List<ProductVariantOption> normalized = new ArrayList<>();
-            for (ProductVariantOption option : variants) {
-                if (option != null) {
-                    normalized.add(option);
-                }
-            }
-            return List.copyOf(normalized);
-        } catch (JsonSyntaxException ex) {
-            return List.of();
-        }
-    }
-
-    private boolean hasVariants(String variantSchema) {
-        return variantSchema != null && !"NONE".equalsIgnoreCase(variantSchema);
-    }
-
-    private String normalizeVariantCode(String variantCode) {
-        if (variantCode == null) {
-            return null;
-        }
-        String trimmed = variantCode.trim();
-        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private static Map<OrderStatus, String> buildStatusLabels() {


### PR DESCRIPTION
## Summary
- remove unused JSON parsing helpers from OrderService that referenced undefined Gson instances
- clean up redundant imports now that ProductVariantUtils handles variant parsing

## Testing
- ant clean dist *(fails: `ant` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fdfb1867788320abe526461f5bbbb6