### PR TITLE
Add wallet timeline visualization on order detail page

### DIFF
--- a/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
@@ -17,6 +17,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -60,23 +61,7 @@ public class WalletTransactionDAO {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    String s = rs.getString(COL_TRANSACTION_TYPE);
-                    if (s != null) {
-                        wt.setTransactionType(TransactionType.fromDbValue(s));
-                    }
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -180,24 +165,7 @@ public class WalletTransactionDAO {
             ps.setInt(14, offset);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    //map từ ENUM java --> enum DB
-                    String s = rs.getString(COL_TRANSACTION_TYPE); //"Deposit" | "Purchase" |
-                    TransactionType type = TransactionType.fromDbValue(s);
-
-                    wt.setTransactionType(type);
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -208,12 +176,70 @@ public class WalletTransactionDAO {
         return null;
     }
 
+    /**
+     * Tìm giao dịch ví theo mã đồng thời đảm bảo thuộc sở hữu của người dùng.
+     *
+     * @param transactionId mã giao dịch ví
+     * @param userId mã người dùng cần xác thực
+     * @return {@link Optional} chứa giao dịch nếu tìm thấy
+     */
+    public Optional<WalletTransactions> findByIdForUser(int transactionId, int userId) {
+        String sql = """
+              SELECT wt.*
+              FROM wallet_transactions AS wt
+              JOIN wallets AS w ON w.id = wt.wallet_id
+              WHERE wt.id = ? AND w.user_id = ?
+              LIMIT 1
+              """;
+        try (Connection con = DBConnect.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, transactionId);
+            ps.setInt(2, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapTransaction(rs, false));
+                }
+            }
+        } catch (SQLException e) {
+            Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.SEVERE,
+                    "Lỗi liên quan đến lấy dữ liệu từ DB", e);
+        }
+        return Optional.empty();
+    }
+
     public static void main(String[] args) {
         WalletTransactionDAO wdao = new WalletTransactionDAO();
         List<WalletTransactions> list = wdao.getListWalletTransactionPaging(1, 1, 5, null, null, null, null, null);
         for (WalletTransactions walletTransactions : list) {
             System.out.println(walletTransactions);
         }
+    }
+
+    private WalletTransactions mapTransaction(ResultSet rs, boolean includeWallet) throws SQLException {
+        WalletTransactions wt = new WalletTransactions();
+        wt.setId(rs.getInt(COL_ID));
+        int walletId = rs.getInt(COL_WALLET_ID);
+        wt.setWalletId(walletId);
+        if (includeWallet) {
+            wt.setWallet(wdao.getWalletById(walletId));
+        }
+        Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
+        wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
+        String s = rs.getString(COL_TRANSACTION_TYPE);
+        if (s != null) {
+            try {
+                wt.setTransactionType(TransactionType.fromDbValue(s));
+            } catch (IllegalArgumentException ex) {
+                Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.WARNING,
+                        "Không nhận diện được transaction_type {0}", s);
+            }
+        }
+        wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
+        wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
+        wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
+        wt.setNote(rs.getString(COL_NOTE));
+        Timestamp c = rs.getTimestamp(COL_CREATED_AT);
+        wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+        return wt;
     }
 
     public int insertTransaction(Connection connection, int walletId, Integer relatedEntityId, TransactionType type,

--- a/MMO_Trader_Market/src/java/model/view/OrderWalletEvent.java
+++ b/MMO_Trader_Market/src/java/model/view/OrderWalletEvent.java
@@ -1,0 +1,71 @@
+package model.view;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * View model mô tả từng bước liên quan tới ví khi xử lý đơn hàng.
+ * <p>
+ * Mỗi sự kiện tương ứng với một hành động trong worker: đưa đơn vào hàng
+ * đợi, khóa ví, ghi nhận giao dịch... giúp giao diện trình bày luồng tiền dưới
+ * dạng timeline dễ hiểu cho người mua.</p>
+ */
+public class OrderWalletEvent {
+
+    private final String code;
+    private final String title;
+    private final String description;
+    private final Date occurredAt;
+    private final BigDecimal amount;
+    private final BigDecimal balanceAfter;
+    private final String reference;
+    private final boolean primary;
+
+    public OrderWalletEvent(String code, String title, String description, Date occurredAt,
+            BigDecimal amount, BigDecimal balanceAfter, String reference, boolean primary) {
+        this.code = code;
+        this.title = title;
+        this.description = description;
+        this.occurredAt = copyDate(occurredAt);
+        this.amount = amount;
+        this.balanceAfter = balanceAfter;
+        this.reference = reference;
+        this.primary = primary;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Date getOccurredAt() {
+        return copyDate(occurredAt);
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public BigDecimal getBalanceAfter() {
+        return balanceAfter;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    private static Date copyDate(Date input) {
+        return input == null ? null : new Date(input.getTime());
+    }
+}

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -9,9 +9,12 @@ import model.OrderStatus;
 import model.Orders;
 import model.PaginatedResult;
 import model.Products;
+import model.TransactionType;
 import model.product.ProductVariantOption;
 import model.view.OrderDetailView;
 import model.view.OrderRow;
+import model.view.OrderWalletEvent;
+import model.WalletTransactions;
 import model.Wallets;
 import queue.OrderQueueProducer;
 import queue.memory.InMemoryOrderQueue;
@@ -19,8 +22,13 @@ import service.util.ProductVariantUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,6 +55,7 @@ public class OrderService {
     );
     // Bảng ánh xạ trạng thái sang nhãn tiếng Việt.
     private static final Map<OrderStatus, String> STATUS_LABELS = buildStatusLabels();
+    private static final Map<TransactionType, String> TRANSACTION_TYPE_LABELS = buildTransactionTypeLabels();
 
     // DAO quản lý đơn hàng.
     private final OrderDAO orderDAO;
@@ -397,6 +406,130 @@ public class OrderService {
     }
 
     /**
+     * Lấy thông tin giao dịch thanh toán gắn với đơn hàng (nếu có).
+     *
+     * @param order bản ghi đơn hàng cần tra cứu
+     * @return {@link Optional} chứa giao dịch nếu tìm thấy và thuộc về người mua
+     */
+    public Optional<WalletTransactions> getPaymentTransactionForOrder(Orders order) {
+        if (order == null) {
+            return Optional.empty();
+        }
+        Integer txId = order.getPaymentTransactionId();
+        Integer buyerId = order.getBuyerId();
+        if (txId == null || buyerId == null) {
+            return Optional.empty();
+        }
+        return walletTransactionDAO.findByIdForUser(txId, buyerId);
+    }
+
+    /**
+     * Xây dựng timeline mô tả các bước thao tác ví cho đơn hàng.
+     *
+     * @param order bản ghi đơn cần hiển thị
+     * @param paymentTxOpt giao dịch ví thực tế (nếu đã ghi nhận)
+     * @return danh sách sự kiện theo thứ tự thời gian
+     */
+    public List<OrderWalletEvent> buildWalletTimeline(Orders order, Optional<WalletTransactions> paymentTxOpt) {
+        if (order == null) {
+            return Collections.emptyList();
+        }
+        List<OrderWalletEvent> events = new ArrayList<>();
+        Date createdAt = copyDate(order.getCreatedAt());
+        Integer orderId = order.getId();
+        events.add(new OrderWalletEvent(
+                "QUEUE_ENQUEUED",
+                "Đưa vào hàng đợi xử lý",
+                "Người mua xác nhận \"Mua ngay\". Hệ thống tạo đơn và gửi thông điệp cho worker bất đồng bộ.",
+                createdAt,
+                null,
+                null,
+                buildSyntheticReference("Q", orderId, 1),
+                false));
+
+        Date walletStepTime = copyDate(order.getUpdatedAt());
+        if (walletStepTime == null) {
+            walletStepTime = createdAt;
+        }
+        StringBuilder walletDesc = new StringBuilder("Worker khóa ví người mua, kiểm tra trạng thái hoạt động và số dư trước khi trừ tiền.");
+        BigDecimal totalAmount = order.getTotalAmount();
+        if (totalAmount != null) {
+            walletDesc.append(' ').append("Tổng tiền cần thanh toán: ")
+                    .append(formatCurrency(totalAmount)).append(" đ.");
+        }
+        events.add(new OrderWalletEvent(
+                "WALLET_VALIDATED",
+                "Kiểm tra số dư ví",
+                walletDesc.toString(),
+                walletStepTime,
+                totalAmount,
+                null,
+                buildSyntheticReference("V", orderId, 2),
+                false));
+
+        if (paymentTxOpt.isPresent()) {
+            WalletTransactions tx = paymentTxOpt.get();
+            Date transactionTime = copyDate(tx.getCreatedAt());
+            if (transactionTime == null) {
+                transactionTime = walletStepTime;
+            }
+            TransactionType type = tx.getTransactionTypeEnum();
+            String typeLabel = getTransactionTypeLabel(type);
+            String normalizedTypeLabel = typeLabel == null
+                    ? "thanh toán"
+                    : typeLabel.toLowerCase(Locale.ROOT);
+            String desc = "Ghi nhận giao dịch " + normalizedTypeLabel + " và cập nhật số dư ví.";
+            events.add(new OrderWalletEvent(
+                    "PAYMENT_CAPTURED",
+                    "Trừ tiền ví",
+                    desc,
+                    transactionTime,
+                    tx.getAmount(),
+                    tx.getBalanceAfter(),
+                    tx.getId() == null ? null : "#" + tx.getId(),
+                    true));
+        } else {
+            events.add(new OrderWalletEvent(
+                    "PAYMENT_PENDING",
+                    "Chờ ghi nhận giao dịch",
+                    "Worker đang xử lý các bước trừ tiền và sẽ cập nhật mã giao dịch ngay khi hoàn tất.",
+                    walletStepTime,
+                    null,
+                    null,
+                    buildSyntheticReference("P", orderId, 3),
+                    true));
+        }
+
+        String status = order.getStatus();
+        if (status != null && !status.isBlank()) {
+            Date statusTime = copyDate(order.getUpdatedAt());
+            String statusLabel = getStatusLabel(status);
+            String desc = "Trạng thái đơn hàng hiện tại: " + statusLabel + ".";
+            events.add(new OrderWalletEvent(
+                    "ORDER_STATUS",
+                    "Cập nhật trạng thái đơn",
+                    desc,
+                    statusTime,
+                    null,
+                    null,
+                    buildSyntheticReference("S", orderId, 4),
+                    false));
+        }
+
+        return events;
+    }
+
+    /**
+     * Trả về nhãn tiếng Việt cho loại giao dịch ví.
+     */
+    public String getTransactionTypeLabel(TransactionType type) {
+        if (type == null) {
+            return "Không xác định";
+        }
+        return TRANSACTION_TYPE_LABELS.getOrDefault(type, type.getDbValue());
+    }
+
+    /**
      * Chuẩn hóa trạng thái đầu vào (đầu chữ hoa, phần còn lại chữ thường) và
      * kiểm tra hợp lệ.
      */
@@ -427,6 +560,37 @@ public class OrderService {
         labels.put(OrderStatus.FAILED, "Thất bại");
         labels.put(OrderStatus.REFUNDED, "Đã hoàn tiền");
         labels.put(OrderStatus.DISPUTED, "Khiếu nại");
+        return labels;
+    }
+
+    private static Date copyDate(Date input) {
+        return input == null ? null : new Date(input.getTime());
+    }
+
+    private static String buildSyntheticReference(String prefix, Integer orderId, int step) {
+        if (prefix == null || orderId == null) {
+            return null;
+        }
+        int normalized = Math.max(orderId, 1);
+        String base = Integer.toString(normalized, 36).toUpperCase();
+        return prefix + '-' + base + '-' + step;
+    }
+
+    private static String formatCurrency(BigDecimal amount) {
+        NumberFormat format = NumberFormat.getNumberInstance(new Locale("vi", "VN"));
+        format.setMinimumFractionDigits(0);
+        format.setMaximumFractionDigits(2);
+        return format.format(amount);
+    }
+
+    private static Map<TransactionType, String> buildTransactionTypeLabels() {
+        Map<TransactionType, String> labels = new EnumMap<>(TransactionType.class);
+        labels.put(TransactionType.PURCHASE, "Thanh toán đơn hàng");
+        labels.put(TransactionType.DEPOSIT, "Nạp tiền vào ví");
+        labels.put(TransactionType.WITHDRAWAL, "Rút tiền");
+        labels.put(TransactionType.REFUND, "Hoàn tiền");
+        labels.put(TransactionType.FEE, "Phí giao dịch");
+        labels.put(TransactionType.PAYOUT, "Chi trả");
         return labels;
     }
 

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -72,8 +72,8 @@
                  aria-labelledby="orderProcessingTitle" aria-describedby="orderProcessingMessage">
                 <h3 id="orderProcessingTitle">Đơn hàng đang được xử lý</h3>
                 <p id="orderProcessingMessage">
-                    Hệ thống đang khóa ví, kiểm tra tồn kho và nạp credential bàn giao.
-                    Vui lòng bấm "Xem chi tiết đơn hàng" để theo dõi trạng thái cập nhật theo thời gian thực.
+                    Hệ thống đang khóa ví, kiểm tra tồn kho, nạp credential bàn giao và ghi nhận giao dịch trừ tiền.
+                    Vui lòng bấm "Xem chi tiết đơn hàng" để theo dõi trạng thái cập nhật theo thời gian thực cùng thông tin giao dịch ví.
                 </p>
                 <div class="order-modal__actions">
                     <button type="button" class="button button--ghost" id="orderProcessingLater">Ở lại trang</button>
@@ -115,31 +115,250 @@
             <h2 class="panel__title">Chi tiết đơn hàng #<c:out value="${order.id}" /></h2>
         </div>
         <div class="panel__body">
+            <style>
+                .order-detail__info-grid {
+                    display: flex;
+                    flex-wrap: wrap;
+                    gap: 2rem;
+                }
+
+                .order-detail__info-column {
+                    flex: 1 1 260px;
+                    min-width: 0;
+                }
+
+                .order-detail__info-column--wallet {
+                    border-left: 1px solid #e2e8f0;
+                    padding-left: 1.5rem;
+                }
+
+                .order-detail__info-title {
+                    margin: 0 0 1rem 0;
+                    font-size: 1.1rem;
+                    font-weight: 600;
+                    color: #0f172a;
+                }
+
+                .order-detail__info-subtitle {
+                    margin: 1.75rem 0 0.75rem;
+                    font-size: 1rem;
+                    font-weight: 600;
+                    color: #0f172a;
+                }
+
+                .order-wallet-timeline {
+                    list-style: none;
+                    margin: 0;
+                    padding: 0;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 1.25rem;
+                }
+
+                .order-wallet-timeline__item {
+                    display: flex;
+                    gap: 1rem;
+                    align-items: flex-start;
+                }
+
+                .order-wallet-timeline__badge {
+                    width: 2rem;
+                    height: 2rem;
+                    border-radius: 50%;
+                    background: #e2e8f0;
+                    color: #0f172a;
+                    font-weight: 600;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    flex-shrink: 0;
+                }
+
+                .order-wallet-timeline__item--primary .order-wallet-timeline__badge {
+                    background: #2563eb;
+                    color: #fff;
+                }
+
+                .order-wallet-timeline__content {
+                    flex: 1;
+                    min-width: 0;
+                    padding: 0.75rem 1rem;
+                    background: #f8fafc;
+                    border-radius: 12px;
+                    border: 1px solid #e2e8f0;
+                    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+                }
+
+                .order-wallet-timeline__item--primary .order-wallet-timeline__content {
+                    border-color: #2563eb;
+                    box-shadow: 0 16px 30px rgba(37, 99, 235, 0.12);
+                }
+
+                .order-wallet-timeline__header {
+                    display: flex;
+                    flex-wrap: wrap;
+                    align-items: center;
+                    gap: 0.5rem 1rem;
+                    margin-bottom: 0.5rem;
+                }
+
+                .order-wallet-timeline__title {
+                    font-weight: 600;
+                    color: #0f172a;
+                }
+
+                .order-wallet-timeline__time {
+                    font-size: 0.9rem;
+                    color: #475569;
+                }
+
+                .order-wallet-timeline__description {
+                    margin: 0 0 0.5rem 0;
+                    color: #475569;
+                    line-height: 1.6;
+                }
+
+                .order-wallet-timeline__reference {
+                    margin: 0 0 0.5rem 0;
+                    color: #0f172a;
+                    font-size: 0.95rem;
+                }
+
+                .order-wallet-timeline__reference span {
+                    font-weight: 600;
+                }
+
+                .order-wallet-timeline__metrics {
+                    margin-top: 0;
+                }
+
+                .order-wallet-timeline__metrics li span {
+                    min-width: 130px;
+                }
+
+                @media (max-width: 768px) {
+                    .order-detail__info-grid {
+                        flex-direction: column;
+                    }
+
+                    .order-detail__info-column--wallet {
+                        border-left: none;
+                        border-top: 1px solid #e2e8f0;
+                        padding-left: 0;
+                        padding-top: 1.5rem;
+                    }
+
+                    .order-wallet-timeline__item {
+                        flex-direction: column;
+                    }
+
+                    .order-wallet-timeline__badge {
+                        margin-bottom: 0.5rem;
+                    }
+                }
+            </style>
             <div class="grid grid--two-columns">
                 <div class="card">
                     <h3 class="card__title">Thông tin đơn</h3>
-                    <ul class="definition-list">
-                        <li><span>Mã đơn:</span> #<c:out value="${order.id}" /></li>
-                        <li><span>Sản phẩm:</span> <c:out value="${product.name}" /></li>
-                            <c:if test="${not empty order.variantCode}">
-                            <li><span>Biến thể:</span> <c:out value="${order.variantCode}" /></li>
+                    <div class="order-detail__info-grid">
+                        <div class="order-detail__info-column">
+                            <h4 class="order-detail__info-title">Đơn hàng</h4>
+                            <ul class="definition-list">
+                                <li><span>Mã đơn:</span> #<c:out value="${order.id}" /></li>
+                                <li><span>Sản phẩm:</span> <c:out value="${product.name}" /></li>
+                                <c:if test="${not empty order.variantCode}">
+                                    <li><span>Biến thể:</span> <c:out value="${order.variantCode}" /></li>
+                                </c:if>
+                                <c:if test="${order.quantity ne null}">
+                                    <li><span>Số lượng:</span> <c:out value="${order.quantity}" /></li>
+                                </c:if>
+                                <c:if test="${order.unitPrice ne null}">
+                                    <li><span>Đơn giá:</span>
+                                        <fmt:formatNumber value="${order.unitPrice}" type="currency" currencySymbol="" /> đ
+                                    </li>
+                                </c:if>
+                                <li><span>Tổng tiền:</span>
+                                    <fmt:formatNumber value="${order.totalAmount}" type="currency" currencySymbol="" /> đ
+                                </li>
+                                <li><span>Trạng thái:</span> <c:out value="${statusLabel}" /></li>
+                                <li><span>Ngày tạo:</span>
+                                    <fmt:formatDate value="${order.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="order-detail__info-column order-detail__info-column--wallet">
+                            <h4 class="order-detail__info-title">Giao dịch ví</h4>
+                            <c:if test="${not empty walletTimeline}">
+                                <ol class="order-wallet-timeline">
+                                    <c:forEach var="event" items="${walletTimeline}" varStatus="loop">
+                                        <li class="order-wallet-timeline__item${event.primary ? ' order-wallet-timeline__item--primary' : ''}">
+                                            <div class="order-wallet-timeline__badge">${loop.index + 1}</div>
+                                            <div class="order-wallet-timeline__content">
+                                                <div class="order-wallet-timeline__header">
+                                                    <span class="order-wallet-timeline__title"><c:out value="${event.title}" /></span>
+                                                    <c:if test="${not empty event.occurredAt}">
+                                                        <time class="order-wallet-timeline__time">
+                                                            <fmt:formatDate value="${event.occurredAt}" pattern="dd/MM/yyyy HH:mm" />
+                                                        </time>
+                                                    </c:if>
+                                                </div>
+                                                <p class="order-wallet-timeline__description"><c:out value="${event.description}" /></p>
+                                                <c:if test="${not empty event.reference}">
+                                                    <p class="order-wallet-timeline__reference">Mã tham chiếu: <span><c:out value="${event.reference}" /></span></p>
+                                                </c:if>
+                                                <c:if test="${not empty event.amount or not empty event.balanceAfter}">
+                                                    <ul class="definition-list order-wallet-timeline__metrics">
+                                                        <c:if test="${not empty event.amount}">
+                                                            <li><span>Số tiền:</span>
+                                                                <fmt:formatNumber value="${event.amount}" type="currency" currencySymbol="" /> đ
+                                                            </li>
+                                                        </c:if>
+                                                        <c:if test="${not empty event.balanceAfter}">
+                                                            <li><span>Số dư sau:</span>
+                                                                <fmt:formatNumber value="${event.balanceAfter}" type="currency" currencySymbol="" /> đ
+                                                            </li>
+                                                        </c:if>
+                                                    </ul>
+                                                </c:if>
+                                            </div>
+                                        </li>
+                                    </c:forEach>
+                                </ol>
                             </c:if>
-                            <c:if test="${order.quantity ne null}">
-                            <li><span>Số lượng:</span> <c:out value="${order.quantity}" /></li>
+                            <c:if test="${not empty paymentTransaction}">
+                                <h5 class="order-detail__info-subtitle">Chi tiết giao dịch</h5>
+                                <ul class="definition-list">
+                                    <li><span>Mã giao dịch ví:</span> #<c:out value="${paymentTransaction.id}" /></li>
+                                    <li><span>Loại giao dịch:</span> <c:out value="${paymentTransactionTypeLabel}" /></li>
+                                    <li><span>Số tiền trừ:</span>
+                                        <c:choose>
+                                            <c:when test="${not empty paymentTransactionAmountAbs}">
+                                                -<fmt:formatNumber value="${paymentTransactionAmountAbs}" type="currency" currencySymbol="" /> đ
+                                            </c:when>
+                                            <c:when test="${not empty paymentTransaction.amount}">
+                                                <fmt:formatNumber value="${paymentTransaction.amount}" type="currency" currencySymbol="" /> đ
+                                            </c:when>
+                                            <c:otherwise>
+                                                Không xác định
+                                            </c:otherwise>
+                                        </c:choose>
+                                    </li>
+                                    <li><span>Số dư trước:</span>
+                                        <fmt:formatNumber value="${paymentTransaction.balanceBefore}" type="currency" currencySymbol="" /> đ
+                                    </li>
+                                    <li><span>Số dư sau:</span>
+                                        <fmt:formatNumber value="${paymentTransaction.balanceAfter}" type="currency" currencySymbol="" /> đ
+                                    </li>
+                                    <li><span>Thời gian thanh toán:</span>
+                                        <fmt:formatDate value="${paymentTransaction.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                                    </li>
+                                    <c:if test="${not empty paymentTransaction.note}">
+                                        <li><span>Ghi chú:</span> <c:out value="${paymentTransaction.note}" /></li>
+                                    </c:if>
+                                </ul>
                             </c:if>
-                            <c:if test="${order.unitPrice ne null}">
-                            <li><span>Đơn giá:</span>
-                                <fmt:formatNumber value="${order.unitPrice}" type="currency" currencySymbol="" /> đ
-                            </li>
-                        </c:if>
-                        <li><span>Tổng tiền:</span>
-                            <fmt:formatNumber value="${order.totalAmount}" type="currency" currencySymbol="" /> đ
-                        </li>
-                        <li><span>Trạng thái:</span> <c:out value="${statusLabel}" /></li>
-                        <li><span>Ngày tạo:</span>
-                            <fmt:formatDate value="${order.createdAt}" pattern="dd/MM/yyyy HH:mm" />
-                        </li>
-                    </ul>
+                        </div>
+                    </div>
                 </div>
                 <div class="card">
                     <h3 class="card__title">Sản phẩm</h3>


### PR DESCRIPTION
## Summary
- add an OrderWalletEvent view model and service logic to build a wallet activity timeline for each order
- surface the timeline from the controller and render it beside the order metadata on the detail page
- style the new timeline and retained transaction summary to highlight the sequential wallet steps

## Testing
- Not run (project has no automated tests)
