### PR TITLE
Display logged-in user info and KYC CTA in header

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -21,6 +21,10 @@
 
 <c:url value="/login" var="loginUrl" />
 <c:url value="/auth?action=logout" var="logoutUrl" />
+<c:url value="/profile" var="profileUrl" />
+<c:url value="/profile" var="kycUrl">
+  <c:param name="section" value="kyc" />
+</c:url>
 
 <c:set var="currentUri" value="${pageContext.request.requestURI}" />
 <c:set var="isAuthPage"
@@ -30,6 +34,8 @@
                 or fn:contains(currentUri, '/forgot')
                 or fn:contains(currentUri, '/reset-password')}" />
 <c:set var="isLoggedIn" value="${not empty sessionScope.authUser}" />
+<c:set var="userRole" value="${sessionScope.userRole}" />
+<c:set var="showKycLink" value="${isLoggedIn and userRole eq 3}" />
 
 <c:if test="${empty headerModifier}">
   <c:set var="headerModifier" value="" />
@@ -82,7 +88,7 @@
               <div class="${dropdownClass}">
                 <button class="menu__dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">
                   <span class="menu__text"><c:out value="${empty item['text'] ? item['label'] : item['text']}" /></span>
-                 
+
                 </button>
                 <div class="menu__dropdown-panel">
                   <c:forEach var="child" items="${item['children']}">
@@ -116,6 +122,21 @@
           </c:choose>
         </c:forEach>
       </nav>
+    </c:if>
+
+    <c:if test="${isLoggedIn}">
+      <div class="site-header__actions">
+        <c:if test="${showKycLink}">
+          <a class="site-header__cta" href="${kycUrl}">Trở thành người bán</a>
+        </c:if>
+        <div class="site-header__user" aria-label="Thông tin người dùng">
+          <span class="site-header__avatar" aria-hidden="true"><c:out value="${avatarInitial}" /></span>
+          <div class="site-header__user-info">
+            <span class="site-header__user-name"><c:out value="${displayName}" /></span>
+            <a class="site-header__user-link" href="${profileUrl}">Quản lý tài khoản</a>
+          </div>
+        </div>
+      </div>
     </c:if>
   </div>
 </header>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -253,6 +253,41 @@ display: grid;
     font-size: 0.95rem;
 }
 
+.site-header__user-link {
+    font-size: 0.85rem;
+    color: rgba(0, 0, 0, 0.6);
+    text-decoration: none;
+    transition: var(--transition);
+}
+
+.site-header__user-link:hover,
+.site-header__user-link:focus {
+    color: var(--primary-color-dark);
+    text-decoration: underline;
+}
+
+.site-header__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 91, 150, 0.25);
+    background: rgba(0, 91, 150, 0.08);
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+    transition: var(--transition);
+    white-space: nowrap;
+}
+
+.site-header__cta:hover,
+.site-header__cta:focus {
+    background: var(--primary-color);
+    color: #fff;
+    border-color: var(--primary-color);
+}
+
 .layout__header--auth .site-header__inner {
     grid-template-columns: auto 1fr auto;
     gap: 1.25rem;


### PR DESCRIPTION
## Summary
- show the signed-in user with avatar initial and profile link in the shared header
- add a "Trở thành người bán" call-to-action for buyers that points to the KYC section
- style the new header CTA and account link to match the existing layout

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68fee24f71cc8320b8c278b005187af7