### PR TITLE
Auto-seed credentials and show post-payment prompt

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -131,7 +131,7 @@ public class OrderController extends BaseController {
                 .orElse(UUID.randomUUID().toString());
         try {
             int orderId = orderService.placeOrderPending(userId, productId, quantity, variantCode, idemKeyParam);
-            String redirectUrl = request.getContextPath() + "/orders/detail?id=" + orderId;
+            String redirectUrl = request.getContextPath() + "/orders/detail?id=" + orderId + "&processing=1";
             response.sendRedirect(redirectUrl);
         } catch (IllegalArgumentException ex) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
@@ -222,6 +222,8 @@ public class OrderController extends BaseController {
         request.setAttribute("product", product);
         request.setAttribute("credentials", credentials);
         request.setAttribute("statusLabel", orderService.getStatusLabel(order.getStatus()));
+        boolean showProcessingModal = "1".equals(request.getParameter("processing"));
+        request.setAttribute("showProcessingModal", showProcessingModal);
 
         forward(request, response, "order/detail");
     }

--- a/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
@@ -2,12 +2,15 @@ package dao.order;
 
 import dao.BaseDAO;
 
+import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -17,6 +20,9 @@ import java.util.logging.Logger;
 public class CredentialDAO extends BaseDAO {
 
     private static final Logger LOGGER = Logger.getLogger(CredentialDAO.class.getName());
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final char[] ALPHANUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final char[] PASSWORD_SYMBOLS = "!@#$%&*-_".toCharArray();
 
     public List<Integer> pickFreeCredentialIds(int productId, int qty) {
         return pickFreeCredentialIds(productId, qty, null);
@@ -37,11 +43,12 @@ public class CredentialDAO extends BaseDAO {
 
     public List<Integer> pickFreeCredentialIds(Connection connection, int productId, int qty, String variantCode) throws SQLException {
         String normalized = normalizeVariantCode(variantCode);
+        // Các bản ghi cũ có thể lưu trữ variant_code rỗng thay vì NULL nên cần gom về chung điều kiện.
         StringBuilder sql = new StringBuilder("SELECT id FROM product_credentials WHERE product_id = ? AND is_sold = 0");
         if (normalized == null) {
-            sql.append(" AND variant_code IS NULL");
+            sql.append(" AND (variant_code IS NULL OR TRIM(variant_code) = '')");
         } else {
-            sql.append(" AND LOWER(variant_code) = ?");
+            sql.append(" AND LOWER(TRIM(variant_code)) = ?");
         }
         sql.append(" ORDER BY id ASC LIMIT ? FOR UPDATE");
         List<Integer> ids = new ArrayList<>();
@@ -62,22 +69,8 @@ public class CredentialDAO extends BaseDAO {
     }
 
     public CredentialAvailability fetchAvailability(int productId) {
-        final String sql = "SELECT COUNT(*) AS total, "
-                + "SUM(CASE WHEN is_sold = 0 THEN 1 ELSE 0 END) AS available "
-                + "FROM product_credentials WHERE product_id = ?";
-        try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.setInt(1, productId);
-            try (ResultSet rs = statement.executeQuery()) {
-                if (rs.next()) {
-                    int total = rs.getInt("total");
-                    int available = rs.getInt("available");
-                    if (rs.wasNull()) {
-                        available = 0;
-                    }
-                    return new CredentialAvailability(total, available);
-                }
-            }
+        try (Connection connection = getConnection()) {
+            return fetchAvailability(connection, productId);
         } catch (SQLException ex) {
             LOGGER.log(Level.SEVERE, "Không thể thống kê credential khả dụng", ex);
         }
@@ -89,13 +82,20 @@ public class CredentialDAO extends BaseDAO {
         if (normalized == null) {
             return fetchAvailability(productId);
         }
+        try (Connection connection = getConnection()) {
+            return fetchAvailabilityForVariant(connection, productId, normalized);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể thống kê credential khả dụng", ex);
+        }
+        return new CredentialAvailability(0, 0);
+    }
+
+    public CredentialAvailability fetchAvailability(Connection connection, int productId) throws SQLException {
         final String sql = "SELECT COUNT(*) AS total, "
                 + "SUM(CASE WHEN is_sold = 0 THEN 1 ELSE 0 END) AS available "
-                + "FROM product_credentials WHERE product_id = ? AND LOWER(variant_code) = ?";
-        try (Connection connection = getConnection();
-             PreparedStatement statement = connection.prepareStatement(sql)) {
+                + "FROM product_credentials WHERE product_id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setInt(1, productId);
-            statement.setString(2, normalized);
             try (ResultSet rs = statement.executeQuery()) {
                 if (rs.next()) {
                     int total = rs.getInt("total");
@@ -106,8 +106,37 @@ public class CredentialDAO extends BaseDAO {
                     return new CredentialAvailability(total, available);
                 }
             }
-        } catch (SQLException ex) {
-            LOGGER.log(Level.SEVERE, "Không thể thống kê credential khả dụng", ex);
+        }
+        return new CredentialAvailability(0, 0);
+    }
+
+    public CredentialAvailability fetchAvailabilityForVariant(Connection connection, int productId, String variantCode)
+            throws SQLException {
+        String normalized = normalizeVariantCode(variantCode);
+        StringBuilder sql = new StringBuilder("SELECT COUNT(*) AS total, "
+                + "SUM(CASE WHEN is_sold = 0 THEN 1 ELSE 0 END) AS available "
+                + "FROM product_credentials WHERE product_id = ?");
+        boolean filterDefaultVariant = normalized == null;
+        if (filterDefaultVariant) {
+            sql.append(" AND (variant_code IS NULL OR TRIM(variant_code) = '')");
+        } else {
+            sql.append(" AND LOWER(TRIM(variant_code)) = ?");
+        }
+        try (PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            statement.setInt(1, productId);
+            if (!filterDefaultVariant) {
+                statement.setString(2, normalized);
+            }
+            try (ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    int total = rs.getInt("total");
+                    int available = rs.getInt("available");
+                    if (rs.wasNull()) {
+                        available = 0;
+                    }
+                    return new CredentialAvailability(total, available);
+                }
+            }
         }
         return new CredentialAvailability(0, 0);
     }
@@ -155,6 +184,35 @@ public class CredentialDAO extends BaseDAO {
     public record CredentialAvailability(int total, int available) {
     }
 
+    /**
+     * Sinh thêm credential ảo cho sản phẩm/biến thể để bảo đảm mỗi đơn vị hàng hóa đều có dữ liệu bàn giao riêng biệt.
+     */
+    public void generateFakeCredentials(Connection connection, int productId, String variantCode, int quantity)
+            throws SQLException {
+        if (quantity <= 0) {
+            return;
+        }
+        String normalized = normalizeVariantCode(variantCode);
+        final String sql = "INSERT INTO product_credentials (product_id, encrypted_value, variant_code, is_sold) "
+                + "VALUES (?, ?, ?, 0)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (int i = 0; i < quantity; i++) {
+                statement.setInt(1, productId);
+                statement.setString(2, buildFakeCredentialPayload(productId, normalized));
+                if (normalized == null) {
+                    statement.setNull(3, Types.VARCHAR);
+                } else {
+                    statement.setString(3, normalized);
+                }
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+        LOGGER.log(Level.INFO,
+                "Sinh thêm {0} credential ảo cho sản phẩm {1}{2}",
+                new Object[]{quantity, productId, normalized == null ? "" : " - biến thể " + normalized});
+    }
+
     private String normalizeVariantCode(String variantCode) {
         if (variantCode == null) {
             return null;
@@ -163,6 +221,30 @@ public class CredentialDAO extends BaseDAO {
         if (trimmed.isEmpty()) {
             return null;
         }
-        return trimmed.toLowerCase(java.util.Locale.ROOT);
+        return trimmed.toLowerCase(Locale.ROOT);
+    }
+
+    private String buildFakeCredentialPayload(int productId, String normalizedVariantCode) {
+        String variantSlug = normalizedVariantCode == null ? "prod" + productId
+                : normalizedVariantCode.replaceAll("[^a-z0-9]", "");
+        if (variantSlug.isEmpty()) {
+            variantSlug = "prod" + productId;
+        }
+        String usernameSuffix = randomAlphaNumeric(6).toLowerCase(Locale.ROOT);
+        String username = variantSlug + "_" + usernameSuffix;
+        String password = randomAlphaNumeric(8) + randomPasswordSymbol() + randomAlphaNumeric(6);
+        return String.format(Locale.ROOT, "{\"username\":\"%s\",\"password\":\"%s\"}", username, password);
+    }
+
+    private String randomAlphaNumeric(int length) {
+        StringBuilder builder = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            builder.append(ALPHANUMERIC[RANDOM.nextInt(ALPHANUMERIC.length)]);
+        }
+        return builder.toString();
+    }
+
+    private char randomPasswordSymbol() {
+        return PASSWORD_SYMBOLS[RANDOM.nextInt(PASSWORD_SYMBOLS.length)];
     }
 }

--- a/MMO_Trader_Market/src/java/queue/memory/AsyncOrderWorker.java
+++ b/MMO_Trader_Market/src/java/queue/memory/AsyncOrderWorker.java
@@ -57,6 +57,10 @@ public class AsyncOrderWorker implements OrderWorker {
             try {
                 processMessage(msg);
                 return;
+            } catch (OrderProcessingException ex) {
+                LOGGER.log(ex.level(), "Đơn hàng {0} thất bại: {1}", new Object[]{msg.orderId(), ex.getMessage()});
+                LOGGER.log(Level.FINE, "Chi tiết ngoại lệ khi xử lý đơn hàng " + msg.orderId(), ex);
+                return;
             } catch (SQLException ex) {
                 LOGGER.log(Level.WARNING, "Lỗi xử lý đơn hàng {0} ở lần thử {1}", new Object[]{msg.orderId(), attempt + 1});
                 if (attempt >= RETRY_DELAYS.length - 1) {
@@ -85,90 +89,19 @@ public class AsyncOrderWorker implements OrderWorker {
         try (Connection connection = orderDAO.openConnection()) {
             connection.setAutoCommit(false);
             try {
+                OrderProcessingContext context = new OrderProcessingContext(msg, order);
                 // B1: Đánh dấu đơn hàng đang xử lý để đảm bảo các worker khác không xử lý trùng.
                 orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.PROCESSING);
-                // B2: Khóa ví của người mua ở mức hàng (SELECT ... FOR UPDATE) để cố định số dư.
-                Wallets wallet = walletsDAO.lockWalletForUpdate(connection, order.getBuyerId());
-                if (wallet == null || Boolean.FALSE.equals(wallet.getStatus())) {
-                    LOGGER.log(Level.WARNING, "Ví của người dùng {0} không khả dụng", order.getBuyerId());
-                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                    connection.commit();
-                    return;
-                }
-                BigDecimal totalAmount = order.getTotalAmount();
-                if (totalAmount == null) {
-                    LOGGER.log(Level.SEVERE, "Đơn hàng {0} thiếu thông tin tổng tiền", order.getId());
-                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                    connection.commit();
-                    return;
-                }
-                BigDecimal balanceBefore = wallet.getBalance() == null ? BigDecimal.ZERO : wallet.getBalance();
-                if (balanceBefore.compareTo(totalAmount) < 0) {
-                    LOGGER.log(Level.INFO, "Ví người dùng {0} không đủ số dư cho đơn {1}",
-                            new Object[]{order.getBuyerId(), order.getId()});
-                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                    connection.commit();
-                    return;
-                }
-                // B3: Khóa tồn kho sản phẩm và credential để đảm bảo đủ hàng bàn giao.
-                String variantCode = msg.variantCode();
-                if (variantCode == null || variantCode.isBlank()) {
-                    variantCode = order.getVariantCode();
-                }
-                ProductDAO.ProductInventoryLock lockedProduct = productDAO.lockProductForUpdate(connection, msg.productId());
-                int inventory = lockedProduct.inventoryCount() == null ? 0 : lockedProduct.inventoryCount();
-                if (inventory < msg.qty()) {
-                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                    connection.commit();
-                    return;
-                }
-                List<ProductVariantOption> variants = ProductVariantUtils.parseVariants(
-                        lockedProduct.variantSchema(), lockedProduct.variantsJson());
-                ProductVariantOption variant = null;
-                if (variantCode != null && !variantCode.isBlank()) {
-                    String normalized = ProductVariantUtils.normalizeCode(variantCode);
-                    Optional<ProductVariantOption> variantOpt = ProductVariantUtils.findVariant(variants, normalized);
-                    if (variantOpt.isEmpty() || !variantOpt.get().isAvailable()) {
-                        orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                        connection.commit();
-                        return;
-                    }
-                    variant = variantOpt.get();
-                    Integer variantInventory = variant.getInventoryCount();
-                    if (variantInventory == null || variantInventory < msg.qty()) {
-                        orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                        connection.commit();
-                        return;
-                    }
-                }
-                List<Integer> credentialIds = credentialDAO.pickFreeCredentialIds(connection, msg.productId(), msg.qty(), variantCode);
-                if (credentialIds.size() < msg.qty()) {
-                    orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.FAILED);
-                    connection.commit();
-                    return;
-                }
-                boolean decremented = productDAO.decrementInventory(connection, msg.productId(), msg.qty());
-                if (!decremented) {
-                    throw new SQLException("Không thể trừ tồn kho");
-                }
-                if (variant != null) {
-                    ProductVariantUtils.decreaseInventory(variant, msg.qty());
-                    String updatedJson = ProductVariantUtils.toJson(variants);
-                    productDAO.updateVariantsJson(connection, msg.productId(), updatedJson);
-                }
-                // B4: Trừ tiền trong ví và ghi nhận giao dịch thanh toán để log lại luồng tiền.
-                BigDecimal balanceAfter = balanceBefore.subtract(totalAmount);
-                boolean balanceUpdated = walletsDAO.updateBalance(connection, wallet.getId(), balanceAfter);
-                if (!balanceUpdated) {
-                    throw new SQLException("Không thể cập nhật số dư ví");
-                }
-                String note = "Thanh toán đơn hàng #" + order.getId();
-                int walletTxId = walletTransactionDAO.insertTransaction(connection, wallet.getId(), order.getId(),
-                        TransactionType.PURCHASE, totalAmount.negate(), balanceBefore, balanceAfter, note);
-                orderDAO.assignPaymentTransaction(connection, order.getId(), walletTxId);
-                // B5: Giao credential cho người mua và ghi nhận log tồn kho phục vụ kiểm toán.
-                credentialDAO.markCredentialsSold(connection, msg.orderId(), credentialIds);
-                orderDAO.insertInventoryLog(connection, msg.productId(), msg.orderId(), -msg.qty(), "Sale");
+                // B2: Chuẩn hóa dữ liệu đầu vào và khóa ví người mua.
+                prepareVariantCode(context);
+                lockWalletAndValidateBalance(connection, context);
+                // B3: Khóa tồn kho & credential để đảm bảo đủ hàng bàn giao.
+                lockProductAndVerifyInventory(connection, context);
+                reserveCredentials(connection, context);
+                // B4: Trừ tiền và ghi giao dịch thanh toán.
+                chargeWallet(connection, context);
+                // B5: Giao credential, cập nhật tồn kho chi tiết & log kiểm toán.
+                finalizeFulfillment(connection, context);
                 // B6: Hoàn tất đơn hàng và commit transaction.
                 orderDAO.updateStatus(connection, msg.orderId(), OrderStatus.COMPLETED);
                 connection.commit();
@@ -179,6 +112,130 @@ public class AsyncOrderWorker implements OrderWorker {
                 connection.setAutoCommit(true);
             }
         }
+    }
+
+    /**
+     * Chuẩn hóa và lưu biến thể tương ứng của đơn hàng (nếu có) vào context.
+     */
+    private void prepareVariantCode(OrderProcessingContext context) {
+        String resolved = context.message().variantCode();
+        if (resolved == null || resolved.isBlank()) {
+            resolved = context.order().getVariantCode();
+        }
+        context.setNormalizedVariantCode(ProductVariantUtils.normalizeCode(resolved));
+    }
+
+    /**
+     * Khóa ví, kiểm tra trạng thái ví và số dư so với tổng tiền đơn hàng.
+     */
+    private void lockWalletAndValidateBalance(Connection connection, OrderProcessingContext context) throws SQLException {
+        Wallets wallet = walletsDAO.lockWalletForUpdate(connection, context.order().getBuyerId());
+        if (wallet == null || Boolean.FALSE.equals(wallet.getStatus())) {
+            failWithReason(connection, context.order(), "Ví của người dùng không khả dụng", Level.WARNING);
+        }
+        BigDecimal totalAmount = context.order().getTotalAmount();
+        if (totalAmount == null) {
+            failWithReason(connection, context.order(), "Đơn hàng thiếu thông tin tổng tiền", Level.SEVERE);
+        }
+        BigDecimal balanceBefore = wallet.getBalance() == null ? BigDecimal.ZERO : wallet.getBalance();
+        if (balanceBefore.compareTo(totalAmount) < 0) {
+            failWithReason(connection, context.order(), "Ví người dùng không đủ số dư", Level.INFO);
+        }
+        context.setWallet(wallet);
+        context.setTotalAmount(totalAmount);
+        context.setBalanceBefore(balanceBefore);
+    }
+
+    /**
+     * Khóa tồn kho sản phẩm, kiểm tra tổng tồn kho và tồn kho biến thể.
+     */
+    private void lockProductAndVerifyInventory(Connection connection, OrderProcessingContext context) throws SQLException {
+        ProductDAO.ProductInventoryLock productLock = productDAO.lockProductForUpdate(connection, context.message().productId());
+        List<ProductVariantOption> variants = ProductVariantUtils.parseVariants(productLock.variantSchema(), productLock.variantsJson());
+        int inventory = calculateAvailableInventory(productLock, variants);
+        if (inventory < context.message().qty()) {
+            failWithReason(connection, context.order(), "Tổng tồn kho sản phẩm không đủ", Level.WARNING);
+        }
+        context.setAvailableInventory(inventory);
+        if (context.normalizedVariantCode() != null) {
+            Optional<ProductVariantOption> variantOpt = ProductVariantUtils.findVariant(variants, context.normalizedVariantCode());
+            if (variantOpt.isEmpty() || !variantOpt.get().isAvailable()) {
+                failWithReason(connection, context.order(), "Biến thể sản phẩm không khả dụng", Level.WARNING);
+            }
+            ProductVariantOption variant = variantOpt.get();
+            Integer variantInventory = variant.getInventoryCount();
+            if (variantInventory == null || variantInventory < context.message().qty()) {
+                failWithReason(connection, context.order(), "Biến thể sản phẩm không đủ tồn kho", Level.WARNING);
+            }
+            context.setVariant(variant);
+            context.setVariantInventory(variantInventory);
+        }
+        context.setVariants(variants);
+    }
+
+    /**
+     * Khóa credential phù hợp với sản phẩm/biến thể.
+     */
+    private void reserveCredentials(Connection connection, OrderProcessingContext context) throws SQLException {
+        ensureCredentialPool(connection, context);
+        List<Integer> credentialIds = credentialDAO.pickFreeCredentialIds(connection,
+                context.message().productId(), context.message().qty(), context.normalizedVariantCode());
+        if (credentialIds.size() < context.message().qty()) {
+            failWithReason(connection, context.order(), "Không đủ credential sẵn sàng để giao", Level.WARNING);
+        }
+        context.setCredentialIds(credentialIds);
+    }
+
+    /**
+     * Đảm bảo kho credential luôn >= tồn kho sản phẩm bằng cách tự động sinh credential ảo khi thiếu.
+     */
+    private void ensureCredentialPool(Connection connection, OrderProcessingContext context) throws SQLException {
+        int targetInventory = context.variantInventory() != null
+                ? Math.max(context.variantInventory(), context.message().qty())
+                : Math.max(context.availableInventory(), context.message().qty());
+        if (targetInventory <= 0) {
+            return;
+        }
+        CredentialDAO.CredentialAvailability availability = credentialDAO.fetchAvailabilityForVariant(connection,
+                context.message().productId(), context.normalizedVariantCode());
+        int missing = targetInventory - availability.available();
+        if (missing <= 0) {
+            return;
+        }
+        credentialDAO.generateFakeCredentials(connection, context.message().productId(),
+                context.normalizedVariantCode(), missing);
+    }
+
+    /**
+     * Trừ tiền khỏi ví người mua và ghi nhận giao dịch thanh toán.
+     */
+    private void chargeWallet(Connection connection, OrderProcessingContext context) throws SQLException {
+        BigDecimal balanceAfter = context.balanceBefore().subtract(context.totalAmount());
+        boolean balanceUpdated = walletsDAO.updateBalance(connection, context.wallet().getId(), balanceAfter);
+        if (!balanceUpdated) {
+            throw new SQLException("Không thể cập nhật số dư ví");
+        }
+        String note = "Thanh toán đơn hàng #" + context.order().getId();
+        int walletTxId = walletTransactionDAO.insertTransaction(connection, context.wallet().getId(), context.order().getId(),
+                TransactionType.PURCHASE, context.totalAmount().negate(), context.balanceBefore(), balanceAfter, note);
+        orderDAO.assignPaymentTransaction(connection, context.order().getId(), walletTxId);
+    }
+
+    /**
+     * Cập nhật tồn kho tổng, tồn kho biến thể (nếu có) và bàn giao credential cho khách hàng.
+     */
+    private void finalizeFulfillment(Connection connection, OrderProcessingContext context) throws SQLException {
+        boolean decremented = productDAO.decrementInventory(connection, context.message().productId(), context.message().qty());
+        if (!decremented) {
+            throw new SQLException("Không thể trừ tồn kho");
+        }
+        if (context.variant() != null) {
+            ProductVariantUtils.decreaseInventory(context.variant(), context.message().qty());
+            String updatedJson = ProductVariantUtils.toJson(context.variants());
+            productDAO.updateVariantsJson(connection, context.message().productId(), updatedJson);
+        }
+        credentialDAO.markCredentialsSold(connection, context.message().orderId(), context.credentialIds());
+        orderDAO.insertInventoryLog(connection, context.message().productId(), context.message().orderId(), -context.message().qty(), "Sale");
     }
 
     private void markFailed(int orderId) {
@@ -202,5 +259,153 @@ public class AsyncOrderWorker implements OrderWorker {
         }
         OrderStatus current = OrderStatus.fromDatabaseValue(status);
         return current == OrderStatus.COMPLETED || current == OrderStatus.FAILED;
+    }
+
+    private int calculateAvailableInventory(ProductDAO.ProductInventoryLock lockedProduct,
+            List<ProductVariantOption> variants) {
+        Integer rawInventory = lockedProduct.inventoryCount();
+        if (rawInventory != null) {
+            return rawInventory;
+        }
+        if (!ProductVariantUtils.hasVariants(lockedProduct.variantSchema())) {
+            return 0;
+        }
+        return variants.stream()
+                .filter(option -> option != null && option.isAvailable() && option.getInventoryCount() != null)
+                .mapToInt(ProductVariantOption::getInventoryCount)
+                .sum();
+    }
+
+    /**
+     * Đánh dấu đơn hàng thất bại, commit giao dịch rồi ném ngoại lệ để {@link #handle(OrderMessage)} log chi tiết.
+     */
+    private void failWithReason(Connection connection, Orders order, String reason, Level level) throws SQLException {
+        orderDAO.updateStatus(connection, order.getId(), OrderStatus.FAILED);
+        connection.commit();
+        throw new OrderProcessingException(reason, level);
+    }
+
+    /**
+     * Ngoại lệ runtime dành riêng cho các tình huống nghiệp vụ khiến đơn hàng thất bại.
+     */
+    private static final class OrderProcessingException extends RuntimeException {
+
+        private final Level level;
+
+        OrderProcessingException(String message, Level level) {
+            this(message, level, null);
+        }
+
+        OrderProcessingException(String message, Level level, Throwable cause) {
+            super(message, cause);
+            this.level = level == null ? Level.WARNING : level;
+        }
+
+        Level level() {
+            return level;
+        }
+    }
+
+    /**
+     * Context gom thông tin trong suốt vòng đời xử lý đơn hàng để tái sử dụng.
+     */
+    private static final class OrderProcessingContext {
+
+        private final OrderMessage message;
+        private final Orders order;
+        private Wallets wallet;
+        private BigDecimal balanceBefore;
+        private BigDecimal totalAmount;
+        private String normalizedVariantCode;
+        private List<ProductVariantOption> variants;
+        private ProductVariantOption variant;
+        private List<Integer> credentialIds;
+        private int availableInventory;
+        private Integer variantInventory;
+
+        OrderProcessingContext(OrderMessage message, Orders order) {
+            this.message = message;
+            this.order = order;
+        }
+
+        OrderMessage message() {
+            return message;
+        }
+
+        Orders order() {
+            return order;
+        }
+
+        Wallets wallet() {
+            return wallet;
+        }
+
+        void setWallet(Wallets wallet) {
+            this.wallet = wallet;
+        }
+
+        BigDecimal balanceBefore() {
+            return balanceBefore;
+        }
+
+        void setBalanceBefore(BigDecimal balanceBefore) {
+            this.balanceBefore = balanceBefore;
+        }
+
+        BigDecimal totalAmount() {
+            return totalAmount;
+        }
+
+        void setTotalAmount(BigDecimal totalAmount) {
+            this.totalAmount = totalAmount;
+        }
+
+        String normalizedVariantCode() {
+            return normalizedVariantCode;
+        }
+
+        void setNormalizedVariantCode(String normalizedVariantCode) {
+            this.normalizedVariantCode = normalizedVariantCode;
+        }
+
+        List<ProductVariantOption> variants() {
+            return variants;
+        }
+
+        void setVariants(List<ProductVariantOption> variants) {
+            this.variants = variants;
+        }
+
+        ProductVariantOption variant() {
+            return variant;
+        }
+
+        void setVariant(ProductVariantOption variant) {
+            this.variant = variant;
+        }
+
+        List<Integer> credentialIds() {
+            return credentialIds;
+        }
+
+        void setCredentialIds(List<Integer> credentialIds) {
+            this.credentialIds = credentialIds;
+        }
+
+        int availableInventory() {
+            return availableInventory;
+        }
+
+        void setAvailableInventory(int availableInventory) {
+            this.availableInventory = availableInventory;
+        }
+
+        Integer variantInventory() {
+            return variantInventory;
+        }
+
+        void setVariantInventory(Integer variantInventory) {
+            this.variantInventory = variantInventory;
+        }
     }
 }

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -13,6 +13,105 @@
     - statusLabel: chuỗi tiếng Việt do OrderService map từ enum.
 --%>
 <main class="layout__content">
+    <c:if test="${showProcessingModal}">
+        <c:url var="orderDetailUrl" value="/orders/detail">
+            <c:param name="id" value="${order.id}" />
+        </c:url>
+        <style>
+            /* Modal thông báo xử lý đơn hàng */
+            .order-modal {
+                position: fixed;
+                inset: 0;
+                display: none;
+                align-items: center;
+                justify-content: center;
+                z-index: 1000;
+            }
+
+            .order-modal.is-visible {
+                display: flex;
+            }
+
+            .order-modal__backdrop {
+                position: absolute;
+                inset: 0;
+                background: rgba(15, 23, 42, 0.55);
+            }
+
+            .order-modal__dialog {
+                position: relative;
+                background: #fff;
+                border-radius: 12px;
+                padding: 2rem;
+                max-width: 440px;
+                width: calc(100% - 2rem);
+                box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
+                z-index: 1;
+            }
+
+            .order-modal__dialog h3 {
+                margin-top: 0;
+                margin-bottom: 0.75rem;
+                font-size: 1.25rem;
+                font-weight: 600;
+            }
+
+            .order-modal__dialog p {
+                margin: 0 0 1.5rem 0;
+                color: #475569;
+                line-height: 1.6;
+            }
+
+            .order-modal__actions {
+                display: flex;
+                justify-content: flex-end;
+                gap: 0.75rem;
+            }
+        </style>
+        <div class="order-modal" id="orderProcessingModal">
+            <div class="order-modal__backdrop" id="orderProcessingBackdrop"></div>
+            <div class="order-modal__dialog" role="dialog" aria-modal="true"
+                 aria-labelledby="orderProcessingTitle" aria-describedby="orderProcessingMessage">
+                <h3 id="orderProcessingTitle">Đơn hàng đang được xử lý</h3>
+                <p id="orderProcessingMessage">
+                    Hệ thống đang khóa ví, kiểm tra tồn kho và nạp credential bàn giao.
+                    Vui lòng bấm "Xem chi tiết đơn hàng" để theo dõi trạng thái cập nhật theo thời gian thực.
+                </p>
+                <div class="order-modal__actions">
+                    <button type="button" class="button button--ghost" id="orderProcessingLater">Ở lại trang</button>
+                    <button type="button" class="button button--primary" id="orderProcessingGo"
+                            data-target="${orderDetailUrl}">Xem chi tiết đơn hàng</button>
+                </div>
+            </div>
+        </div>
+        <script>
+            // Hiển thị pop-up nhắc người mua chuyển sang trang chi tiết đơn hàng để theo dõi tiến độ.
+            document.addEventListener('DOMContentLoaded', function () {
+                const modal = document.getElementById('orderProcessingModal');
+                if (!modal) {
+                    return;
+                }
+                const backdrop = document.getElementById('orderProcessingBackdrop');
+                const stayButton = document.getElementById('orderProcessingLater');
+                const goButton = document.getElementById('orderProcessingGo');
+
+                function closeModal() {
+                    modal.classList.remove('is-visible');
+                }
+
+                backdrop.addEventListener('click', closeModal);
+                stayButton.addEventListener('click', closeModal);
+                goButton.addEventListener('click', function () {
+                    const target = goButton.getAttribute('data-target');
+                    if (target) {
+                        window.location.href = target;
+                    }
+                });
+
+                modal.classList.add('is-visible');
+            });
+        </script>
+    </c:if>
     <section class="panel">
         <div class="panel__header">
             <h2 class="panel__title">Chi tiết đơn hàng #<c:out value="${order.id}" /></h2>


### PR DESCRIPTION
## Summary
- auto-generate virtual credentials when stock lacks matching records so every unit has a unique handover
- expose inventory context to the order worker to top up credential pools before reserving them
- display a processing modal after checkout with a call-to-action that redirects buyers to their order detail page

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68fec2487e3c8320b3dd57adfe5900b6