### PR TITLE
Add servlet listener to clean up MySQL resources on shutdown

### DIFF
--- a/MMO_Trader_Market/src/java/listener/ApplicationShutdownListener.java
+++ b/MMO_Trader_Market/src/java/listener/ApplicationShutdownListener.java
@@ -1,0 +1,50 @@
+package listener;
+
+import com.mysql.cj.jdbc.AbandonedConnectionCleanupThread;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Enumeration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Ensures JDBC resources that are registered by the application are
+ * released when the web application is stopped to prevent memory leaks.
+ */
+@WebListener
+public class ApplicationShutdownListener implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(ApplicationShutdownListener.class.getName());
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        shutdownAbandonedCleanupThread();
+        deregisterJdbcDrivers();
+    }
+
+    private void shutdownAbandonedCleanupThread() {
+        try {
+            AbandonedConnectionCleanupThread.checkedShutdown();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            LOGGER.log(Level.WARNING, "Interrupted while shutting down MySQL abandoned connection cleanup thread", ex);
+        }
+    }
+
+    private void deregisterJdbcDrivers() {
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            try {
+                DriverManager.deregisterDriver(driver);
+                LOGGER.log(Level.FINE, "Deregistered JDBC driver {0}", driver);
+            } catch (SQLException ex) {
+                LOGGER.log(Level.WARNING, "Unable to deregister JDBC driver " + driver, ex);
+            }
+        }
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/web.xml
+++ b/MMO_Trader_Market/web/WEB-INF/web.xml
@@ -10,4 +10,8 @@
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>
     </welcome-file-list>
+
+    <listener>
+        <listener-class>listener.ApplicationShutdownListener</listener-class>
+    </listener>
 </web-app>


### PR DESCRIPTION
## Summary
- add a ServletContextListener that stops the MySQL abandoned connection cleanup thread and deregisters JDBC drivers when the app stops
- register the listener in web.xml so the cleanup runs during application shutdown

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68fe0e9fa0248320b7010de5a2b1ec61