### PR TITLE
Refactor homepage to load fragments asynchronously

### DIFF
--- a/MMO_Trader_Market/src/java/controller/product/HomepageController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageController.java
@@ -5,19 +5,13 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import model.Shops;
-import model.SystemConfigs;
-import model.view.ConversationMessageView;
-import model.view.CustomerProfileView;
-import model.view.MarketplaceSummary;
-import model.view.product.ProductSummaryView;
 import service.HomepageService;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 
 /**
  * Điều phối luồng "Trang chủ" dành cho khách truy cập.
@@ -40,7 +34,7 @@ public class HomepageController extends BaseController {
         request.setAttribute("pageTitle", "Chợ tài khoản MMO - Trang chủ");
         request.setAttribute("bodyClass", "layout layout--landing");
 
-        populateHomepageData(request); //để nạp toàn bộ dữ liệu cần cho giao diện.
+        prepareStaticContent(request);
 
         request.setAttribute("query", ""); //Set các filter mặc định
         request.setAttribute("selectedType", "");
@@ -49,41 +43,10 @@ public class HomepageController extends BaseController {
         forward(request, response, "product/home");
     }
 
-    // Tải toàn bộ dữ liệu cần thiết cho trang chủ và gán vào request.
-    private void populateHomepageData(HttpServletRequest request) {
-        MarketplaceSummary summary = homepageService.loadMarketplaceSummary();
-        request.setAttribute("summary", summary); //số liệu tổng quan
-
-        List<ProductSummaryView> featuredProducts = homepageService.loadFeaturedProducts();
-        request.setAttribute("featuredProducts", featuredProducts); //danh sách sản phẩm nổi bật
-
-        List<Shops> shops = homepageService.loadActiveShops();
-        request.setAttribute("shops", shops);
-        request.setAttribute("shopIcons", buildShopIconMap());
-
-        request.setAttribute("productCategories", homepageService.loadProductCategories()); //danh mục chính
-
-        CustomerProfileView profile = homepageService.loadHighlightedBuyer();
-        request.setAttribute("customerProfile", profile);
-
-        List<ConversationMessageView> messages = homepageService.loadRecentMessages();
-        request.setAttribute("recentMessages", messages);
-
-        List<SystemConfigs> systemNotes = homepageService.loadSystemNotes();
-        request.setAttribute("systemNotes", systemNotes);
-
+    // Chuẩn bị các dữ liệu tĩnh cần cho skeleton trang chủ.
+    private void prepareStaticContent(HttpServletRequest request) {
         request.setAttribute("faqs", buildFaqEntries());
-        
-        request.setAttribute("typeOptions", homepageService.loadFilterTypeOptions()); //tuỳ chọn filter loại sản phẩm
-    }
-
-    // Xây dựng bộ ánh xạ trạng thái shop sang biểu tượng hiển thị nhanh.
-    private Map<String, String> buildShopIconMap() {
-        Map<String, String> icons = new HashMap<>();
-        icons.put("Active", "🛍️");
-        icons.put("Pending", "⏳");
-        icons.put("Suspended", "⚠️");
-        return icons;
+        request.setAttribute("typeOptions", homepageService.loadFilterTypeOptions());
     }
 
     // Chuẩn bị danh sách câu hỏi thường gặp hiển thị trên trang chủ.

--- a/MMO_Trader_Market/src/java/controller/product/HomepageFragmentController.java
+++ b/MMO_Trader_Market/src/java/controller/product/HomepageFragmentController.java
@@ -1,0 +1,199 @@
+package controller.product;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import model.SystemConfigs;
+import model.view.MarketplaceSummary;
+import model.view.product.ProductCategorySummary;
+import model.view.product.ProductSummaryView;
+import service.HomepageService;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * API trả về từng khối dữ liệu trang chủ dưới dạng JSON để giao diện nạp rời.
+ */
+@WebServlet(name = "HomepageFragmentController", urlPatterns = {"/api/home/*"})
+public class HomepageFragmentController extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(HomepageFragmentController.class.getName());
+
+    private static final int DEFAULT_FEATURED_LIMIT = 6;
+
+    private final HomepageService homepageService = new HomepageService();
+    private final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd").create();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+
+        String fragment = resolveFragment(request.getPathInfo());
+        if (fragment.isEmpty()) {
+            writeError(response, HttpServletResponse.SC_BAD_REQUEST, "Thiếu fragment cần lấy dữ liệu");
+            return;
+        }
+
+        try {
+            switch (fragment) {
+                case "summary" -> renderSummary(response);
+                case "categories" -> renderCategories(response);
+                case "highlights" -> renderHighlights(request, response);
+                case "system-notes" -> renderSystemNotes(response);
+                default -> writeError(response, HttpServletResponse.SC_NOT_FOUND, "Fragment không tồn tại");
+            }
+        } catch (RuntimeException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể tải fragment homepage: " + fragment, ex);
+            writeError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Không thể tải dữ liệu, vui lòng thử lại sau.");
+        }
+    }
+
+    private void renderSummary(HttpServletResponse response) throws IOException {
+        MarketplaceSummary summary = homepageService.loadMarketplaceSummary();
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("summary", summary);
+        writeJson(response, payload);
+    }
+
+    private void renderCategories(HttpServletResponse response) throws IOException {
+        List<ProductCategorySummary> categories = homepageService.loadProductCategories();
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("categories", categories);
+        writeJson(response, payload);
+    }
+
+    private void renderHighlights(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        int limit = parsePositiveInt(request.getParameter("limit"), DEFAULT_FEATURED_LIMIT);
+        List<ProductSummaryView> products = homepageService.loadFeaturedProducts(limit);
+        List<ProductHighlight> highlights = new ArrayList<>();
+        for (ProductSummaryView product : products) {
+            highlights.add(ProductHighlight.from(product));
+        }
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("products", highlights);
+        writeJson(response, payload);
+    }
+
+    private void renderSystemNotes(HttpServletResponse response) throws IOException {
+        List<SystemConfigs> configs = homepageService.loadSystemNotes();
+        List<SystemNote> notes = new ArrayList<>();
+        for (SystemConfigs config : configs) {
+            notes.add(new SystemNote(config.getId(), config.getConfigKey(), config.getDescription()));
+        }
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("notes", notes);
+        writeJson(response, payload);
+    }
+
+    private String resolveFragment(String pathInfo) {
+        if (pathInfo == null || pathInfo.isBlank()) {
+            return "";
+        }
+        String normalized = pathInfo.trim();
+        if (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        return normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private int parsePositiveInt(String raw, int defaultValue) {
+        if (raw == null || raw.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            int value = Integer.parseInt(raw);
+            return value > 0 ? value : defaultValue;
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+
+    private void writeJson(HttpServletResponse response, Object payload) throws IOException {
+        try (PrintWriter writer = response.getWriter()) {
+            writer.write(gson.toJson(payload));
+        }
+    }
+
+    private void writeError(HttpServletResponse response, int status, String message) throws IOException {
+        response.setStatus(status);
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("error", message);
+        writeJson(response, payload);
+    }
+
+    private static final class ProductHighlight {
+        private final int id;
+        private final String encodedId;
+        private final String name;
+        private final String shortDescription;
+        private final String primaryImageUrl;
+        private final String productTypeLabel;
+        private final String productSubtypeLabel;
+        private final String shopName;
+        private final BigDecimal minPrice;
+        private final BigDecimal maxPrice;
+        private final Integer inventoryCount;
+        private final Integer soldCount;
+
+        private ProductHighlight(int id, String encodedId, String name, String shortDescription, String primaryImageUrl,
+                String productTypeLabel, String productSubtypeLabel, String shopName, BigDecimal minPrice,
+                BigDecimal maxPrice, Integer inventoryCount, Integer soldCount) {
+            this.id = id;
+            this.encodedId = encodedId;
+            this.name = name;
+            this.shortDescription = shortDescription;
+            this.primaryImageUrl = primaryImageUrl;
+            this.productTypeLabel = productTypeLabel;
+            this.productSubtypeLabel = productSubtypeLabel;
+            this.shopName = shopName;
+            this.minPrice = minPrice;
+            this.maxPrice = maxPrice;
+            this.inventoryCount = inventoryCount;
+            this.soldCount = soldCount;
+        }
+
+        private static ProductHighlight from(ProductSummaryView view) {
+            return new ProductHighlight(
+                    view.getId(),
+                    view.getEncodedId(),
+                    view.getName(),
+                    view.getShortDescription(),
+                    view.getPrimaryImageUrl(),
+                    view.getProductTypeLabel(),
+                    view.getProductSubtypeLabel(),
+                    view.getShopName(),
+                    view.getMinPrice(),
+                    view.getMaxPrice(),
+                    view.getInventoryCount(),
+                    view.getSoldCount()
+            );
+        }
+    }
+
+    private static final class SystemNote {
+        private final Integer id;
+        private final String key;
+        private final String description;
+
+        private SystemNote(Integer id, String key, String description) {
+            this.id = id;
+            this.key = key;
+            this.description = Optional.ofNullable(description).orElse("");
+        }
+    }
+}

--- a/MMO_Trader_Market/src/java/service/HomepageService.java
+++ b/MMO_Trader_Market/src/java/service/HomepageService.java
@@ -36,9 +36,11 @@ import java.util.Objects;
 public class HomepageService {
 
     // Số lượng shop tối đa hiển thị ở trang chủ.
-    private static final int SHOP_LIMIT = 4;
+    private static final int DEFAULT_SHOP_LIMIT = 4;
+    private static final int MAX_SHOP_LIMIT = 12;
     // Số lượng tin nhắn chứng thực hiển thị.
-    private static final int MESSAGE_LIMIT = 3;
+    private static final int DEFAULT_MESSAGE_LIMIT = 3;
+    private static final int MAX_MESSAGE_LIMIT = 12;
 
     // Dịch vụ sản phẩm để lấy dữ liệu hiển thị.
     private final ProductService productService = new ProductService();
@@ -62,10 +64,25 @@ public class HomepageService {
     }
 
     /**
+     * Lấy danh sách sản phẩm nổi bật với khả năng điều chỉnh giới hạn.
+     */
+    public List<ProductSummaryView> loadFeaturedProducts(int limit) {
+        return productService.getHomepageHighlights(limit);
+    }
+
+    /**
      * Truy vấn các shop đang hoạt động để hiển thị trong carousel.
      */
     public List<Shops> loadActiveShops() {
-        return shopDAO.findActive(SHOP_LIMIT);
+        return loadActiveShops(DEFAULT_SHOP_LIMIT);
+    }
+
+    /**
+     * Truy vấn shop đang hoạt động với giới hạn linh hoạt.
+     */
+    public List<Shops> loadActiveShops(int limit) {
+        int resolvedLimit = Math.max(1, Math.min(limit, MAX_SHOP_LIMIT));
+        return shopDAO.findActive(resolvedLimit);
     }
 
     /**
@@ -99,7 +116,15 @@ public class HomepageService {
      * Lấy danh sách tin nhắn gần nhất để hiển thị bằng block testimonial.
      */
     public List<ConversationMessageView> loadRecentMessages() {
-        return conversationMessageDAO.findLatest(MESSAGE_LIMIT);
+        return loadRecentMessages(DEFAULT_MESSAGE_LIMIT);
+    }
+
+    /**
+     * Lấy danh sách tin nhắn mới nhất với giới hạn linh hoạt.
+     */
+    public List<ConversationMessageView> loadRecentMessages(int limit) {
+        int resolvedLimit = Math.max(1, Math.min(limit, MAX_MESSAGE_LIMIT));
+        return conversationMessageDAO.findLatest(resolvedLimit);
     }
 
     /**

--- a/MMO_Trader_Market/src/java/service/ProductService.java
+++ b/MMO_Trader_Market/src/java/service/ProductService.java
@@ -51,6 +51,7 @@ public class ProductService {
 
     // Số lượng sản phẩm nổi bật hiển thị trên trang chủ.
     private static final int DEFAULT_HOMEPAGE_LIMIT = 6;
+    private static final int MAX_HOMEPAGE_LIMIT = 24;
     // Số lượng sản phẩm tương tự hiển thị ở trang chi tiết.
     private static final int DEFAULT_SIMILAR_LIMIT = 4;
     // Đường dẫn gốc tới thư mục ảnh sản phẩm.
@@ -118,7 +119,18 @@ public class ProductService {
      * {@link ProductSummaryView}.
      */
     public List<ProductSummaryView> getHomepageHighlights() {
-        List<ProductListRow> rows = productDAO.findTopAvailable(DEFAULT_HOMEPAGE_LIMIT);
+        return getHomepageHighlights(DEFAULT_HOMEPAGE_LIMIT);
+    }
+
+    /**
+     * Lấy danh sách sản phẩm nổi bật với giới hạn linh hoạt.
+     *
+     * @param limit số lượng sản phẩm mong muốn
+     * @return danh sách sản phẩm nổi bật đã ánh xạ
+     */
+    public List<ProductSummaryView> getHomepageHighlights(int limit) {
+        int resolvedLimit = Math.max(1, Math.min(limit, MAX_HOMEPAGE_LIMIT));
+        List<ProductListRow> rows = productDAO.findTopAvailable(resolvedLimit);
         return rows.stream().map(this::toSummaryView).toList();
     }
 

--- a/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/home.jsp
@@ -6,6 +6,10 @@
 <c:set var="cPath" value="${pageContext.request.contextPath}" />
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<div id="homepage-config"
+     data-context-path="${cPath}"
+     data-products-url="${cPath}/products"
+     data-product-detail-base="${cPath}/product/detail/"></div>
 <main class="layout__content landing">
 
     <section class="panel landing__filters">
@@ -25,54 +29,33 @@
     </section>
 
     <section class="panel landing__hero">
-        <div class="landing__hero-main">
+        <div class="landing__hero-main"
+             data-fragment-type="summary"
+             data-fragment-endpoint="${cPath}/api/home/summary">
             <h2>Chợ tài khoản MMO chuyên nghiệp, UY TÍN </h2>
             <p class="landing__lead">
                 Điều mà chúng tôi đã đạt được:
             </p>
-            <c:set var="summary" value="${summary}" />
             <ul class="landing__metrics">
                 <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.totalCompletedOrders}" type="number" />
-                    </strong> đơn đã hoàn tất
+                    <strong class="metric-value" data-field="totalCompletedOrders">--</strong> đơn đã hoàn tất
                 </li>
                 <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.activeShopCount}" type="number" />
-                    </strong> shop đang hoạt động
+                    <strong class="metric-value" data-field="activeShopCount">--</strong> shop đang hoạt động
                 </li>
                 <li>
-                    <strong>
-                        <fmt:formatNumber value="${summary.activeBuyerCount}" type="number" />
-                    </strong> người mua đã xác minh
+                    <strong class="metric-value" data-field="activeBuyerCount">--</strong> người mua đã xác minh
                 </li>
             </ul>
+            <p class="fragment__status" data-fragment-status>Đang tải thống kê...</p>
         </div>
 
-        <aside class="landing__categories" id="product-types">
+        <aside class="landing__categories" id="product-types"
+               data-fragment-type="categories"
+               data-fragment-endpoint="${cPath}/api/home/categories">
             <h3 class="landing__aside-title">Danh mục chính</h3>
-            <c:choose>
-                <c:when test="${empty productCategories}">
-                    <p>Đang cập nhật dữ liệu.</p>
-                </c:when>
-                <c:otherwise>
-                    <ul class="category-menu">
-                        <c:forEach var="category" items="${productCategories}">
-                            <c:url var="categoryUrl" value="/products">
-                                <c:param name="type" value="${category.typeCode}" />
-                            </c:url>
-                            <li class="category-menu__item">
-                                <span class="category-menu__icon">🏷️</span>
-                                <div>
-                                    <strong><a href="${categoryUrl}"><c:out value="${category.typeLabel}" /></a></strong>
-                                    <p><fmt:formatNumber value="${category.availableProducts}" type="number" /> sản phẩm khả dụng</p>
-                                </div>
-                            </li>
-                        </c:forEach>
-                    </ul>
-                </c:otherwise>
-            </c:choose>
+            <ul class="category-menu" data-fragment-list></ul>
+            <p class="fragment__status" data-fragment-status>Đang tải danh mục...</p>
         </aside>
     </section>
 
@@ -83,75 +66,10 @@
             <span class="panel__tag">Dữ liệu trực tiếp</span>
         </div>
 
-        <div class="landing__products">
-            <c:choose>
-                <c:when test="${empty featuredProducts}">
-                    <p>Chưa có dữ liệu.</p>
-                </c:when>
-                <c:otherwise>
-                    <c:forEach var="product" items="${featuredProducts}">
-                        <article class="product-card product-card--featured product-card--grid">
-                            <div class="product-card__image product-card__media">
-                                <c:choose>
-                                    <c:when test="${not empty product.primaryImageUrl}">
-                                        <c:set var="featuredImageSource" value="${product.primaryImageUrl}" />
-                                        <c:choose>
-                                            <c:when test="${fn:startsWith(featuredImageSource, 'http://')
-                                                            or fn:startsWith(featuredImageSource, 'https://')
-                                                            or fn:startsWith(featuredImageSource, '//')
-                                                            or fn:startsWith(featuredImageSource, 'data:')
-                                                            or fn:startsWith(featuredImageSource, cPath)}">
-                                                <c:set var="featuredImageUrl" value="${featuredImageSource}" />
-                                            </c:when>
-                                            <c:otherwise>
-                                                <c:url var="featuredImageUrl" value="${featuredImageSource}" />
-                                            </c:otherwise>
-                                        </c:choose>
-                                        <img class="product-card__img" src="${featuredImageUrl}" alt="Ảnh sản phẩm ${fn:escapeXml(product.name)}" loading="lazy" />
-                                    </c:when>
-                                    <c:otherwise>
-                                        <div class="product-card__placeholder">Không có ảnh</div>
-                                    </c:otherwise>
-                                </c:choose>
-                            </div>
-                            <div class="product-card__body product-card__body--stack">
-                                <header class="product-card__header">
-                                    <h4><c:out value="${product.name}" /></h4>
-                                </header>
-                                <p class="product-card__meta">
-                                    <span><c:out value="${product.productTypeLabel}" /> • <c:out value="${product.productSubtypeLabel}" /></span>
-                                    <span>Shop: <strong><c:out value="${product.shopName}" /></strong></span>
-                                </p>
-                                <p class="product-card__description"><c:out value="${product.shortDescription}" /></p>
-                                <p class="product-card__price">
-                                    <c:choose>
-                                        <c:when test="${product.minPrice eq product.maxPrice}">
-                                            Giá
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:when>
-                                        <c:otherwise>
-                                            Giá từ
-                                            <fmt:formatNumber value="${product.minPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                            –
-                                            <fmt:formatNumber value="${product.maxPrice}" type="currency" currencySymbol="đ" minFractionDigits="0" maxFractionDigits="0" />
-                                        </c:otherwise>
-                                    </c:choose>
-                                </p>
-                                <ul class="product-card__meta product-card__meta--stats">
-                                    <li>Tồn kho: <strong><c:out value="${product.inventoryCount}" /></strong></li>
-                                    <li>Đã bán: <strong><c:out value="${product.soldCount}" /></strong></li>
-                                </ul>
-                                <footer class="product-card__footer">
-                                    <c:url var="detailUrl" value="/product/detail/${product.encodedId}" />
-                                    <div class="product-card__actions product-card__actions--justify">
-                                        <a class="button button--primary product-card__cta" href="${detailUrl}">Xem chi tiết</a>
-                                    </div>
-                                </footer>
-                            </div>
-                        </article>
-                    </c:forEach>
-                </c:otherwise>
-            </c:choose>
+        <div class="landing__products"
+             data-fragment-type="highlights"
+             data-fragment-endpoint="${cPath}/api/home/highlights?limit=6">
+            <p class="fragment__status" data-fragment-status>Đang tải sản phẩm nổi bật...</p>
         </div>
     </section>
 
@@ -177,25 +95,18 @@
         </div>
     </section>
 
-    <section class="panel landing__section">
+    <section class="panel landing__section"
+             data-fragment-type="systemNotes"
+             data-fragment-endpoint="${cPath}/api/home/system-notes">
         <div class="panel__header">
             <h3 class="panel__title">Cấu hình hệ thống</h3>
         </div>
-        <c:if test="${empty systemNotes}">
-            <p>Chưa có dữ liệu.</p>
-        </c:if>
-        <c:if test="${not empty systemNotes}">
-            <ol class="tips-list">
-                <c:forEach var="config" items="${systemNotes}">
-                    <li>
-                        <strong><c:out value="${config.description}" /></strong>
-                    </li>
-                </c:forEach>
-            </ol>
-        </c:if>
+        <ol class="tips-list" data-fragment-list></ol>
+        <p class="fragment__status" data-fragment-status>Đang tải ghi chú hệ thống...</p>
     </section>
 
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<script src="${cPath}/assets/Script/homepage.js" defer></script>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/assets/Script/homepage.js
+++ b/MMO_Trader_Market/web/assets/Script/homepage.js
@@ -1,0 +1,373 @@
+(function () {
+    const config = document.getElementById('homepage-config');
+    if (!config) {
+        return;
+    }
+
+    const contextPath = config.dataset.contextPath || '';
+    const productsUrl = config.dataset.productsUrl || (contextPath + '/products');
+    const detailBase = config.dataset.productDetailBase || (contextPath + '/product/detail/');
+
+    const numberFormatter = new Intl.NumberFormat('vi-VN');
+    const currencyFormatter = new Intl.NumberFormat('vi-VN', {
+        style: 'currency',
+        currency: 'VND',
+        maximumFractionDigits: 0,
+        minimumFractionDigits: 0
+    });
+
+    const fragments = document.querySelectorAll('[data-fragment-endpoint]');
+    if (!fragments.length) {
+        return;
+    }
+
+    const context = {
+        contextPath,
+        productsUrl,
+        detailBase,
+        numberFormatter,
+        currencyFormatter
+    };
+
+    const renderers = {
+        summary(container, payload, ctx) {
+            const summary = payload && payload.summary;
+            if (!summary) {
+                setStatus(container, 'Không có dữ liệu thống kê.');
+                return;
+            }
+            setMetric(container, 'totalCompletedOrders', summary.totalCompletedOrders, ctx.numberFormatter);
+            setMetric(container, 'activeShopCount', summary.activeShopCount, ctx.numberFormatter);
+            setMetric(container, 'activeBuyerCount', summary.activeBuyerCount, ctx.numberFormatter);
+            setStatus(container, '');
+        },
+        categories(container, payload, ctx) {
+            const list = container.querySelector('[data-fragment-list]');
+            if (!list) {
+                setStatus(container, 'Không thể hiển thị danh mục.');
+                return;
+            }
+            clearChildren(list);
+            const categories = payload && Array.isArray(payload.categories) ? payload.categories : [];
+            if (!categories.length) {
+                list.appendChild(createTextItem('Chưa có danh mục khả dụng.'));
+                setStatus(container, '');
+                return;
+            }
+            categories.forEach((category) => {
+                list.appendChild(renderCategory(category, ctx));
+            });
+            setStatus(container, '');
+        },
+        highlights(container, payload, ctx) {
+            const statusEl = container.querySelector('[data-fragment-status]');
+            if (statusEl) {
+                statusEl.remove();
+            }
+            clearChildren(container);
+            const products = payload && Array.isArray(payload.products) ? payload.products : [];
+            if (!products.length) {
+                container.appendChild(createTextParagraph('Chưa có dữ liệu.'));
+                return;
+            }
+            products.forEach((product) => {
+                container.appendChild(renderProductCard(product, ctx));
+            });
+        },
+        systemNotes(container, payload) {
+            const list = container.querySelector('[data-fragment-list]');
+            if (!list) {
+                setStatus(container, 'Không thể hiển thị ghi chú.');
+                return;
+            }
+            clearChildren(list);
+            const notes = payload && Array.isArray(payload.notes) ? payload.notes : [];
+            if (!notes.length) {
+                list.appendChild(createTextItem('Chưa có ghi chú hệ thống.'));
+                setStatus(container, '');
+                return;
+            }
+            notes.forEach((note) => {
+                const li = document.createElement('li');
+                const strong = document.createElement('strong');
+                strong.textContent = note.description || note.key || '---';
+                li.appendChild(strong);
+                list.appendChild(li);
+            });
+            setStatus(container, '');
+        }
+    };
+
+    fragments.forEach((container) => {
+        const endpoint = container.dataset.fragmentEndpoint;
+        const type = container.dataset.fragmentType || container.dataset.fragment;
+        if (!endpoint || !type || !(type in renderers)) {
+            return;
+        }
+        const statusEl = ensureStatusElement(container);
+        if (statusEl && statusEl.textContent.trim().length === 0) {
+            statusEl.textContent = 'Đang tải dữ liệu...';
+        }
+        fetch(endpoint, {
+            headers: {
+                'Accept': 'application/json'
+            }
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('HTTP ' + response.status);
+                }
+                return response.json();
+            })
+            .then((data) => {
+                if (data && data.error) {
+                    throw new Error(data.error);
+                }
+                renderers[type](container, data || {}, context);
+            })
+            .catch((error) => {
+                console.error('Không thể tải fragment', type, error);
+                setStatus(container, 'Không tải được dữ liệu. Vui lòng thử lại.');
+            });
+    });
+
+    function ensureStatusElement(container) {
+        let statusEl = container.querySelector('[data-fragment-status]');
+        if (!statusEl) {
+            statusEl = document.createElement('p');
+            statusEl.className = 'fragment__status';
+            statusEl.setAttribute('data-fragment-status', '');
+            statusEl.textContent = '';
+            container.appendChild(statusEl);
+        }
+        return statusEl;
+    }
+
+    function setMetric(container, field, value, formatter) {
+        const target = container.querySelector('[data-field="' + field + '"]');
+        if (!target) {
+            return;
+        }
+        if (value === null || value === undefined) {
+            target.textContent = '--';
+            return;
+        }
+        target.textContent = typeof value === 'number' ? formatter.format(value) : value;
+    }
+
+    function setStatus(container, message) {
+        const statusEl = ensureStatusElement(container);
+        if (!statusEl) {
+            return;
+        }
+        if (!message) {
+            statusEl.textContent = '';
+            statusEl.style.display = 'none';
+        } else {
+            statusEl.textContent = message;
+            statusEl.style.display = '';
+        }
+    }
+
+    function clearChildren(element) {
+        if (!element) {
+            return;
+        }
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function createTextItem(content) {
+        const li = document.createElement('li');
+        li.textContent = content;
+        return li;
+    }
+
+    function createTextParagraph(content) {
+        const p = document.createElement('p');
+        p.textContent = content;
+        return p;
+    }
+
+    function renderCategory(category, ctx) {
+        const li = document.createElement('li');
+        li.className = 'category-menu__item';
+
+        const icon = document.createElement('span');
+        icon.className = 'category-menu__icon';
+        icon.textContent = '🏷️';
+        li.appendChild(icon);
+
+        const wrapper = document.createElement('div');
+        const strong = document.createElement('strong');
+        const link = document.createElement('a');
+        link.href = buildCategoryUrl(category.typeCode, ctx.productsUrl);
+        link.textContent = category.typeLabel || category.typeCode || 'Danh mục';
+        strong.appendChild(link);
+        wrapper.appendChild(strong);
+
+        const description = document.createElement('p');
+        const total = typeof category.availableProducts === 'number'
+            ? ctx.numberFormatter.format(category.availableProducts)
+            : '0';
+        description.textContent = total + ' sản phẩm khả dụng';
+        wrapper.appendChild(description);
+
+        li.appendChild(wrapper);
+        return li;
+    }
+
+    function buildCategoryUrl(typeCode, baseUrl) {
+        if (!typeCode) {
+            return baseUrl;
+        }
+        const url = new URL(baseUrl, window.location.origin);
+        url.searchParams.set('type', typeCode);
+        return url.toString().replace(window.location.origin, '');
+    }
+
+    function renderProductCard(product, ctx) {
+        const article = document.createElement('article');
+        article.className = 'product-card product-card--featured product-card--grid';
+
+        const media = document.createElement('div');
+        media.className = 'product-card__image product-card__media';
+        const imageUrl = resolveImageUrl(product.primaryImageUrl, ctx.contextPath);
+        if (imageUrl) {
+            const img = document.createElement('img');
+            img.className = 'product-card__img';
+            img.src = imageUrl;
+            img.loading = 'lazy';
+            img.alt = 'Ảnh sản phẩm ' + (product.name || '');
+            media.appendChild(img);
+        } else {
+            const placeholder = document.createElement('div');
+            placeholder.className = 'product-card__placeholder';
+            placeholder.textContent = 'Không có ảnh';
+            media.appendChild(placeholder);
+        }
+        article.appendChild(media);
+
+        const body = document.createElement('div');
+        body.className = 'product-card__body product-card__body--stack';
+
+        const header = document.createElement('header');
+        header.className = 'product-card__header';
+        const title = document.createElement('h4');
+        title.textContent = product.name || 'Sản phẩm';
+        header.appendChild(title);
+        body.appendChild(header);
+
+        const meta = document.createElement('p');
+        meta.className = 'product-card__meta';
+        const typeSpan = document.createElement('span');
+        const typeLabel = product.productTypeLabel || '';
+        const subtypeLabel = product.productSubtypeLabel || '';
+        const separator = typeLabel && subtypeLabel ? ' • ' : '';
+        typeSpan.textContent = typeLabel + separator + subtypeLabel;
+        const shopSpan = document.createElement('span');
+        shopSpan.textContent = 'Shop: ';
+        const shopStrong = document.createElement('strong');
+        shopStrong.textContent = product.shopName || '---';
+        shopSpan.appendChild(shopStrong);
+        meta.appendChild(typeSpan);
+        meta.appendChild(shopSpan);
+        body.appendChild(meta);
+
+        const description = document.createElement('p');
+        description.className = 'product-card__description';
+        description.textContent = product.shortDescription || '';
+        body.appendChild(description);
+
+        const price = document.createElement('p');
+        price.className = 'product-card__price';
+        const minPrice = toNumber(product.minPrice);
+        const maxPrice = toNumber(product.maxPrice);
+        if (minPrice !== null && maxPrice !== null) {
+            if (minPrice === maxPrice) {
+                price.textContent = 'Giá ' + ctx.currencyFormatter.format(minPrice);
+            } else {
+                price.textContent = 'Giá từ ' + ctx.currencyFormatter.format(minPrice) + ' – '
+                    + ctx.currencyFormatter.format(maxPrice);
+            }
+        } else {
+            price.textContent = 'Liên hệ shop để biết giá.';
+        }
+        body.appendChild(price);
+
+        const stats = document.createElement('ul');
+        stats.className = 'product-card__meta product-card__meta--stats';
+        const inventory = document.createElement('li');
+        inventory.textContent = 'Tồn kho: ';
+        const inventoryStrong = document.createElement('strong');
+        inventoryStrong.textContent = renderNumber(product.inventoryCount, ctx.numberFormatter);
+        inventory.appendChild(inventoryStrong);
+        const sold = document.createElement('li');
+        sold.textContent = 'Đã bán: ';
+        const soldStrong = document.createElement('strong');
+        soldStrong.textContent = renderNumber(product.soldCount, ctx.numberFormatter);
+        sold.appendChild(soldStrong);
+        stats.appendChild(inventory);
+        stats.appendChild(sold);
+        body.appendChild(stats);
+
+        const footer = document.createElement('footer');
+        footer.className = 'product-card__footer';
+        const actions = document.createElement('div');
+        actions.className = 'product-card__actions product-card__actions--justify';
+        const link = document.createElement('a');
+        link.className = 'button button--primary product-card__cta';
+        link.href = buildDetailUrl(product.encodedId, ctx.detailBase);
+        link.textContent = 'Xem chi tiết';
+        actions.appendChild(link);
+        footer.appendChild(actions);
+        body.appendChild(footer);
+
+        article.appendChild(body);
+        return article;
+    }
+
+    function resolveImageUrl(source, contextPath) {
+        if (!source) {
+            return null;
+        }
+        const trimmed = source.trim();
+        if (!trimmed) {
+            return null;
+        }
+        if (/^(https?:)?\/\//i.test(trimmed) || trimmed.startsWith('data:')) {
+            return trimmed;
+        }
+        if (trimmed.startsWith(contextPath)) {
+            return trimmed;
+        }
+        if (trimmed.startsWith('/')) {
+            return contextPath + trimmed;
+        }
+        return contextPath + '/' + trimmed.replace(/^\/+/, '');
+    }
+
+    function toNumber(value) {
+        if (typeof value === 'number') {
+            return Number.isFinite(value) ? value : null;
+        }
+        if (typeof value === 'string' && value.trim() !== '') {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : null;
+        }
+        return null;
+    }
+
+    function renderNumber(value, formatter) {
+        const numeric = toNumber(value);
+        return numeric === null ? '0' : formatter.format(numeric);
+    }
+
+    function buildDetailUrl(encodedId, base) {
+        if (!encodedId) {
+            return base;
+        }
+        return base + encodedId;
+    }
+})();


### PR DESCRIPTION
## Summary
- add a dedicated `/api/home/*` servlet that serves homepage fragments as JSON
- allow homepage and product services to honour dynamic limits for highlights, shops and testimonials
- update the homepage JSP and add a new script so blocks load asynchronously from the new APIs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_690478e8bb3c8320af024b24e737731f