### PR TITLE
Show wallet balance errors on product detail page

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -147,8 +147,24 @@ public class OrderController extends BaseController {
         } catch (IllegalArgumentException ex) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
         } catch (IllegalStateException ex) {
-            response.sendError(HttpServletResponse.SC_CONFLICT, ex.getMessage());
+            if (!redirectBackWithError(request, response, session, productId, ex.getMessage())) {
+                response.sendError(HttpServletResponse.SC_CONFLICT, ex.getMessage());
+            }
         }
+    }
+
+    private boolean redirectBackWithError(HttpServletRequest request, HttpServletResponse response,
+                                          HttpSession session, int productId, String message) throws IOException {
+        if (session == null || productId <= 0) {
+            return false;
+        }
+        String resolvedMessage = (message == null || message.isBlank())
+                ? "Không thể xử lý giao dịch. Vui lòng thử lại sau."
+                : message;
+        session.setAttribute("purchaseError", resolvedMessage);
+        String target = request.getContextPath() + "/product/detail/" + IdObfuscator.encode(productId);
+        response.sendRedirect(target);
+        return true;
     }
 
     /**

--- a/MMO_Trader_Market/src/java/controller/product/ProductDetailController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductDetailController.java
@@ -62,6 +62,16 @@ public class ProductDetailController extends BaseController {
             HttpSession session = request.getSession(false);
             boolean isAuthenticated = session != null && session.getAttribute("userId") != null;
 
+            if (session != null) {
+                String purchaseError = (String) session.getAttribute("purchaseError");
+                if (purchaseError != null && !purchaseError.isBlank()) {
+                    request.setAttribute("purchaseError", purchaseError);
+                }
+                if (purchaseError != null) {
+                    session.removeAttribute("purchaseError");
+                }
+            }
+
             boolean canBuy = isAuthenticated && product.isAvailable()
                     && productService.hasDeliverableCredentials(product.getId(), product.getVariants());
 

--- a/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
@@ -66,6 +66,11 @@
                 </p>
                 <p class="product-detail__shop">Gian hàng: <strong><c:out value="${product.shopName}" /></strong></p>
             </header>
+            <c:if test="${not empty purchaseError}">
+                <div class="alert alert--error" role="alert" aria-live="assertive">
+                    <c:out value="${purchaseError}" />
+                </div>
+            </c:if>
             <div class="product-detail__pricing" data-min-price="${priceMin}" data-max-price="${priceMax}">
                 <span>Giá hiện tại:</span>
                 <strong id="priceDisplay">


### PR DESCRIPTION
## Summary
- redirect business-rule failures when placing an order back to the product detail page instead of returning HTTP 409
- persist the error message in the session and display it as an alert on the product detail view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff02aeedf48320b8179954ffd1ad13