### PR TITLE
Turn account button into dropdown with seller shortcut

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -21,6 +21,10 @@
 
 <c:url value="/login" var="loginUrl" />
 <c:url value="/auth?action=logout" var="logoutUrl" />
+<c:url value="/profile" var="profileUrl" />
+<c:url value="/profile" var="kycUrl">
+  <c:param name="section" value="kyc" />
+</c:url>
 
 <c:set var="currentUri" value="${pageContext.request.requestURI}" />
 <c:set var="isAuthPage"
@@ -30,6 +34,8 @@
                 or fn:contains(currentUri, '/forgot')
                 or fn:contains(currentUri, '/reset-password')}" />
 <c:set var="isLoggedIn" value="${not empty sessionScope.authUser}" />
+<c:set var="userRole" value="${sessionScope.userRole}" />
+<c:set var="showKycLink" value="${isLoggedIn and userRole eq 3}" />
 
 <c:if test="${empty headerModifier}">
   <c:set var="headerModifier" value="" />
@@ -82,7 +88,7 @@
               <div class="${dropdownClass}">
                 <button class="menu__dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">
                   <span class="menu__text"><c:out value="${empty item['text'] ? item['label'] : item['text']}" /></span>
-                 
+
                 </button>
                 <div class="menu__dropdown-panel">
                   <c:forEach var="child" items="${item['children']}">
@@ -116,6 +122,28 @@
           </c:choose>
         </c:forEach>
       </nav>
+    </c:if>
+
+    <c:if test="${isLoggedIn}">
+      <div class="site-header__actions">
+        <div class="site-header__user" aria-label="Tài khoản người dùng">
+          <button class="site-header__user-toggle" type="button" aria-haspopup="true">
+            <span class="site-header__avatar" aria-hidden="true"><c:out value="${avatarInitial}" /></span>
+            <div class="site-header__user-info">
+              <span class="site-header__user-label">Xin chào</span>
+              <span class="site-header__user-name"><c:out value="${displayName}" /></span>
+            </div>
+            <span class="site-header__user-caret" aria-hidden="true"></span>
+          </button>
+          <div class="site-header__user-menu" role="menu">
+            <a class="site-header__user-link" role="menuitem" href="${profileUrl}">Quản lý tài khoản</a>
+            <c:if test="${showKycLink}">
+              <a class="site-header__user-link" role="menuitem" href="${kycUrl}">Trở thành người bán</a>
+            </c:if>
+            <a class="site-header__user-link site-header__user-link--logout" role="menuitem" href="${logoutUrl}">Đăng xuất</a>
+          </div>
+        </div>
+      </div>
     </c:if>
   </div>
 </header>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -223,9 +223,28 @@ display: grid;
 }
 
 .site-header__user {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.site-header__user-toggle {
     display: flex;
     align-items: center;
     gap: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    border: none;
+    background: transparent;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: var(--transition);
+    color: inherit;
+}
+
+.site-header__user-toggle:hover,
+.site-header__user-toggle:focus {
+    background: rgba(0, 91, 150, 0.08);
+    outline: none;
 }
 
 .site-header__avatar {
@@ -246,11 +265,104 @@ display: grid;
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
+    text-align: left;
+}
+
+.site-header__user-label {
+    font-size: 0.75rem;
+    color: var(--text-light);
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
 }
 
 .site-header__user-name {
     font-weight: 600;
     font-size: 0.95rem;
+    color: var(--primary-color);
+}
+
+.site-header__user-caret {
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid rgba(31, 45, 61, 0.45);
+    margin-left: 0.5rem;
+    transition: var(--transition);
+}
+
+.site-header__user:hover .site-header__user-caret,
+.site-header__user:focus-within .site-header__user-caret {
+    transform: rotate(180deg);
+}
+
+.site-header__user-menu {
+    position: absolute;
+    top: calc(100% + 0.65rem);
+    right: 0;
+    min-width: 220px;
+    padding: 0.75rem;
+    display: none;
+    flex-direction: column;
+    gap: 0.25rem;
+    border-radius: var(--radius-sm);
+    background: var(--surface-color);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.15);
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    z-index: 25;
+}
+
+.site-header__user:hover .site-header__user-menu,
+.site-header__user:focus-within .site-header__user-menu {
+    display: flex;
+}
+
+.site-header__user-link {
+    font-size: 0.9rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    color: var(--text-color);
+    text-decoration: none;
+    transition: var(--transition);
+    display: block;
+}
+
+.site-header__user-link:hover,
+.site-header__user-link:focus {
+    background: rgba(0, 91, 150, 0.08);
+    color: var(--primary-color-dark);
+}
+
+.site-header__user-link--logout {
+    color: var(--danger-color);
+}
+
+.site-header__user-link--logout:hover,
+.site-header__user-link--logout:focus {
+    background: rgba(192, 57, 43, 0.12);
+    color: var(--danger-color);
+}
+
+.site-header__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 91, 150, 0.25);
+    background: rgba(0, 91, 150, 0.08);
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+    transition: var(--transition);
+    white-space: nowrap;
+}
+
+.site-header__cta:hover,
+.site-header__cta:focus {
+    background: var(--primary-color);
+    color: #fff;
+    border-color: var(--primary-color);
 }
 
 .layout__header--auth .site-header__inner {


### PR DESCRIPTION
## Summary
- replace the static account chip with a dropdown that shows the signed-in user name
- add quick links inside the dropdown for managing the account and starting the seller KYC flow
- refresh the header styling to support the new toggle, caret, and dropdown panel

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68fee24f71cc8320b8c278b005187af7