### PR TITLE
Add filters to order history page

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/order/my.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/my.jsp
@@ -17,6 +17,16 @@
             <h2 class="panel__title">Lịch sử mua hàng</h2>
             <form class="panel__filters" method="get" action="${pageContext.request.contextPath}/orders/my">
                 <label class="form-field">
+                    <span class="form-field__label">Mã đơn</span>
+                    <input class="form-field__input" type="text" name="code" placeholder="VD: 5003"
+                           value="<c:out value='${orderCode}'/>" />
+                </label>
+                <label class="form-field">
+                    <span class="form-field__label">Sản phẩm</span>
+                    <input class="form-field__input" type="text" name="product" placeholder="Tên sản phẩm"
+                           value="<c:out value='${productName}'/>" />
+                </label>
+                <label class="form-field">
                     <span class="form-field__label">Trạng thái</span>
                     <select class="form-field__input" name="status">
                         <option value="">Tất cả</option>
@@ -27,6 +37,16 @@
                             </option>
                         </c:forEach>
                     </select>
+                </label>
+                <label class="form-field">
+                    <span class="form-field__label">Từ ngày</span>
+                    <input class="form-field__input" type="date" name="fromDate"
+                           max="<c:out value='${todayIso}'/>" value="<c:out value='${fromDate}'/>" />
+                </label>
+                <label class="form-field">
+                    <span class="form-field__label">Đến ngày</span>
+                    <input class="form-field__input" type="date" name="toDate"
+                           max="<c:out value='${todayIso}'/>" value="<c:out value='${toDate}'/>" />
                 </label>
                 <label class="form-field">
                     <span class="form-field__label">Mỗi trang</span>


### PR DESCRIPTION
## Summary
- add order code, product name, and date range filters to the buyer order history page
- extend the order controller/service/DAO to apply the new filters and clamp future dates
- surface the selected filter values back to the view for a consistent experience

## Testing
- ant -f MMO_Trader_Market/build.xml compile *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fefb33123c8320a44ea3348d00d822