### PR TITLE
Enhance product list pagination controls

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/ProductListController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductListController.java
@@ -33,6 +33,7 @@ public class ProductListController extends BaseController {
     private static final long serialVersionUID = 1L;
     private static final int DEFAULT_PAGE = 1;
     private static final int DEFAULT_SIZE = 5;
+    private static final List<Integer> PAGE_SIZE_OPTIONS = List.of(5, 10, 20, 40);
 
     private final ProductService productService = new ProductService();
 
@@ -55,7 +56,8 @@ public class ProductListController extends BaseController {
         }
 
         int page = parsePositiveIntOrDefault(request.getParameter("page"), DEFAULT_PAGE);
-        int size = parsePositiveIntOrDefault(resolveSizeParam(request), DEFAULT_SIZE);
+        int sizeCandidate = parsePositiveIntOrDefault(resolveSizeParam(request), DEFAULT_SIZE);
+        int size = PAGE_SIZE_OPTIONS.contains(sizeCandidate) ? sizeCandidate : DEFAULT_SIZE;
 
         String rawKeyword = request.getParameter("keyword");
         String normalizedKeyword = rawKeyword == null ? null : rawKeyword.trim();
@@ -82,6 +84,7 @@ public class ProductListController extends BaseController {
         request.setAttribute("page", result.getPage());
         request.setAttribute("currentPage", result.getPage());
         request.setAttribute("pageSize", result.getSize());
+        request.setAttribute("pageSizeOptions", PAGE_SIZE_OPTIONS);
         request.setAttribute("totalPages", result.getTotalPages());
         request.setAttribute("selectedType", normalizedType);
         request.setAttribute("selectedSubtypes", selectedSubtypeSet);

--- a/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/list.jsp
@@ -59,8 +59,24 @@
             </aside>
             <div class="product-browse__results">
                 <div class="product-list__meta product-browse__meta">
-                    <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
-                    <span>Trang ${page} / ${totalPages}</span>
+                    <div class="product-list__stats">
+                        <span>Tổng <strong>${totalItems}</strong> sản phẩm khả dụng.</span>
+                        <span>Trang ${page} / ${totalPages}</span>
+                    </div>
+                    <form class="product-list__page-size" method="get" action="${cPath}/products">
+                        <input type="hidden" name="type" value="${fn:escapeXml(type)}" />
+                        <input type="hidden" name="keyword" value="${fn:escapeXml(keyword)}" />
+                        <input type="hidden" name="page" value="1" />
+                        <c:forEach var="code" items="${selectedSubtypes}">
+                            <input type="hidden" name="subtype" value="${fn:escapeXml(code)}" />
+                        </c:forEach>
+                        <label class="product-list__page-size-label" for="product-page-size">Hiển thị</label>
+                        <select class="select" name="pageSize" id="product-page-size" onchange="this.form.submit()">
+                            <c:forEach var="option" items="${pageSizeOptions}">
+                                <option value="${option}" <c:if test="${option == pageSize}">selected</c:if>>${option} / trang</option>
+                            </c:forEach>
+                        </select>
+                    </form>
                 </div>
                 <c:choose>
                     <c:when test="${not empty items}">
@@ -130,23 +146,66 @@
                     </c:otherwise>
                 </c:choose>
                 <c:if test="${totalPages > 1}">
-                    <c:set var="ctx" value="${pageContext.request.contextPath}" />
-                    <c:set var="subtypeQuery" value="" />
-                    <c:if test="${not empty selectedSubtypes}">
-                        <c:forEach var="s" items="${selectedSubtypes}">
-                            <c:set var="subtypeQuery"
-                                   value="${subtypeQuery}${'&subtype='}${fn:escapeXml(s)}" />
+                    <nav class="pagination" aria-label="Phân trang sản phẩm">
+                        <c:choose>
+                            <c:when test="${page == 1}">
+                                <span class="pagination__item pagination__item--disabled" aria-disabled="true">«</span>
+                            </c:when>
+                            <c:otherwise>
+                                <c:url var="prevUrl" value="/products">
+                                    <c:param name="type" value="${type}" />
+                                    <c:if test="${not empty keyword}">
+                                        <c:param name="keyword" value="${keyword}" />
+                                    </c:if>
+                                    <c:forEach var="s" items="${selectedSubtypes}">
+                                        <c:param name="subtype" value="${s}" />
+                                    </c:forEach>
+                                    <c:param name="pageSize" value="${pageSize}" />
+                                    <c:param name="page" value="${page - 1}" />
+                                </c:url>
+                                <a class="pagination__item" href="${prevUrl}">«</a>
+                            </c:otherwise>
+                        </c:choose>
+                        <c:forEach var="pageNumber" begin="1" end="${totalPages}">
+                            <c:url var="pageUrl" value="/products">
+                                <c:param name="type" value="${type}" />
+                                <c:if test="${not empty keyword}">
+                                    <c:param name="keyword" value="${keyword}" />
+                                </c:if>
+                                <c:forEach var="s" items="${selectedSubtypes}">
+                                    <c:param name="subtype" value="${s}" />
+                                </c:forEach>
+                                <c:param name="pageSize" value="${pageSize}" />
+                                <c:param name="page" value="${pageNumber}" />
+                            </c:url>
+                            <c:choose>
+                                <c:when test="${pageNumber == page}">
+                                    <a class="pagination__item pagination__item--active" href="${pageUrl}" aria-current="page">${pageNumber}</a>
+                                </c:when>
+                                <c:otherwise>
+                                    <a class="pagination__item" href="${pageUrl}">${pageNumber}</a>
+                                </c:otherwise>
+                            </c:choose>
                         </c:forEach>
-                    </c:if>
-                    <nav class="pagination">
-                        <a class="page-btn ${page==1?'disabled':''}"
-                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${page==1 ? page : page-1}">&laquo;</a>
-                        <c:forEach var="p" begin="1" end="${totalPages}">
-                            <a class="page-num ${p==page?'active':''}"
-                               href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${p}">${p}</a>
-                        </c:forEach>
-                        <a class="page-btn ${page==totalPages?'disabled':''}"
-                           href="${ctx}/products?type=${fn:escapeXml(type)}&keyword=${fn:escapeXml(keyword)}${subtypeQuery}&pageSize=${pageSize}&page=${page==totalPages ? page : page+1}">&raquo;</a>
+                        <c:choose>
+                            <c:when test="${page >= totalPages}">
+                                <span class="pagination__item pagination__item--disabled" aria-disabled="true">»</span>
+                            </c:when>
+                            <c:otherwise>
+                                <c:url var="nextUrl" value="/products">
+                                    <c:param name="type" value="${type}" />
+                                    <c:if test="${not empty keyword}">
+                                        <c:param name="keyword" value="${keyword}" />
+                                    </c:if>
+                                    <c:forEach var="s" items="${selectedSubtypes}">
+                                        <c:param name="subtype" value="${s}" />
+                                    </c:forEach>
+                                    <c:param name="pageSize" value="${pageSize}" />
+                                    <c:param name="page" value="${page + 1}" />
+                                </c:url>
+                                <a class="pagination__item" href="${nextUrl}">»</a>
+                            </c:otherwise>
+                        </c:choose>
                     </nav>
                 </c:if>
             </div>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -610,6 +610,30 @@ code {
     color: var(--text-light);
 }
 
+.product-list__stats {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.product-list__page-size {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-light);
+}
+
+.product-list__page-size-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+}
+
+.product-list__page-size .select {
+    min-width: 140px;
+    height: 38px;
+}
+
 .product-grid {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- restrict product list page size to a curated set of options and expose them to the view
- update the product list JSP to render template-styled pagination controls and a page size selector
- add styling hooks for the new page size form within the product list meta bar

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ff06c6d98083208a55be118c6090a2