### PR TITLE
Add seller navigation and seed product galleries

### DIFF
--- a/DB_v1.sql
+++ b/DB_v1.sql
@@ -399,7 +399,7 @@ VALUES
  'Tài khoản Gmail Doanh nghiệp 50GB. Bạn nhận được email và mật khẩu kèm hướng dẫn đổi bảo mật 2 lớp.',
  250000.0000,
   'gmail.png',
-  JSON_ARRAY('gmail.png'),
+  JSON_ARRAY('gmail.png','gmail2.jpg','mailedu.png'),
  19,128,'Available','DURATION_PLAN',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','gmail-basic-1m','attributes', JSON_OBJECT('service','gmail','plan','basic','duration','1m'),'price',250000.0000,'inventory_count',10,'status','Available'),
@@ -414,7 +414,7 @@ VALUES
  'Gia hạn Spotify Premium tài khoản chính chủ, bảo hành 30 ngày. Hỗ trợ kích hoạt nhanh.',
  80000.0000,
   'spotify.png',
-  JSON_ARRAY('spotify.png'),
+  JSON_ARRAY('spotify.png','telegram.png'),
  27,256,'Available','DURATION_PLAN',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','sp-1m','attributes', JSON_OBJECT('service','spotify','duration','1m'),'price',80000.0000,'inventory_count',20,'status','Available'),
@@ -428,8 +428,8 @@ VALUES
  'Key bản quyền Windows 11 Pro, kích hoạt online.',
  'Khóa bản quyền Windows 11 Pro, kích hoạt online trọn đời. Lưu ý: sản phẩm hiện đang ẩn khỏi gian hàng.',
  390000.0000,
- 'https://cdn.mmo.local/products/win11pro_main.jpg',
- JSON_ARRAY('https://cdn.mmo.local/products/win11pro_main.jpg'),
+ 'win11.jpg',
+ JSON_ARRAY('win11.jpg','office.jpg'),
  50,42,'Unlisted','EDITION_LICENSE',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','win11pro-oem','attributes', JSON_OBJECT('edition','pro','license','oem'),'price',390000.0000,'inventory_count',50,'status','Unlisted')
@@ -443,7 +443,7 @@ VALUES
  'Tài khoản Facebook cổ (năm tạo 2009–2012), có bảo hành đổi mật khẩu. Dùng cho chạy quảng cáo & seeding.',
  150000.0000,
   'facebook.png',
-  JSON_ARRAY('facebook.png'),
+  JSON_ARRAY('facebook.png','fb2.png'),
  30,73,'Available','CUSTOM',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','fb-2009','attributes', JSON_OBJECT('age','2009'),'price',180000.0000,'inventory_count',10,'status','Available'),
@@ -458,7 +458,7 @@ VALUES
  'Tài khoản TikTok Pro, dùng quay và đăng video với analytics nâng cao.',
  99000.0000,
   'tiktok.png',
-  JSON_ARRAY('tiktok.png'),
+  JSON_ARRAY('tiktok.png','tiktok2.png','tiktoklive.png'),
  40,58,'Available','CUSTOM',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','tt-pro','attributes', JSON_OBJECT('tier','pro'),'price',99000.0000,'inventory_count',40,'status','Available')
@@ -472,7 +472,7 @@ VALUES
  'Dịch vụ nạp Valorant Points (VP) nhiều mệnh giá, xử lý trong 5–10 phút.',
  95000.0000,
   'valorant.png',
-  JSON_ARRAY('valorant.png'),
+  JSON_ARRAY('valorant.png','varo.png'),
  100,121,'Available','CUSTOM',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','vp-470','attributes', JSON_OBJECT('amount','470VP'),'price',95000.0000,'inventory_count',50,'status','Available'),
@@ -487,7 +487,7 @@ VALUES
  'Cung cấp tài khoản Canva Pro chính chủ, kích hoạt ngay sau khi thanh toán, bảo hành 30 ngày.',
  90000.0000,
   'canva.jpg',
-  JSON_ARRAY('canva.jpg'),
+  JSON_ARRAY('canva.jpg','canva2.png'),
  60,187,'Available','DURATION_PLAN',
  JSON_ARRAY(
    JSON_OBJECT('variant_code','canva-1m','attributes',JSON_OBJECT('duration','1m'),'price',90000.0000,'inventory_count',40,'status','Available'),
@@ -498,94 +498,94 @@ VALUES
 INSERT INTO `products`
 (`id`,`shop_id`,`product_type`,`product_subtype`,`name`,`short_description`,`description`,`price`,`primary_image_url`,`gallery_json`,`inventory_count`,`sold_count`,`status`,`variant_schema`,`variants_json`,`created_at`,`updated_at`)
 VALUES
-(1008,1,'EMAIL','GMAIL','Gmail Doanh nghiệp 100GB','Gmail 100GB, bảo hành, hướng dẫn 2FA.','Tài khoản Gmail dung lượng 100GB, hỗ trợ bảo mật 2 lớp và khôi phục.',350000.0000,'gmail.png',JSON_ARRAY('gmail.png'),20,95,'Available','DURATION_PLAN',JSON_ARRAY(
+(1008,1,'EMAIL','GMAIL','Gmail Doanh nghiệp 100GB','Gmail 100GB, bảo hành, hướng dẫn 2FA.','Tài khoản Gmail dung lượng 100GB, hỗ trợ bảo mật 2 lớp và khôi phục.',350000.0000,'gmail.png',JSON_ARRAY('gmail.png','gmail2.jpg','mailedu.png'),20,95,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','gmail-100g-1m','attributes', JSON_OBJECT('service','gmail','plan','100GB','duration','1m'),'price',350000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','gmail-100g-12m','attributes', JSON_OBJECT('service','gmail','plan','100GB','duration','12m'),'price',1800000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1009,1,'SOCIAL','FACEBOOK','Facebook cổ 2013+ (Mail+Pass)','Tài khoản Facebook cổ, có mail & pass.','Tài khoản Facebook năm 2013–2015, dành cho marketing hợp lệ theo chính sách.',180000.0000,'facebook.png',JSON_ARRAY('facebook.png'),25,210,'Available','CUSTOM',JSON_ARRAY(
+(1009,1,'SOCIAL','FACEBOOK','Facebook cổ 2013+ (Mail+Pass)','Tài khoản Facebook cổ, có mail & pass.','Tài khoản Facebook năm 2013–2015, dành cho marketing hợp lệ theo chính sách.',180000.0000,'facebook.png',JSON_ARRAY('facebook.png','fb2.png'),25,210,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','fb-2013','attributes', JSON_OBJECT('year','2013','verify','mail+pass'),'price',180000.0000,'inventory_count',15,'status','Available'),
   JSON_OBJECT('variant_code','fb-2015','attributes', JSON_OBJECT('year','2015','verify','mail+pass'),'price',160000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1010,1,'SOCIAL','TIKTOK','TikTok Shop – Seller Pro','Thiết lập & tối ưu TikTok Shop.','Dịch vụ tạo TikTok Shop cho người bán mới, kèm tài liệu vận hành.',300000.0000,'tiktok.png',JSON_ARRAY('tiktok.png'),20,74,'Available','CUSTOM',JSON_ARRAY(
+(1010,1,'SOCIAL','TIKTOK','TikTok Shop – Seller Pro','Thiết lập & tối ưu TikTok Shop.','Dịch vụ tạo TikTok Shop cho người bán mới, kèm tài liệu vận hành.',300000.0000,'tiktok.png',JSON_ARRAY('tiktok.png','tiktok2.png','tiktoklive.png'),20,74,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','ttshop-basic-1m','attributes', JSON_OBJECT('service','tiktok_shop','plan','basic','duration','1m'),'price',300000.0000,'inventory_count',12,'status','Available'),
   JSON_OBJECT('variant_code','ttshop-pro-3m','attributes', JSON_OBJECT('service','tiktok_shop','plan','pro','duration','3m'),'price',700000.0000,'inventory_count',8,'status','Available')
 ),NOW(),NOW()),
-(1011,1,'SOFTWARE','CANVA','Canva Pro 1 tháng','Cấp quyền Canva Pro 1 tháng.','Tài khoản Canva Pro 1 tháng, dùng thiết kế không giới hạn mẫu.',90000.0000,'canva.jpg',JSON_ARRAY('canva.jpg'),40,320,'Available','DURATION_PLAN',JSON_ARRAY(
+(1011,1,'SOFTWARE','CANVA','Canva Pro 1 tháng','Cấp quyền Canva Pro 1 tháng.','Tài khoản Canva Pro 1 tháng, dùng thiết kế không giới hạn mẫu.',90000.0000,'canva.jpg',JSON_ARRAY('canva.jpg','canva2.png'),40,320,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','canva-1m','attributes', JSON_OBJECT('service','canva','plan','pro','duration','1m'),'price',90000.0000,'inventory_count',25,'status','Available'),
   JSON_OBJECT('variant_code','canva-12m','attributes', JSON_OBJECT('service','canva','plan','pro','duration','12m'),'price',850000.0000,'inventory_count',15,'status','Available')
 ),NOW(),NOW()),
-(1012,1,'SOFTWARE','CANVA','Canva Team 5 người','Nhóm Canva Pro 5 seats.','Canva Pro cho nhóm 5 người, chia sẻ brand kit & thư viện.',250000.0000,'canva-team.png',JSON_ARRAY('canva-team.png'),18,96,'Available','DURATION_PLAN',JSON_ARRAY(
+(1012,1,'SOFTWARE','CANVA','Canva Team 5 người','Nhóm Canva Pro 5 seats.','Canva Pro cho nhóm 5 người, chia sẻ brand kit & thư viện.',250000.0000,'canva2.png',JSON_ARRAY('canva2.png','canva.jpg'),18,96,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','canvateam5-1m','attributes', JSON_OBJECT('service','canva','seats',5,'duration','1m'),'price',250000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','canvateam5-12m','attributes', JSON_OBJECT('service','canva','seats',5,'duration','12m'),'price',2400000.0000,'inventory_count',8,'status','Available')
 ),NOW(),NOW()),
-(1013,1,'SOFTWARE','OTHER','Windows 11 Pro (Key Retail)','Key kích hoạt Windows 11 Pro bản quyền.','Cung cấp key Windows 11 Pro loại Retail, hướng dẫn active hợp lệ.',450000.0000,'win11pro.png',JSON_ARRAY('win11pro.png'),30,190,'Available','EDITION_LICENSE',JSON_ARRAY(
+(1013,1,'SOFTWARE','OTHER','Windows 11 Pro (Key Retail)','Key kích hoạt Windows 11 Pro bản quyền.','Cung cấp key Windows 11 Pro loại Retail, hướng dẫn active hợp lệ.',450000.0000,'win11.jpg',JSON_ARRAY('win11.jpg','office.jpg'),30,190,'Available','EDITION_LICENSE',JSON_ARRAY(
   JSON_OBJECT('variant_code','win11pro-retail','attributes', JSON_OBJECT('edition','Pro','activation','Retail'),'price',450000.0000,'inventory_count',30,'status','Available')
 ),NOW(),NOW()),
-(1014,1,'EMAIL','OTHER','Outlook 50GB','Hộp thư Outlook 50GB, bảo mật.','Tài khoản Outlook dung lượng 50GB, kèm hướng dẫn bảo mật & khôi phục.',200000.0000,'outlook.png',JSON_ARRAY('outlook.png'),14,57,'Available','DURATION_PLAN',JSON_ARRAY(
+(1014,1,'EMAIL','OTHER','Outlook 50GB','Hộp thư Outlook 50GB, bảo mật.','Tài khoản Outlook dung lượng 50GB, kèm hướng dẫn bảo mật & khôi phục.',200000.0000,'mailedu.png',JSON_ARRAY('mailedu.png','gmail2.jpg','gmail.png'),14,57,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','outlook-1m','attributes', JSON_OBJECT('service','outlook','plan','standard','duration','1m'),'price',200000.0000,'inventory_count',8,'status','Available'),
   JSON_OBJECT('variant_code','outlook-12m','attributes', JSON_OBJECT('service','outlook','plan','standard','duration','12m'),'price',1200000.0000,'inventory_count',6,'status','Available')
 ),NOW(),NOW()),
-(1015,1,'GAME','VALORANT','Valorant Account – Rank Silver/Gold','Tài khoản Valorant rank Silver/Gold.','Tài khoản Valorant, vùng AP/SEA, bảo hành đăng nhập.',400000.0000,'valorant.png',JSON_ARRAY('valorant.png'),12,45,'Available','CUSTOM',JSON_ARRAY(
+(1015,1,'GAME','VALORANT','Valorant Account – Rank Silver/Gold','Tài khoản Valorant rank Silver/Gold.','Tài khoản Valorant, vùng AP/SEA, bảo hành đăng nhập.',400000.0000,'valorant.png',JSON_ARRAY('valorant.png','varo.png'),12,45,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','valo-silver','attributes', JSON_OBJECT('rank','Silver','region','AP'),'price',400000.0000,'inventory_count',7,'status','Available'),
   JSON_OBJECT('variant_code','valo-gold','attributes', JSON_OBJECT('rank','Gold','region','AP'),'price',550000.0000,'inventory_count',5,'status','Available')
 ),NOW(),NOW()),
-(1016,1,'GAME','VALORANT','Nạp Valorant VP','Gói nạp VP chính chủ.','Dịch vụ nạp Valorant Points (VP) theo mệnh giá, giao nhanh.',160000.0000,'valorant-topup.png',JSON_ARRAY('valorant-topup.png'),50,260,'Available','CUSTOM',JSON_ARRAY(
+(1016,1,'GAME','VALORANT','Nạp Valorant VP','Gói nạp VP chính chủ.','Dịch vụ nạp Valorant Points (VP) theo mệnh giá, giao nhanh.',160000.0000,'valorant.png',JSON_ARRAY('valorant.png','varo.png'),50,260,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','vp-475','attributes', JSON_OBJECT('amount','475'),'price',160000.0000,'inventory_count',20,'status','Available'),
   JSON_OBJECT('variant_code','vp-1375','attributes', JSON_OBJECT('amount','1375'),'price',430000.0000,'inventory_count',20,'status','Available'),
   JSON_OBJECT('variant_code','vp-2400','attributes', JSON_OBJECT('amount','2400'),'price',720000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1017,1,'SOCIAL','FACEBOOK','Business Manager (BM) gói hỗ trợ','Tư vấn & cấu hình BM.','Thiết lập BM, hướng dẫn bảo mật & phân quyền đúng chính sách.',220000.0000,'facebook-bm.png',JSON_ARRAY('facebook-bm.png'),22,81,'Available','CUSTOM',JSON_ARRAY(
+(1017,1,'SOCIAL','FACEBOOK','Business Manager (BM) gói hỗ trợ','Tư vấn & cấu hình BM.','Thiết lập BM, hướng dẫn bảo mật & phân quyền đúng chính sách.',220000.0000,'facebook.png',JSON_ARRAY('facebook.png','fb2.png'),22,81,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','bm-basic','attributes', JSON_OBJECT('package','basic','support','7d'),'price',220000.0000,'inventory_count',12,'status','Available'),
   JSON_OBJECT('variant_code','bm-pro','attributes', JSON_OBJECT('package','pro','support','30d'),'price',480000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1018,1,'SOCIAL','TIKTOK','TikTok Live – Setup & Coaching','Thiết lập Live + coaching.','Cài đặt TikTok Live Studio, cấu hình cảnh & âm thanh, huấn luyện vận hành.',350000.0000,'tiktok-live.png',JSON_ARRAY('tiktok-live.png'),18,69,'Available','CUSTOM',JSON_ARRAY(
+(1018,1,'SOCIAL','TIKTOK','TikTok Live – Setup & Coaching','Thiết lập Live + coaching.','Cài đặt TikTok Live Studio, cấu hình cảnh & âm thanh, huấn luyện vận hành.',350000.0000,'tiktoklive.png',JSON_ARRAY('tiktoklive.png','tiktok.png','tiktok2.png'),18,69,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','ttlive-basic','attributes', JSON_OBJECT('package','basic','sessions',1),'price',350000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','ttlive-pro','attributes', JSON_OBJECT('package','pro','sessions',3),'price',900000.0000,'inventory_count',8,'status','Available')
 ),NOW(),NOW()),
-(1019,1,'EMAIL','GMAIL','Gmail gói bảo hành 3 tháng','Gmail bảo hành 3 tháng, hỗ trợ bảo mật.','Tài khoản Gmail mới, hỗ trợ kỹ thuật trong 3 tháng.',270000.0000,'gmail.png',JSON_ARRAY('gmail.png'),20,102,'Available','DURATION_PLAN',JSON_ARRAY(
+(1019,1,'EMAIL','GMAIL','Gmail gói bảo hành 3 tháng','Gmail bảo hành 3 tháng, hỗ trợ bảo mật.','Tài khoản Gmail mới, hỗ trợ kỹ thuật trong 3 tháng.',270000.0000,'gmail.png',JSON_ARRAY('gmail.png','gmail2.jpg','mailedu.png'),20,102,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','gmail-3m','attributes', JSON_OBJECT('service','gmail','plan','standard','duration','3m'),'price',270000.0000,'inventory_count',12,'status','Available'),
   JSON_OBJECT('variant_code','gmail-12m','attributes', JSON_OBJECT('service','gmail','plan','standard','duration','12m'),'price',1000000.0000,'inventory_count',8,'status','Available')
 ),NOW(),NOW()),
-(1020,1,'SOFTWARE','OTHER','Office 365 Family 12 tháng (6 người)','Chia sẻ Office 365 Family hợp lệ.','Gói Office 365 Family 12 tháng cho 6 tài khoản, hướng dẫn kích hoạt.',890000.0000,'office365.png',JSON_ARRAY('office365.png'),16,130,'Available','DURATION_PLAN',JSON_ARRAY(
+(1020,1,'SOFTWARE','OTHER','Office 365 Family 12 tháng (6 người)','Chia sẻ Office 365 Family hợp lệ.','Gói Office 365 Family 12 tháng cho 6 tài khoản, hướng dẫn kích hoạt.',890000.0000,'office.jpg',JSON_ARRAY('office.jpg','win11.jpg'),16,130,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','o365family-12m','attributes', JSON_OBJECT('seats',6,'duration','12m'),'price',890000.0000,'inventory_count',16,'status','Available')
 ),NOW(),NOW()),
-(1021,1,'SOFTWARE','OTHER','Adobe Photoshop (Key 12 tháng)','Key kích hoạt Photoshop 12 tháng.','Cung cấp key Adobe Photoshop dùng 12 tháng cho cá nhân.',1500000.0000,'adobe-ps.png',JSON_ARRAY('adobe-ps.png'),10,41,'Available','EDITION_LICENSE',JSON_ARRAY(
+(1021,1,'SOFTWARE','OTHER','Adobe Photoshop (Key 12 tháng)','Key kích hoạt Photoshop 12 tháng.','Cung cấp key Adobe Photoshop dùng 12 tháng cho cá nhân.',1500000.0000,'adope.jpg',JSON_ARRAY('adope.jpg','canva2.png'),10,41,'Available','EDITION_LICENSE',JSON_ARRAY(
   JSON_OBJECT('variant_code','ps-12m','attributes', JSON_OBJECT('product','Photoshop','term','12m'),'price',1500000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1022,1,'GAME','OTHER','Steam Wallet Code (VN)','Mã nạp Steam mệnh giá VN.','Cung cấp mã Steam Wallet Code theo mệnh giá phổ biến.',500000.0000,'steam.png',JSON_ARRAY('steam.png'),35,220,'Available','CUSTOM',JSON_ARRAY(
+(1022,1,'GAME','OTHER','Steam Wallet Code (VN)','Mã nạp Steam mệnh giá VN.','Cung cấp mã Steam Wallet Code theo mệnh giá phổ biến.',500000.0000,'steam.png',JSON_ARRAY('steam.png','valorant.png','varo.png'),35,220,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','steam-100k','attributes', JSON_OBJECT('amount','100000'),'price',105000.0000,'inventory_count',15,'status','Available'),
   JSON_OBJECT('variant_code','steam-200k','attributes', JSON_OBJECT('amount','200000'),'price',205000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','steam-500k','attributes', JSON_OBJECT('amount','500000'),'price',500000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1023,1,'GAME','VALORANT','Valorant – Skin Bundle Random','Account có skin bundle ngẫu nhiên.','Tài khoản Valorant unranked, sở hữu skin random; bảo hành đăng nhập.',350000.0000,'valorant-skin.png',JSON_ARRAY('valorant-skin.png'),9,33,'Available','CUSTOM',JSON_ARRAY(
+(1023,1,'GAME','VALORANT','Valorant – Skin Bundle Random','Account có skin bundle ngẫu nhiên.','Tài khoản Valorant unranked, sở hữu skin random; bảo hành đăng nhập.',350000.0000,'varo.png',JSON_ARRAY('varo.png','valorant.png'),9,33,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','valo-skin-rand','attributes', JSON_OBJECT('rank','Unranked','skin_bundle','random'),'price',350000.0000,'inventory_count',9,'status','Available')
 ),NOW(),NOW()),
-(1024,1,'SOCIAL','OTHER','Discord Nitro','Gói Discord Nitro theo thời hạn.','Discord Nitro hỗ trợ upload lớn, emoji & perks.',95000.0000,'discord.png',JSON_ARRAY('discord.png'),28,175,'Available','DURATION_PLAN',JSON_ARRAY(
+(1024,1,'SOCIAL','OTHER','Discord Nitro','Gói Discord Nitro theo thời hạn.','Discord Nitro hỗ trợ upload lớn, emoji & perks.',95000.0000,'telegram.png',JSON_ARRAY('telegram.png','tiktok2.png'),28,175,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','nitro-1m','attributes', JSON_OBJECT('service','discord','plan','nitro','duration','1m'),'price',95000.0000,'inventory_count',18,'status','Available'),
   JSON_OBJECT('variant_code','nitro-3m','attributes', JSON_OBJECT('service','discord','plan','nitro','duration','3m'),'price',270000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','nitro-12m','attributes', JSON_OBJECT('service','discord','plan','nitro','duration','12m'),'price',980000.0000,'inventory_count',5,'status','Available')
 ),NOW(),NOW()),
-(1025,1,'SOCIAL','FACEBOOK','Fanpage Template & Hướng dẫn','Bộ template + hướng dẫn vận hành fanpage.','Tài nguyên số cho fanpage: template bài viết, checklist, lịch đăng.',120000.0000,'facebook-page.png',JSON_ARRAY('facebook-page.png'),40,95,'Available','CUSTOM',JSON_ARRAY(
+(1025,1,'SOCIAL','FACEBOOK','Fanpage Template & Hướng dẫn','Bộ template + hướng dẫn vận hành fanpage.','Tài nguyên số cho fanpage: template bài viết, checklist, lịch đăng.',120000.0000,'facebook.png',JSON_ARRAY('facebook.png','fb2.png'),40,95,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','fp-template-basic','attributes', JSON_OBJECT('package','basic'),'price',120000.0000,'inventory_count',25,'status','Available'),
   JSON_OBJECT('variant_code','fp-template-pro','attributes', JSON_OBJECT('package','pro'),'price',240000.0000,'inventory_count',15,'status','Available')
 ),NOW(),NOW()),
-(1026,1,'SOCIAL','TIKTOK','TikTok Shop – Gói đào tạo','Đào tạo vận hành TikTok Shop.','Khoá đào tạo 1:1/nhóm về vận hành TikTok Shop.',650000.0000,'tiktok-course.png',JSON_ARRAY('tiktok-course.png'),12,58,'Available','CUSTOM',JSON_ARRAY(
+(1026,1,'SOCIAL','TIKTOK','TikTok Shop – Gói đào tạo','Đào tạo vận hành TikTok Shop.','Khoá đào tạo 1:1/nhóm về vận hành TikTok Shop.',650000.0000,'tiktok2.png',JSON_ARRAY('tiktok2.png','tiktok.png'),12,58,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','tttrain-1s','attributes', JSON_OBJECT('sessions',1,'duration','2h'),'price',650000.0000,'inventory_count',7,'status','Available'),
   JSON_OBJECT('variant_code','tttrain-3s','attributes', JSON_OBJECT('sessions',3,'duration','6h'),'price',1800000.0000,'inventory_count',5,'status','Available')
 ),NOW(),NOW()),
-(1027,1,'EMAIL','GMAIL','Gmail – Cài đặt Forward & Filter','Thiết lập chuyển tiếp, bộ lọc, nhãn chuyên nghiệp.','Dịch vụ thiết kế hệ thống hộp thư: forward, filter, nhãn, auto-reply.',170000.0000,'gmail-setup.png',JSON_ARRAY('gmail-setup.png'),25,60,'Available','CUSTOM',JSON_ARRAY(
+(1027,1,'EMAIL','GMAIL','Gmail – Cài đặt Forward & Filter','Thiết lập chuyển tiếp, bộ lọc, nhãn chuyên nghiệp.','Dịch vụ thiết kế hệ thống hộp thư: forward, filter, nhãn, auto-reply.',170000.0000,'gmail2.jpg',JSON_ARRAY('gmail2.jpg','gmail.png','mailedu.png'),25,60,'Available','CUSTOM',JSON_ARRAY(
   JSON_OBJECT('variant_code','gmail-setup-basic','attributes', JSON_OBJECT('package','basic'),'price',170000.0000,'inventory_count',15,'status','Available'),
   JSON_OBJECT('variant_code','gmail-setup-pro','attributes', JSON_OBJECT('package','pro'),'price',320000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW()),
-(1028,1,'SOFTWARE','CANVA','Canva Pro – Gia hạn 36 tháng','Gia hạn Canva Pro 24–36 tháng.','Dịch vụ gia hạn Canva Pro dài hạn tiết kiệm.',2300000.0000,'canva-extend.png',JSON_ARRAY('canva-extend.png'),6,22,'Available','DURATION_PLAN',JSON_ARRAY(
+(1028,1,'SOFTWARE','CANVA','Canva Pro – Gia hạn 36 tháng','Gia hạn Canva Pro 24–36 tháng.','Dịch vụ gia hạn Canva Pro dài hạn tiết kiệm.',2300000.0000,'canva2.png',JSON_ARRAY('canva2.png','canva.jpg'),6,22,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','canva-24m','attributes', JSON_OBJECT('service','canva','duration','24m'),'price',1600000.0000,'inventory_count',3,'status','Available'),
   JSON_OBJECT('variant_code','canva-36m','attributes', JSON_OBJECT('service','canva','duration','36m'),'price',2300000.0000,'inventory_count',3,'status','Available')
 ),NOW(),NOW()),
-(1029,1,'EMAIL','GMAIL','Gmail Edu (tuỳ trường)','Gmail Edu dung lượng lớn, dùng cho học tập.','Tài khoản Gmail Edu (tuỳ trường), kèm hướng dẫn bảo mật & sử dụng.',300000.0000,'gmail-edu.png',JSON_ARRAY('gmail-edu.png'),18,70,'Available','DURATION_PLAN',JSON_ARRAY(
+(1029,1,'EMAIL','GMAIL','Gmail Edu (tuỳ trường)','Gmail Edu dung lượng lớn, dùng cho học tập.','Tài khoản Gmail Edu (tuỳ trường), kèm hướng dẫn bảo mật & sử dụng.',300000.0000,'mailedu.png',JSON_ARRAY('mailedu.png','gmail.png','gmail2.jpg'),18,70,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','gmail-edu-6m','attributes', JSON_OBJECT('service','gmail','segment','edu','duration','6m'),'price',300000.0000,'inventory_count',10,'status','Available'),
   JSON_OBJECT('variant_code','gmail-edu-12m','attributes', JSON_OBJECT('service','gmail','segment','edu','duration','12m'),'price',520000.0000,'inventory_count',8,'status','Available')
 ),NOW(),NOW()),
-(1030,1,'SOCIAL','OTHER','Telegram Premium','Nâng cấp Telegram Premium theo kỳ hạn.','Tính năng Premium: upload lớn, chuyển giọng nói sang text, sticker/emoji nâng cao.',115000.0000,'telegram-premium.png',JSON_ARRAY('telegram-premium.png'),26,110,'Available','DURATION_PLAN',JSON_ARRAY(
+(1030,1,'SOCIAL','OTHER','Telegram Premium','Nâng cấp Telegram Premium theo kỳ hạn.','Tính năng Premium: upload lớn, chuyển giọng nói sang text, sticker/emoji nâng cao.',115000.0000,'telegram.png',JSON_ARRAY('telegram.png','tiktok.png'),26,110,'Available','DURATION_PLAN',JSON_ARRAY(
   JSON_OBJECT('variant_code','tg-prem-1m','attributes', JSON_OBJECT('service','telegram','duration','1m'),'price',115000.0000,'inventory_count',16,'status','Available'),
   JSON_OBJECT('variant_code','tg-prem-12m','attributes', JSON_OBJECT('service','telegram','duration','12m'),'price',1150000.0000,'inventory_count',10,'status','Available')
 ),NOW(),NOW());

--- a/MMO_Trader_Market/src/java/controller/seller/SellerBaseController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerBaseController.java
@@ -1,0 +1,31 @@
+package controller.seller;
+
+import controller.BaseController;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+
+/**
+ * Base controller cho các màn hình dành riêng cho người bán. Đảm bảo người dùng
+ * đã đăng nhập và có vai trò SELLER trước khi truy cập trang quản lý cửa hàng.
+ */
+public abstract class SellerBaseController extends BaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    protected boolean ensureSellerAccess(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            response.sendRedirect(request.getContextPath() + "/auth");
+            return false;
+        }
+        Object role = session.getAttribute("userRole");
+        if (!(role instanceof Integer) || ((Integer) role) != 2) {
+            response.sendRedirect(request.getContextPath() + "/auth");
+            return false;
+        }
+        return true;
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/seller/SellerCreateProductController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerCreateProductController.java
@@ -1,0 +1,30 @@
+package controller.seller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Trang tạo sản phẩm mới cho người bán.
+ */
+@WebServlet(name = "SellerCreateProductController", urlPatterns = {"/seller/products/create"})
+public class SellerCreateProductController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+        request.setAttribute("pageTitle", "Tạo sản phẩm mới - Quản lý cửa hàng");
+        request.setAttribute("bodyClass", "layout");
+        request.setAttribute("headerTitle", "Tạo sản phẩm");
+        request.setAttribute("headerSubtitle", "Đăng bán sản phẩm MMO nhanh chóng");
+        request.setAttribute("headerModifier", "layout__header--split");
+        forward(request, response, "seller/create-product");
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/seller/SellerIncomeController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerIncomeController.java
@@ -1,0 +1,30 @@
+package controller.seller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Trang thống kê thu nhập cho người bán.
+ */
+@WebServlet(name = "SellerIncomeController", urlPatterns = {"/seller/income"})
+public class SellerIncomeController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+        request.setAttribute("pageTitle", "Thu nhập - Quản lý cửa hàng");
+        request.setAttribute("bodyClass", "layout");
+        request.setAttribute("headerTitle", "Thu nhập");
+        request.setAttribute("headerSubtitle", "Theo dõi doanh thu và dòng tiền");
+        request.setAttribute("headerModifier", "layout__header--split");
+        forward(request, response, "seller/income");
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/seller/SellerInventoryController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerInventoryController.java
@@ -1,0 +1,30 @@
+package controller.seller;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Trang cập nhật kho hàng dành cho người bán.
+ */
+@WebServlet(name = "SellerInventoryController", urlPatterns = {"/seller/inventory"})
+public class SellerInventoryController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+        request.setAttribute("pageTitle", "Cập nhật kho - Quản lý cửa hàng");
+        request.setAttribute("bodyClass", "layout");
+        request.setAttribute("headerTitle", "Cập nhật kho");
+        request.setAttribute("headerSubtitle", "Điều chỉnh tồn kho và trạng thái sản phẩm");
+        request.setAttribute("headerModifier", "layout__header--split");
+        forward(request, response, "seller/inventory");
+    }
+}

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -37,6 +37,13 @@ public final class NavigationBuilder {
                     isActive(currentPath, "/orders")));
         }
 
+        if (isSellerRole(roleId)) {
+            Map<String, Object> sellerDropdown = buildSellerDropdown(contextPath, currentPath);
+            if (sellerDropdown != null) {
+                items.add(sellerDropdown);
+            }
+        }
+
         addBaseItems(items, request, contextPath, currentPath);
 
         return items;
@@ -108,6 +115,48 @@ public final class NavigationBuilder {
         return dropdown;
     }
 
+    private static Map<String, Object> buildSellerDropdown(String contextPath, String currentPath) {
+        List<Map<String, Object>> children = new ArrayList<>();
+
+        Map<String, Object> dashboardItem = new HashMap<>();
+        dashboardItem.put("href", contextPath + "/dashboard");
+        dashboardItem.put("text", "Dashboard");
+        dashboardItem.put("label", "Dashboard");
+        boolean dashboardActive = isActive(currentPath, "/dashboard");
+        dashboardItem.put("active", dashboardActive);
+        children.add(dashboardItem);
+
+        Map<String, Object> createProductItem = new HashMap<>();
+        createProductItem.put("href", contextPath + "/seller/products/create");
+        createProductItem.put("text", "Tạo sản phẩm");
+        createProductItem.put("label", "Tạo sản phẩm");
+        boolean createActive = isActive(currentPath, "/seller/products/create");
+        createProductItem.put("active", createActive);
+        children.add(createProductItem);
+
+        Map<String, Object> inventoryItem = new HashMap<>();
+        inventoryItem.put("href", contextPath + "/seller/inventory");
+        inventoryItem.put("text", "Cập nhật kho");
+        inventoryItem.put("label", "Cập nhật kho");
+        boolean inventoryActive = isActive(currentPath, "/seller/inventory");
+        inventoryItem.put("active", inventoryActive);
+        children.add(inventoryItem);
+
+        Map<String, Object> incomeItem = new HashMap<>();
+        incomeItem.put("href", contextPath + "/seller/income");
+        incomeItem.put("text", "Thu nhập");
+        incomeItem.put("label", "Thu nhập");
+        boolean incomeActive = isActive(currentPath, "/seller/income");
+        incomeItem.put("active", incomeActive);
+        children.add(incomeItem);
+
+        boolean active = dashboardActive || createActive || inventoryActive || incomeActive;
+        Map<String, Object> dropdown = createNavItem(contextPath + "/dashboard", "Quản lý cửa hàng", active);
+        dropdown.put("dropdown", true);
+        dropdown.put("children", children);
+        return dropdown;
+    }
+
     private static boolean isActive(String currentPath, String path) {
         if (path == null || path.isEmpty()) {
             return currentPath == null || currentPath.isEmpty() || "/".equals(currentPath);
@@ -126,5 +175,9 @@ public final class NavigationBuilder {
 
     private static boolean isAdminRole(Integer roleId) {
         return roleId != null && roleId == 1;
+    }
+
+    private static boolean isSellerRole(Integer roleId) {
+        return roleId != null && roleId == 2;
     }
 }

--- a/MMO_Trader_Market/src/java/units/RoleHomeResolver.java
+++ b/MMO_Trader_Market/src/java/units/RoleHomeResolver.java
@@ -5,7 +5,7 @@ import model.Users;
 public final class RoleHomeResolver {
 
     public static final String ADMIN_HOME = "/admin";
-    private static final String SELLER_HOME = "/products";
+    private static final String SELLER_HOME = "/dashboard";
     private static final String BUYER_HOME = "/home";
 
     private RoleHomeResolver() {

--- a/MMO_Trader_Market/web/WEB-INF/views/Admin/_layout.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/Admin/_layout.jsp
@@ -66,6 +66,9 @@
         <div class="main">
             <div class="header">
                 <h5 class="m-0">${pageTitle != null ? pageTitle : "Bảng điều khiển"}</h5>
+                <a class="btn btn-outline-primary" href="${pageContext.request.contextPath}/home">
+                    <i class="bi bi-box-arrow-up-right me-2"></i>Về trang Market
+                </a>
             </div>
 
             <div class="page-content">

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/create-product.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/create-product.jsp
@@ -1,0 +1,57 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%
+    request.setAttribute("pageTitle", "Tạo sản phẩm mới - Quản lý cửa hàng");
+    request.setAttribute("bodyClass", "layout");
+    request.setAttribute("headerTitle", "Tạo sản phẩm mới");
+    request.setAttribute("headerSubtitle", "Điền thông tin cơ bản để đưa sản phẩm lên sàn");
+    request.setAttribute("headerModifier", "layout__header--split");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content seller-page">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Thông tin sản phẩm</h2>
+            <p class="panel__subtitle">Bổ sung mô tả chi tiết, giá bán và ảnh minh hoạ trước khi đăng bán.</p>
+        </div>
+        <div class="form-grid">
+            <div class="form-field">
+                <label class="form-label" for="product-name">Tên sản phẩm</label>
+                <input class="form-input" type="text" id="product-name" placeholder="Ví dụ: Gmail Doanh nghiệp 100GB" disabled>
+                <p class="form-note">Tính năng nhập liệu sẽ được kích hoạt trong các phiên bản tiếp theo.</p>
+            </div>
+            <div class="form-field">
+                <label class="form-label" for="product-type">Loại sản phẩm</label>
+                <input class="form-input" type="text" id="product-type" value="Email / Gmail" disabled>
+            </div>
+            <div class="form-field">
+                <label class="form-label" for="product-price">Giá bán (VNĐ)</label>
+                <input class="form-input" type="number" id="product-price" value="250000" disabled>
+            </div>
+            <div class="form-field">
+                <label class="form-label" for="product-gallery">Ảnh minh hoạ</label>
+                <input class="form-input" type="text" id="product-gallery" placeholder="Tải lên nhiều ảnh" disabled>
+            </div>
+        </div>
+        <div class="panel__footer">
+            <button class="button button--primary" type="button" disabled>
+                Lưu bản nháp
+            </button>
+            <button class="button button--ghost" type="button" disabled>
+                Gửi duyệt sản phẩm
+            </button>
+        </div>
+    </section>
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Mẹo đăng sản phẩm hiệu quả</h2>
+        </div>
+        <ul class="guide-list">
+            <li>Chuẩn bị ít nhất 3 hình ảnh minh hoạ chất lượng cao.</li>
+            <li>Nhập mô tả rõ ràng về quyền lợi bàn giao và chính sách bảo hành.</li>
+            <li>Cập nhật tồn kho thực tế để hệ thống tự động khóa đơn khi bán hết.</li>
+        </ul>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/income.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/income.jsp
@@ -1,0 +1,92 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%
+    request.setAttribute("pageTitle", "Thu nhập - Quản lý cửa hàng");
+    request.setAttribute("bodyClass", "layout");
+    request.setAttribute("headerTitle", "Thu nhập & doanh thu");
+    request.setAttribute("headerSubtitle", "Nắm bắt sức khỏe tài chính của cửa hàng trong nháy mắt");
+    request.setAttribute("headerModifier", "layout__header--split");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content seller-page">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Hiệu suất tháng này</h2>
+        </div>
+        <div class="panel__body dashboard__row">
+            <article class="stat-card">
+                <div class="icon icon--primary">💵</div>
+                <div>
+                    <p class="stat-card__label">Doanh thu đã giải ngân</p>
+                    <p class="stat-card__value">68.250.000 đ</p>
+                </div>
+            </article>
+            <article class="stat-card">
+                <div class="icon icon--accent">📈</div>
+                <div>
+                    <p class="stat-card__label">Tăng trưởng</p>
+                    <p class="stat-card__value">+18% so với tháng trước</p>
+                </div>
+            </article>
+            <article class="stat-card">
+                <div class="icon icon--muted">⏱️</div>
+                <div>
+                    <p class="stat-card__label">Đơn chờ giải ngân</p>
+                    <p class="stat-card__value">4</p>
+                </div>
+            </article>
+        </div>
+    </section>
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Chi tiết dòng tiền</h2>
+            <p class="panel__subtitle">Số liệu minh hoạ dùng để mô tả giao diện báo cáo thu nhập.</p>
+        </div>
+        <div class="panel__body">
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Ngày</th>
+                        <th>Diễn giải</th>
+                        <th>Số tiền</th>
+                        <th>Trạng thái</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>05/02</td>
+                        <td>Giải ngân đơn #5012</td>
+                        <td>+12.500.000 đ</td>
+                        <td><span class="badge">Đã nhận</span></td>
+                    </tr>
+                    <tr>
+                        <td>04/02</td>
+                        <td>Rút tiền về VCB</td>
+                        <td>-8.000.000 đ</td>
+                        <td><span class="badge badge--ghost">Đang xử lý</span></td>
+                    </tr>
+                    <tr>
+                        <td>02/02</td>
+                        <td>Giải ngân đơn #5008</td>
+                        <td>+6.750.000 đ</td>
+                        <td><span class="badge">Đã nhận</span></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Gợi ý tối ưu doanh thu</h2>
+        </div>
+        <div class="panel__body">
+            <ul class="guide-list">
+                <li>Kích hoạt mã giảm giá cho nhóm khách hàng thân thiết.</li>
+                <li>Theo dõi đơn chờ giải ngân và xử lý tranh chấp kịp thời.</li>
+                <li>Đăng thêm sản phẩm hot theo mùa (game, dịch vụ streaming).</li>
+            </ul>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/inventory.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/inventory.jsp
@@ -1,0 +1,75 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%
+    request.setAttribute("pageTitle", "Cập nhật kho - Quản lý cửa hàng");
+    request.setAttribute("bodyClass", "layout");
+    request.setAttribute("headerTitle", "Cập nhật kho hàng");
+    request.setAttribute("headerSubtitle", "Theo dõi nhanh trạng thái tồn kho của sản phẩm");
+    request.setAttribute("headerModifier", "layout__header--split");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content seller-page">
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Tồn kho tổng quan</h2>
+            <p class="panel__subtitle">Dữ liệu mô phỏng phục vụ giao diện quản lý, sẽ kết nối với API thực tế trong giai đoạn kế tiếp.</p>
+        </div>
+        <div class="panel__body">
+            <table class="table table--interactive">
+                <thead>
+                    <tr>
+                        <th>Sản phẩm</th>
+                        <th>Loại</th>
+                        <th>Tồn kho</th>
+                        <th>Đã bán</th>
+                        <th>Trạng thái</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Gmail Doanh nghiệp 50GB</td>
+                        <td>Email</td>
+                        <td>19</td>
+                        <td>128</td>
+                        <td><span class="badge">Available</span></td>
+                    </tr>
+                    <tr>
+                        <td>Tài khoản TikTok Pro</td>
+                        <td>Mạng xã hội</td>
+                        <td>40</td>
+                        <td>58</td>
+                        <td><span class="badge">Available</span></td>
+                    </tr>
+                    <tr>
+                        <td>Valorant VP (top-up)</td>
+                        <td>Game</td>
+                        <td>100</td>
+                        <td>121</td>
+                        <td><span class="badge badge--ghost">Pending</span></td>
+                    </tr>
+                    <tr>
+                        <td>Canva Pro chính chủ</td>
+                        <td>Phần mềm</td>
+                        <td>60</td>
+                        <td>187</td>
+                        <td><span class="badge">Available</span></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+    <section class="panel">
+        <div class="panel__header">
+            <h2 class="panel__title">Lịch sử điều chỉnh gần đây</h2>
+        </div>
+        <div class="panel__body">
+            <ul class="guide-list">
+                <li>29/01: +5 tồn kho cho Spotify Premium (restock thủ công).</li>
+                <li>26/01: -1 tồn kho sau đơn hàng #5002 (Disputed).</li>
+                <li>20/01: -1 tồn kho sau đơn hàng #5001 (Completed).</li>
+            </ul>
+        </div>
+    </section>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
+++ b/MMO_Trader_Market/web/WEB-INF/views/shared/header.jspf
@@ -30,6 +30,8 @@
 </c:url>
 <c:url value="/wallet" var="walletUrl" />
 <c:url value="/orders" var="ordersUrl" />
+<c:url value="/admin" var="adminDashboardUrl" />
+<c:url value="/dashboard" var="sellerDashboardUrl" />
 <c:set var="currentUri" value="${pageContext.request.requestURI}" />
 <c:set var="isAuthPage"
        value="${fn:contains(currentUri, '/auth')
@@ -142,6 +144,16 @@
 
         <!-- Account Actions -->
         <div class="site-header__actions">
+            <c:if test="${isLoggedIn and userRole eq 1}">
+                <a class="button button--ghost site-header__dashboard" href="${adminDashboardUrl}">
+                    Trang admin
+                </a>
+            </c:if>
+            <c:if test="${isLoggedIn and userRole eq 2}">
+                <a class="button button--ghost site-header__dashboard" href="${sellerDashboardUrl}">
+                    Xem dashboard
+                </a>
+            </c:if>
             <c:choose>
                 <c:when test="${isLoggedIn}">
                     <div class="menu menu--account" aria-label="Tài khoản người dùng">
@@ -155,6 +167,16 @@
                                 <span class="menu__dropdown-icon site-header__user-caret" aria-hidden="true">▾</span>
                             </button>
                             <div class="menu__dropdown-panel site-header__user-menu" role="menu">
+                                <c:if test="${userRole eq 1}">
+                                    <a class="menu__dropdown-item site-header__user-link" role="menuitem" href="${adminDashboardUrl}">
+                                        Trang quản trị
+                                    </a>
+                                </c:if>
+                                <c:if test="${userRole eq 2}">
+                                    <a class="menu__dropdown-item site-header__user-link" role="menuitem" href="${sellerDashboardUrl}">
+                                        Dashboard cửa hàng
+                                    </a>
+                                </c:if>
                                 <c:if test="${userRole eq 3}">
                                     <a class="menu__dropdown-item site-header__user-link" role="menuitem" href="${walletUrl}">
                                         Ví của tôi

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -221,6 +221,10 @@ code {
     justify-self: end;
 }
 
+.site-header__dashboard {
+    white-space: nowrap;
+}
+
 .site-header__actions .menu {
     align-items: center;
 }
@@ -447,6 +451,70 @@ code {
     padding: 1.75rem 2rem;
     display: grid;
     gap: 1.25rem;
+}
+
+.panel__footer {
+    display: flex;
+    gap: 1rem;
+    padding: 1.5rem 2rem;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.form-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+    .form-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.form-field {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.form-label {
+    font-weight: 600;
+    color: var(--text-light);
+}
+
+.form-input {
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: var(--surface-color);
+    font-size: 1rem;
+    transition: var(--transition);
+}
+
+.form-input:focus-visible {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(0, 91, 150, 0.15);
+}
+
+.form-input:disabled {
+    background: #f0f2f5;
+    color: var(--text-light);
+    cursor: not-allowed;
+}
+
+.form-note {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-light);
+}
+
+.guide-list {
+    margin: 0;
+    padding: 0 0 0 1.25rem;
+    display: grid;
+    gap: 0.5rem;
+    color: var(--text-light);
 }
 
 .stat-card {


### PR DESCRIPTION
## Summary
- add role-aware navigation items so admins can switch between sites and sellers get a "Quản lý cửa hàng" dropdown
- scaffold seller management pages and controllers that enforce seller-only access with placeholder content for dashboard, inventory, and income views
- expand database seed data so every product references multiple gallery images that exist in the asset bundle

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6900676ab7048320b426724859992f13