### PR TITLE
Surface wallet transaction details for orders

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -8,11 +8,13 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import model.Orders;
 import model.Products;
+import model.WalletTransactions;
 import model.view.OrderDetailView;
 import service.OrderService;
 import units.IdObfuscator;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -307,6 +309,17 @@ public class OrderController extends BaseController {
         Orders order = detail.order();
         Products product = detail.product();
         List<String> credentials = detail.credentials();
+        Optional<WalletTransactions> paymentTxOpt = orderService.getPaymentTransactionForOrder(order);
+        if (paymentTxOpt.isPresent()) {
+            WalletTransactions paymentTx = paymentTxOpt.get();
+            request.setAttribute("paymentTransaction", paymentTx);
+            request.setAttribute("paymentTransactionTypeLabel",
+                    orderService.getTransactionTypeLabel(paymentTx.getTransactionTypeEnum()));
+            BigDecimal amount = paymentTx.getAmount();
+            if (amount != null) {
+                request.setAttribute("paymentTransactionAmountAbs", amount.abs());
+            }
+        }
 
         request.setAttribute("order", order);
         request.setAttribute("product", product);

--- a/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
@@ -17,6 +17,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -60,23 +61,7 @@ public class WalletTransactionDAO {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    String s = rs.getString(COL_TRANSACTION_TYPE);
-                    if (s != null) {
-                        wt.setTransactionType(TransactionType.fromDbValue(s));
-                    }
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -180,24 +165,7 @@ public class WalletTransactionDAO {
             ps.setInt(14, offset);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    //map từ ENUM java --> enum DB
-                    String s = rs.getString(COL_TRANSACTION_TYPE); //"Deposit" | "Purchase" |
-                    TransactionType type = TransactionType.fromDbValue(s);
-
-                    wt.setTransactionType(type);
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -208,12 +176,70 @@ public class WalletTransactionDAO {
         return null;
     }
 
+    /**
+     * Tìm giao dịch ví theo mã đồng thời đảm bảo thuộc sở hữu của người dùng.
+     *
+     * @param transactionId mã giao dịch ví
+     * @param userId mã người dùng cần xác thực
+     * @return {@link Optional} chứa giao dịch nếu tìm thấy
+     */
+    public Optional<WalletTransactions> findByIdForUser(int transactionId, int userId) {
+        String sql = """
+              SELECT wt.*
+              FROM wallet_transactions AS wt
+              JOIN wallets AS w ON w.id = wt.wallet_id
+              WHERE wt.id = ? AND w.user_id = ?
+              LIMIT 1
+              """;
+        try (Connection con = DBConnect.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, transactionId);
+            ps.setInt(2, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapTransaction(rs, false));
+                }
+            }
+        } catch (SQLException e) {
+            Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.SEVERE,
+                    "Lỗi liên quan đến lấy dữ liệu từ DB", e);
+        }
+        return Optional.empty();
+    }
+
     public static void main(String[] args) {
         WalletTransactionDAO wdao = new WalletTransactionDAO();
         List<WalletTransactions> list = wdao.getListWalletTransactionPaging(1, 1, 5, null, null, null, null, null);
         for (WalletTransactions walletTransactions : list) {
             System.out.println(walletTransactions);
         }
+    }
+
+    private WalletTransactions mapTransaction(ResultSet rs, boolean includeWallet) throws SQLException {
+        WalletTransactions wt = new WalletTransactions();
+        wt.setId(rs.getInt(COL_ID));
+        int walletId = rs.getInt(COL_WALLET_ID);
+        wt.setWalletId(walletId);
+        if (includeWallet) {
+            wt.setWallet(wdao.getWalletById(walletId));
+        }
+        Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
+        wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
+        String s = rs.getString(COL_TRANSACTION_TYPE);
+        if (s != null) {
+            try {
+                wt.setTransactionType(TransactionType.fromDbValue(s));
+            } catch (IllegalArgumentException ex) {
+                Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.WARNING,
+                        "Không nhận diện được transaction_type {0}", s);
+            }
+        }
+        wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
+        wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
+        wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
+        wt.setNote(rs.getString(COL_NOTE));
+        Timestamp c = rs.getTimestamp(COL_CREATED_AT);
+        wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+        return wt;
     }
 
     public int insertTransaction(Connection connection, int walletId, Integer relatedEntityId, TransactionType type,

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -72,8 +72,8 @@
                  aria-labelledby="orderProcessingTitle" aria-describedby="orderProcessingMessage">
                 <h3 id="orderProcessingTitle">Đơn hàng đang được xử lý</h3>
                 <p id="orderProcessingMessage">
-                    Hệ thống đang khóa ví, kiểm tra tồn kho và nạp credential bàn giao.
-                    Vui lòng bấm "Xem chi tiết đơn hàng" để theo dõi trạng thái cập nhật theo thời gian thực.
+                    Hệ thống đang khóa ví, kiểm tra tồn kho, nạp credential bàn giao và ghi nhận giao dịch trừ tiền.
+                    Vui lòng bấm "Xem chi tiết đơn hàng" để theo dõi trạng thái cập nhật theo thời gian thực cùng thông tin giao dịch ví.
                 </p>
                 <div class="order-modal__actions">
                     <button type="button" class="button button--ghost" id="orderProcessingLater">Ở lại trang</button>
@@ -139,6 +139,35 @@
                         <li><span>Ngày tạo:</span>
                             <fmt:formatDate value="${order.createdAt}" pattern="dd/MM/yyyy HH:mm" />
                         </li>
+                        <c:if test="${not empty paymentTransaction}">
+                            <li><span>Mã giao dịch ví:</span> #<c:out value="${paymentTransaction.id}" /></li>
+                            <li><span>Loại giao dịch:</span> <c:out value="${paymentTransactionTypeLabel}" /></li>
+                            <li><span>Số tiền trừ:</span>
+                                <c:choose>
+                                    <c:when test="${not empty paymentTransactionAmountAbs}">
+                                        -<fmt:formatNumber value="${paymentTransactionAmountAbs}" type="currency" currencySymbol="" /> đ
+                                    </c:when>
+                                    <c:when test="${not empty paymentTransaction.amount}">
+                                        <fmt:formatNumber value="${paymentTransaction.amount}" type="currency" currencySymbol="" /> đ
+                                    </c:when>
+                                    <c:otherwise>
+                                        Không xác định
+                                    </c:otherwise>
+                                </c:choose>
+                            </li>
+                            <li><span>Số dư trước:</span>
+                                <fmt:formatNumber value="${paymentTransaction.balanceBefore}" type="currency" currencySymbol="" /> đ
+                            </li>
+                            <li><span>Số dư sau:</span>
+                                <fmt:formatNumber value="${paymentTransaction.balanceAfter}" type="currency" currencySymbol="" /> đ
+                            </li>
+                            <li><span>Thời gian thanh toán:</span>
+                                <fmt:formatDate value="${paymentTransaction.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                            </li>
+                            <c:if test="${not empty paymentTransaction.note}">
+                                <li><span>Ghi chú:</span> <c:out value="${paymentTransaction.note}" /></li>
+                            </c:if>
+                        </c:if>
                     </ul>
                 </div>
                 <div class="card">


### PR DESCRIPTION
## Summary
- expose the payment transaction attached to an order so the controller can pass it to the detail view
- extend the order service and wallet transaction DAO to fetch a buyer-owned wallet transaction and provide localized type labels
- show the captured wallet transaction data and richer processing guidance on the order detail page

## Testing
- Not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_69081acb510c832082f9096a0c27f00e