### PR TITLE
Refactor homepage into asynchronous fragments

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -5,12 +5,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import model.Shops;
-import model.SystemConfigs;
-import model.view.ConversationMessageView;
-import model.view.CustomerProfileView;
-import model.view.MarketplaceSummary;
-import model.view.product.ProductSummaryView;
 import service.HomepageService;
 
 import java.io.IOException;
@@ -40,50 +34,13 @@ public class HomepageController extends BaseController {
         request.setAttribute("pageTitle", "Chợ tài khoản MMO - Trang chủ");
         request.setAttribute("bodyClass", "layout layout--landing");
 
-        populateHomepageData(request); //để nạp toàn bộ dữ liệu cần cho giao diện.
-
         request.setAttribute("query", ""); //Set các filter mặc định
         request.setAttribute("selectedType", "");
         request.setAttribute("selectedSubtype", "");
+        request.setAttribute("typeOptions", homepageService.loadFilterTypeOptions());
+        request.setAttribute("faqs", buildFaqEntries());
 
         forward(request, response, "product/home");
-    }
-
-    // Tải toàn bộ dữ liệu cần thiết cho trang chủ và gán vào request.
-    private void populateHomepageData(HttpServletRequest request) {
-        MarketplaceSummary summary = homepageService.loadMarketplaceSummary();
-        request.setAttribute("summary", summary); //số liệu tổng quan
-
-        List<ProductSummaryView> featuredProducts = homepageService.loadFeaturedProducts();
-        request.setAttribute("featuredProducts", featuredProducts); //danh sách sản phẩm nổi bật
-
-        List<Shops> shops = homepageService.loadActiveShops();
-        request.setAttribute("shops", shops);
-        request.setAttribute("shopIcons", buildShopIconMap());
-
-        request.setAttribute("productCategories", homepageService.loadProductCategories()); //danh mục chính
-
-        CustomerProfileView profile = homepageService.loadHighlightedBuyer();
-        request.setAttribute("customerProfile", profile);
-
-        List<ConversationMessageView> messages = homepageService.loadRecentMessages();
-        request.setAttribute("recentMessages", messages);
-
-        List<SystemConfigs> systemNotes = homepageService.loadSystemNotes();
-        request.setAttribute("systemNotes", systemNotes);
-
-        request.setAttribute("faqs", buildFaqEntries());
-        
-        request.setAttribute("typeOptions", homepageService.loadFilterTypeOptions()); //tuỳ chọn filter loại sản phẩm
-    }
-
-    // Xây dựng bộ ánh xạ trạng thái shop sang biểu tượng hiển thị nhanh.
-    private Map<String, String> buildShopIconMap() {
-        Map<String, String> icons = new HashMap<>();
-        icons.put("Active", "🛍️");
-        icons.put("Pending", "⏳");
-        icons.put("Suspended", "⚠️");
-        return icons;
     }
 
     // Chuẩn bị danh sách câu hỏi thường gặp hiển thị trên trang chủ.

--- a/MMO_Trader_Market/src/java/controller/product/HomepageFragmentController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageFragmentController.java
@@ -1,0 +1,92 @@
+package controller.product;
+
+import controller.ViewResolver;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import model.view.product.ProductSummaryView;
+import service.HomepageService;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Cung cấp các fragment HTML cho trang chủ. Mỗi fragment được tải qua AJAX để
+ * tách riêng thành các transaction độc lập, tránh việc một truy vấn chậm làm
+ * chậm cả trang.
+ */
+@WebServlet(name = "HomepageFragmentController", urlPatterns = {"/fragment/home/*"})
+public class HomepageFragmentController extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    private final HomepageService homepageService = new HomepageService();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setCharacterEncoding("UTF-8");
+
+        String path = request.getPathInfo();
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        switch (path) {
+            case "/summary" -> handleSummary(request, response);
+            case "/featured" -> handleFeatured(request, response);
+            case "/system-notes" -> handleSystemNotes(request, response);
+            default -> response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
+    }
+
+    private void handleSummary(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute("summary", homepageService.loadMarketplaceSummary());
+        request.setAttribute("productCategories", homepageService.loadProductCategories());
+        response.setContentType("text/html;charset=UTF-8");
+        response.setHeader("Cache-Control", "public, max-age=60");
+        renderFragment(request, response, "product/fragments/home/summary");
+    }
+
+    private void handleFeatured(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        int limit = parsePositiveInt(request.getParameter("limit"));
+        List<ProductSummaryView> featured = limit > 0
+                ? homepageService.loadFeaturedProducts(limit)
+                : homepageService.loadFeaturedProducts();
+        request.setAttribute("featuredProducts", featured);
+        response.setContentType("text/html;charset=UTF-8");
+        response.setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+        renderFragment(request, response, "product/fragments/home/featured");
+    }
+
+    private void handleSystemNotes(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        request.setAttribute("systemNotes", homepageService.loadSystemNotes());
+        response.setContentType("text/html;charset=UTF-8");
+        response.setHeader("Cache-Control", "public, max-age=300");
+        renderFragment(request, response, "product/fragments/home/system-notes");
+    }
+
+    private void renderFragment(HttpServletRequest request, HttpServletResponse response, String view)
+            throws ServletException, IOException {
+        String jsp = ViewResolver.resolve(view);
+        request.getRequestDispatcher(jsp).forward(request, response);
+    }
+
+    private int parsePositiveInt(String value) {
+        if (value == null || value.isBlank()) {
+            return -1;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed > 0 ? parsed : -1;
+        } catch (NumberFormatException ex) {
+            return -1;
+        }
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/featured.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/featured.jsp
@@ -1,0 +1,82 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<c:set var="cPath" value="${pageContext.request.contextPath}" />
+
+<div class="panel__header">
+    <h3 class="panel__title">Sản phẩm nổi bật</h3>
+    <span class="panel__tag">Dữ liệu trực tiếp</span>
+</div>
+
+<div class="landing__products">
+    <c:choose>
+        <c:when test="${empty featuredProducts}">
+            <p>Chưa có dữ liệu.</p>
+        </c:when>
+        <c:otherwise>
+            <c:forEach var="product" items="${featuredProducts}">
+                <article class="product-card product-card--featured product-card--grid">
+                    <div class="product-card__image product-card__media">
+                        <c:choose>
+                            <c:when test="${not empty product.primaryImageUrl}">
+                                <c:set var="featuredImageSource" value="${product.primaryImageUrl}" />
+                                <c:choose>
+                                    <c:when test="${fn:startsWith(featuredImageSource, 'http://')
+                                                    or fn:startsWith(featuredImageSource, 'https://')
+                                                    or fn:startsWith(featuredImageSource, '//')
+                                                    or fn:startsWith(featuredImageSource, 'data:')
+                                                    or fn:startsWith(featuredImageSource, cPath)}">
+                                        <c:set var="featuredImageUrl" value="${featuredImageSource}" />
+                                    </c:when>
+                                    <c:otherwise>
+                                        <c:url var="featuredImageUrl" value="${featuredImageSource}" />
+                                    </c:otherwise>
+                                </c:choose>
+                                <img class="product-card__img" src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
+                            </c:when>
+                            <c:otherwise>
+                                <div class="product-card__placeholder">Không có ảnh</div>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                    <div class="product-card__body product-card__body--stack">
+                        <header class="product-card__header">
+                            <h4><c:out value="${product.name}" /></h4>
+                        </header>
+                        <p class="product-card__meta">
+                            <span><c:out value="${product.productTypeLabel}" /> • <c:out value="${product.productSubtypeLabel}" /></span>
+                            <span>Shop: <strong><c:out value="${product.shopName}" /></strong></span>
+                        </p>
+                        <p class="product-card__description"><c:out value="${product.shortDescription}" /></p>
+                        <p class="product-card__price">
+                            <c:choose>
+                                <c:when test="${product.minPrice eq product.maxPrice}">
+                                    Giá
+                                    <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                </c:when>
+                                <c:otherwise>
+                                    Giá từ
+                                    <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                    –
+                                    <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
+                                </c:otherwise>
+                            </c:choose>
+                        </p>
+                        <ul class="product-card__meta product-card__meta--stats">
+                            <li>Tồn kho: <strong><c:out value="${product.inventoryCount}" /></strong></li>
+                            <li>Đã bán: <strong><c:out value="${product.soldCount}" /></strong></li>
+                        </ul>
+                        <footer class="product-card__footer">
+                            <c:url var="detailUrl" value="/product/detail/${product.encodedId}" />
+                            <div class="product-card__actions product-card__actions--justify">
+                                <a class="button button--primary product-card__cta" href="${detailUrl}">Xem chi tiết</a>
+                            </div>
+                        </footer>
+                    </div>
+                </article>
+            </c:forEach>
+        </c:otherwise>
+    </c:choose>
+</div>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/summary.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/summary.jsp
@@ -1,0 +1,61 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<c:set var="cPath" value="${pageContext.request.contextPath}" />
+
+<div class="landing__hero-main">
+    <h2>Chợ tài khoản MMO chuyên nghiệp, UY TÍN </h2>
+    <p class="landing__lead">
+        Điều mà chúng tôi đã đạt được:
+    </p>
+    <c:choose>
+        <c:when test="${not empty summary}">
+            <ul class="landing__metrics">
+                <li>
+                    <strong>
+                        <fmt:formatNumber value="${summary.totalCompletedOrders}" type="number" />
+                    </strong> đơn đã hoàn tất
+                </li>
+                <li>
+                    <strong>
+                        <fmt:formatNumber value="${summary.activeShopCount}" type="number" />
+                    </strong> shop đang hoạt động
+                </li>
+                <li>
+                    <strong>
+                        <fmt:formatNumber value="${summary.activeBuyerCount}" type="number" />
+                    </strong> người mua đã xác minh
+                </li>
+            </ul>
+        </c:when>
+        <c:otherwise>
+            <p>Dữ liệu thống kê sẽ được cập nhật trong giây lát.</p>
+        </c:otherwise>
+    </c:choose>
+</div>
+
+<aside class="landing__categories" id="product-types">
+    <h3 class="landing__aside-title">Danh mục chính</h3>
+    <c:choose>
+        <c:when test="${empty productCategories}">
+            <p>Đang cập nhật dữ liệu.</p>
+        </c:when>
+        <c:otherwise>
+            <ul class="category-menu">
+                <c:forEach var="category" items="${productCategories}">
+                    <c:url var="categoryUrl" value="/products">
+                        <c:param name="type" value="${category.typeCode}" />
+                    </c:url>
+                    <li class="category-menu__item">
+                        <span class="category-menu__icon">🏷️</span>
+                        <div>
+                            <strong><a href="${categoryUrl}"><c:out value="${category.typeLabel}" /></a></strong>
+                            <p><fmt:formatNumber value="${category.availableProducts}" type="number" /> sản phẩm khả dụng</p>
+                        </div>
+                    </li>
+                </c:forEach>
+            </ul>
+        </c:otherwise>
+    </c:choose>
+</aside>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/system-notes.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/system-notes.jsp
@@ -1,0 +1,18 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<div class="panel__header">
+    <h3 class="panel__title">Cấu hình hệ thống</h3>
+</div>
+<c:if test="${empty systemNotes}">
+    <p>Chưa có dữ liệu.</p>
+</c:if>
+<c:if test="${not empty systemNotes}">
+    <ol class="tips-list">
+        <c:forEach var="config" items="${systemNotes}">
+            <li>
+                <strong><c:out value="${config.description}" /></strong>
+            </li>
+        </c:forEach>
+    </ol>
+</c:if>

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <fmt:setLocale value="vi_VN" scope="request" />
 <c:set var="cPath" value="${pageContext.request.contextPath}" />
+<c:set var="fragmentBase" value="${cPath}/fragment/home" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content landing">
@@ -24,134 +25,16 @@
         </div>
     </section>
 
-    <section class="panel landing__hero">
-        <div class="landing__hero-main">
-            <h2>Chợ tài khoản MMO chuyên nghiệp, UY TÍN </h2>
-            <p class="landing__lead">
-                Điều mà chúng tôi đã đạt được:
-            </p>
-            <c:set var="summary" value="${summary}" />
-            <ul class="landing__metrics">
-                <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.totalCompletedOrders}" type="number" />
-                    </strong> đơn đã hoàn tất
-                </li>
-                <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.activeShopCount}" type="number" />
-                    </strong> shop đang hoạt động
-                </li>
-                <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.activeBuyerCount}" type="number" />
-                    </strong> người mua đã xác minh
-                </li>
-            </ul>
+    <section class="panel landing__hero" id="home-summary" data-fragment-url="${fragmentBase}/summary">
+        <div class="fragment fragment--loading">
+            <p>Đang tải dữ liệu tổng quan...</p>
         </div>
-
-        <aside class="landing__categories" id="product-types">
-            <h3 class="landing__aside-title">Danh mục chính</h3>
-            <c:choose>
-                <c:when test="${empty productCategories}">
-                    <p>Đang cập nhật dữ liệu.</p>
-                </c:when>
-                <c:otherwise>
-                    <ul class="category-menu">
-                        <c:forEach var="category" items="${productCategories}">
-                            <c:url var="categoryUrl" value="/products">
-                                <c:param name="type" value="${category.typeCode}" />
-                            </c:url>
-                            <li class="category-menu__item">
-                                <span class="category-menu__icon">🏷️</span>
-                                <div>
-                                    <strong><a href="${categoryUrl}"><c:out value="${category.typeLabel}" /></a></strong>
-                                    <p><fmt:formatNumber value="${category.availableProducts}" type="number" /> sản phẩm khả dụng</p>
-                                </div>
-                            </li>
-                        </c:forEach>
-                    </ul>
-                </c:otherwise>
-            </c:choose>
-        </aside>
     </section>
 
 
-    <section class="panel landing__section">
-        <div class="panel__header">
-            <h3 class="panel__title">Sản phẩm nổi bật</h3>
-            <span class="panel__tag">Dữ liệu trực tiếp</span>
-        </div>
-
-        <div class="landing__products">
-            <c:choose>
-                <c:when test="${empty featuredProducts}">
-                    <p>Chưa có dữ liệu.</p>
-                </c:when>
-                <c:otherwise>
-                    <c:forEach var="product" items="${featuredProducts}">
-                        <article class="product-card product-card--featured product-card--grid">
-                            <div class="product-card__image product-card__media">
-                                <c:choose>
-                                    <c:when test="${not empty product.primaryImageUrl}">
-                                        <c:set var="featuredImageSource" value="${product.primaryImageUrl}" />
-                                        <c:choose>
-                                            <c:when test="${fn:startsWith(featuredImageSource, 'http://')
-                                                            or fn:startsWith(featuredImageSource, 'https://')
-                                                            or fn:startsWith(featuredImageSource, '//')
-                                                            or fn:startsWith(featuredImageSource, 'data:')
-                                                            or fn:startsWith(featuredImageSource, cPath)}">
-                                                <c:set var="featuredImageUrl" value="${featuredImageSource}" />
-                                            </c:when>
-                                            <c:otherwise>
-                                                <c:url var="featuredImageUrl" value="${featuredImageSource}" />
-                                            </c:otherwise>
-                                        </c:choose>
-                                        <img class="product-card__img" src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
-                            </div>
-                            <div class="product-card__body product-card__body--stack">
-                                <header class="product-card__header">
-                                    <h4><c:out value="${product.name}" /></h4>
-                                </header>
-                                <p class="product-card__meta">
-                                    <span><c:out value="${product.productTypeLabel}" /> • <c:out value="${product.productSubtypeLabel}" /></span>
-                                    <span>Shop: <strong><c:out value="${product.shopName}" /></strong></span>
-                                </p>
-                                <p class="product-card__description"><c:out value="${product.shortDescription}" /></p>
-                                <p class="product-card__price">
-                                    <c:choose>
-                                        <c:when test="${product.minPrice eq product.maxPrice}">
-                                            Giá
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:when>
-                                        <c:otherwise>
-                                            Giá từ
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                            –
-                                            <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:otherwise>
-                                    </c:choose>
-                                </p>
-                                <ul class="product-card__meta product-card__meta--stats">
-                                    <li>Tồn kho: <strong><c:out value="${product.inventoryCount}" /></strong></li>
-                                    <li>Đã bán: <strong><c:out value="${product.soldCount}" /></strong></li>
-                                </ul>
-                                <footer class="product-card__footer">
-                                    <c:url var="detailUrl" value="/product/detail/${product.encodedId}" />
-                                    <div class="product-card__actions product-card__actions--justify">
-                                        <a class="button button--primary product-card__cta" href="${detailUrl}">Xem chi tiết</a>
-                                    </div>
-                                </footer>
-                            </div>
-                        </article>
-                    </c:forEach>
-                </c:otherwise>
-            </c:choose>
+    <section class="panel landing__section" id="home-featured" data-fragment-url="${fragmentBase}/featured">
+        <div class="fragment fragment--loading">
+            <p>Đang tải sản phẩm nổi bật...</p>
         </div>
     </section>
 
@@ -177,25 +60,14 @@
         </div>
     </section>
 
-    <section class="panel landing__section">
-        <div class="panel__header">
-            <h3 class="panel__title">Cấu hình hệ thống</h3>
+    <section class="panel landing__section" id="system-notes" data-fragment-url="${fragmentBase}/system-notes">
+        <div class="fragment fragment--loading">
+            <p>Đang tải cấu hình hệ thống...</p>
         </div>
-        <c:if test="${empty systemNotes}">
-            <p>Chưa có dữ liệu.</p>
-        </c:if>
-        <c:if test="${not empty systemNotes}">
-            <ol class="tips-list">
-                <c:forEach var="config" items="${systemNotes}">
-                    <li>
-                        <strong><c:out value="${config.description}" /></strong>
-                    </li>
-                </c:forEach>
-            </ol>
-        </c:if>
     </section>
 
 </main>
 
+<script src="${cPath}/assets/Script/home.js" defer></script>
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/assets/Script/home.js
+++ b/MMO_Trader_Market/web/assets/Script/home.js
@@ -1,0 +1,32 @@
+(function () {
+    function loadFragment(container) {
+        var url = container.getAttribute('data-fragment-url');
+        if (!url) {
+            return;
+        }
+        fetch(url, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest'
+            }
+        })
+            .then(function (response) {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.text();
+            })
+            .then(function (html) {
+                container.innerHTML = html;
+                container.classList.remove('fragment--error');
+            })
+            .catch(function () {
+                container.classList.add('fragment--error');
+                container.innerHTML = '<p>Không thể tải dữ liệu. Vui lòng thử lại sau.</p>';
+            });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var containers = document.querySelectorAll('[data-fragment-url]');
+        containers.forEach(loadFragment);
+    });
+})();


### PR DESCRIPTION
## Summary
- stop loading heavy homepage data inside the main /home request and instead serve lightweight placeholders
- add a fragment controller plus JSP partials that deliver summary, featured products, and system notes over dedicated requests
- load the fragments on the client with a new JavaScript helper so each homepage block becomes its own transaction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690478e8bb3c8320af024b24e737731f