### PR TITLE
Expose wallet timeline API and preview purchase checks

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -8,11 +8,14 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import model.Orders;
 import model.Products;
+import model.WalletTransactions;
 import model.view.OrderDetailView;
+import model.view.OrderWalletEvent;
 import service.OrderService;
 import units.IdObfuscator;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -104,8 +107,14 @@ public class OrderController extends BaseController {
                 redirectToMyOrders(request, response);
             case "/orders/my" ->
                 showMyOrders(request, response);
-            case "/orders/detail" ->
-                showOrderDetail(request, response);
+            case "/orders/detail" -> {
+                String pathInfo = request.getPathInfo();
+                if (pathInfo != null && pathInfo.endsWith("/wallet-events")) {
+                    handleWalletEventsApi(request, response);
+                } else {
+                    showOrderDetail(request, response);
+                }
+            }
             default ->
                 response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
@@ -307,6 +316,17 @@ public class OrderController extends BaseController {
         Orders order = detail.order();
         Products product = detail.product();
         List<String> credentials = detail.credentials();
+        Optional<WalletTransactions> paymentTxOpt = orderService.getPaymentTransactionForOrder(order);
+        if (paymentTxOpt.isPresent()) {
+            WalletTransactions paymentTx = paymentTxOpt.get();
+            request.setAttribute("paymentTransaction", paymentTx);
+            request.setAttribute("paymentTransactionTypeLabel",
+                    orderService.getTransactionTypeLabel(paymentTx.getTransactionTypeEnum()));
+            BigDecimal amount = paymentTx.getAmount();
+            if (amount != null) {
+                request.setAttribute("paymentTransactionAmountAbs", amount.abs());
+            }
+        }
 
         request.setAttribute("order", order);
         request.setAttribute("product", product);
@@ -321,6 +341,136 @@ public class OrderController extends BaseController {
         request.setAttribute("orderToken", IdObfuscator.encode(orderId));
 
         forward(request, response, "order/detail");
+    }
+
+    /**
+     * Phản hồi JSON mô tả các sự kiện ví của đơn hàng để giao diện tải bằng AJAX.
+     */
+    private void handleWalletEventsApi(HttpServletRequest request, HttpServletResponse response)
+            throws IOException {
+        HttpSession session = request.getSession(false);
+        if (!isBuyerOrSeller(session)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        Integer userId = (Integer) session.getAttribute("userId");
+        if (userId == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+        String pathInfo = request.getPathInfo();
+        if (pathInfo == null || !pathInfo.contains("/wallet-events")) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        String token = extractTokenFromPath(request);
+        if (token == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        int orderId;
+        try {
+            orderId = IdObfuscator.decode(token);
+        } catch (IllegalArgumentException ex) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        Optional<OrderDetailView> detailOpt = orderService.getDetail(orderId, userId);
+        if (detailOpt.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        Orders order = detailOpt.get().order();
+        Optional<WalletTransactions> paymentTxOpt = orderService.getPaymentTransactionForOrder(order);
+        List<OrderWalletEvent> events = orderService.buildWalletTimeline(order, paymentTxOpt);
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(buildWalletEventsPayload(events));
+    }
+
+    private String buildWalletEventsPayload(List<OrderWalletEvent> events) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{').append("\"events\":[");
+        for (int i = 0; i < events.size(); i++) {
+            OrderWalletEvent event = events.get(i);
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append('{');
+            appendJsonField(builder, "sequence", Integer.toString(i + 1), false);
+            appendJsonField(builder, "code", escapeJson(event.getCode()), true);
+            appendJsonField(builder, "title", escapeJson(event.getTitle()), true);
+            appendJsonField(builder, "description", escapeJson(event.getDescription()), true);
+            appendJsonField(builder, "occurredAt", formatIso(event.getOccurredAt()), true);
+            appendJsonField(builder, "amount", formatDecimal(event.getAmount()), true);
+            appendJsonField(builder, "balanceAfter", formatDecimal(event.getBalanceAfter()), true);
+            appendJsonField(builder, "reference", escapeJson(event.getReference()), true);
+            appendJsonField(builder, "primary", Boolean.toString(event.isPrimary()), false);
+            trimTrailingComma(builder);
+            builder.append('}');
+        }
+        builder.append(']');
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private void appendJsonField(StringBuilder builder, String name, String value, boolean quote) {
+        if (value == null) {
+            return;
+        }
+        builder.append('"').append(name).append('"').append(':');
+        if (quote) {
+            builder.append('"').append(value).append('"');
+        } else {
+            builder.append(value);
+        }
+        builder.append(',');
+    }
+
+    private void trimTrailingComma(StringBuilder builder) {
+        int length = builder.length();
+        if (length > 0 && builder.charAt(length - 1) == ',') {
+            builder.setLength(length - 1);
+        }
+    }
+
+    private String escapeJson(String input) {
+        if (input == null) {
+            return null;
+        }
+        StringBuilder escaped = new StringBuilder(input.length() + 8);
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            switch (ch) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (ch < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    private String formatIso(java.util.Date date) {
+        if (date == null) {
+            return null;
+        }
+        return java.time.ZonedDateTime.ofInstant(date.toInstant(), java.time.ZoneId.systemDefault())
+                .format(java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    }
+
+    private String formatDecimal(BigDecimal value) {
+        if (value == null) {
+            return null;
+        }
+        return value.stripTrailingZeros().toPlainString();
     }
 
     /**

--- a/MMO_Trader_Market/src/java/controller/product/ProductDetailController.java
+++ b/MMO_Trader_Market/src/java/controller/product/ProductDetailController.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import model.view.product.ProductDetailView;
 import model.view.product.ProductSummaryView;
+import model.view.PurchasePreviewResult;
+import service.OrderService;
 import service.ProductService;
 import units.IdObfuscator;
 
@@ -32,10 +34,17 @@ public class ProductDetailController extends BaseController {
     private static final long serialVersionUID = 1L;
     // Dịch vụ sản phẩm giúp truy vấn chi tiết và tìm kiếm sản phẩm liên quan.
     private final ProductService productService = new ProductService();
+    private final OrderService orderService = new OrderService();
     // Xử lý yêu cầu hiển thị chi tiết sản phẩm bằng token mã hóa hoặc ID cũ.
     @Override
     protected void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
+        String pathInfo = request.getPathInfo();
+        if (pathInfo != null && pathInfo.endsWith("/availability")) {
+            handleAvailabilityCheck(request, response);
+            return;
+        }
+
         String token = extractTokenFromPath(request); //    // Tách token sản phẩm từ phần path của URL thân thiện.
         if (token == null) {
             int legacyId = parsePositiveInt(request.getParameter("id")); //id phải là số dương
@@ -148,5 +157,133 @@ public class ProductDetailController extends BaseController {
             url.append('?').append(String.join("&", queryParts));
         }
         return url.toString();
+    }
+
+    private void handleAvailabilityCheck(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("application/json; charset=UTF-8");
+        String token = extractTokenFromPath(request);
+        if (token == null) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+        int productId;
+        try {
+            productId = IdObfuscator.decode(token);
+        } catch (IllegalArgumentException ex) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+        int quantity = parsePositiveInt(request.getParameter("quantity"));
+        if (quantity <= 0) {
+            quantity = 1;
+        }
+        String variantCode = normalize(request.getParameter("variantCode"));
+        HttpSession session = request.getSession(false);
+        Integer userId = session == null ? null : (Integer) session.getAttribute("userId");
+        PurchasePreviewResult result = orderService.previewPurchase(userId, productId, quantity, variantCode);
+        response.getWriter().write(buildAvailabilityPayload(result, productId, quantity, variantCode));
+    }
+
+    private String buildAvailabilityPayload(PurchasePreviewResult result, int productId, int quantity, String variantCode) {
+        StringBuilder builder = new StringBuilder();
+        builder.append('{');
+        appendBoolean(builder, "ok", result.ok());
+        appendBoolean(builder, "canPurchase", result.canPurchase());
+        appendBoolean(builder, "productAvailable", result.productAvailable());
+        appendBoolean(builder, "variantValid", result.variantValid());
+        appendBoolean(builder, "hasInventory", result.hasInventory());
+        appendBoolean(builder, "hasCredentials", result.hasCredentials());
+        appendBoolean(builder, "walletExists", result.walletExists());
+        appendBoolean(builder, "walletActive", result.walletActive());
+        appendBoolean(builder, "walletHasBalance", result.walletHasBalance());
+        appendNumber(builder, "productId", productId);
+        appendNumber(builder, "quantity", quantity);
+        appendNumber(builder, "availableInventory", result.availableInventory());
+        appendNumber(builder, "availableCredentials", result.availableCredentials());
+        appendString(builder, "variantCode", variantCode);
+        appendDecimal(builder, "unitPrice", result.unitPrice());
+        appendDecimal(builder, "totalPrice", result.totalPrice());
+        appendDecimal(builder, "walletBalance", result.walletBalance());
+        appendStringArray(builder, "blockers", result.blockers());
+        trimTrailingComma(builder);
+        builder.append('}');
+        return builder.toString();
+    }
+
+    private void appendBoolean(StringBuilder builder, String name, boolean value) {
+        builder.append('"').append(name).append('"').append(':').append(value).append(',');
+    }
+
+    private void appendNumber(StringBuilder builder, String name, int value) {
+        builder.append('"').append(name).append('"').append(':').append(value).append(',');
+    }
+
+    private void appendString(StringBuilder builder, String name, String value) {
+        if (value == null) {
+            return;
+        }
+        builder.append('"').append(name).append('"').append(':').append('"').append(escapeJson(value)).append('"').append(',');
+    }
+
+    private void appendDecimal(StringBuilder builder, String name, java.math.BigDecimal value) {
+        if (value == null) {
+            return;
+        }
+        builder.append('"').append(name).append('"').append(':')
+                .append('"').append(value.stripTrailingZeros().toPlainString()).append('"').append(',');
+    }
+
+    private void appendStringArray(StringBuilder builder, String name, List<String> values) {
+        builder.append('"').append(name).append('"').append(':');
+        builder.append('[');
+        if (values != null) {
+            for (int i = 0; i < values.size(); i++) {
+                if (i > 0) {
+                    builder.append(',');
+                }
+                builder.append('"').append(escapeJson(values.get(i))).append('"');
+            }
+        }
+        builder.append(']').append(',');
+    }
+
+    private void trimTrailingComma(StringBuilder builder) {
+        int length = builder.length();
+        if (length > 0 && builder.charAt(length - 1) == ',') {
+            builder.setLength(length - 1);
+        }
+    }
+
+    private String escapeJson(String input) {
+        if (input == null) {
+            return "";
+        }
+        StringBuilder escaped = new StringBuilder(input.length() + 8);
+        for (int i = 0; i < input.length(); i++) {
+            char ch = input.charAt(i);
+            switch (ch) {
+                case '"' -> escaped.append("\\\"");
+                case '\\' -> escaped.append("\\\\");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (ch < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) ch));
+                    } else {
+                        escaped.append(ch);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
+    private String normalize(String input) {
+        if (input == null) {
+            return null;
+        }
+        String trimmed = input.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/WalletTransactionDAO.java
@@ -17,6 +17,7 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -60,23 +61,7 @@ public class WalletTransactionDAO {
             ps.setInt(1, id);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    String s = rs.getString(COL_TRANSACTION_TYPE);
-                    if (s != null) {
-                        wt.setTransactionType(TransactionType.fromDbValue(s));
-                    }
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -180,24 +165,7 @@ public class WalletTransactionDAO {
             ps.setInt(14, offset);
             try (ResultSet rs = ps.executeQuery()) {
                 while (rs.next()) {
-                    WalletTransactions wt = new WalletTransactions();
-                    wt.setId(rs.getInt(COL_ID));
-                    int walletId = rs.getInt(COL_WALLET_ID);
-                    wt.setWalletId(walletId);
-                    wt.setWallet(wdao.getWalletById(walletId));
-                    Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
-                    wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
-                    //map từ ENUM java --> enum DB
-                    String s = rs.getString(COL_TRANSACTION_TYPE); //"Deposit" | "Purchase" |
-                    TransactionType type = TransactionType.fromDbValue(s);
-
-                    wt.setTransactionType(type);
-                    wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
-                    wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
-                    wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
-                    wt.setNote(rs.getString(COL_NOTE));
-                    java.sql.Timestamp c = rs.getTimestamp(COL_CREATED_AT);
-                    wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+                    WalletTransactions wt = mapTransaction(rs, true);
                     list.add(wt);
                 }
                 return list;
@@ -208,12 +176,70 @@ public class WalletTransactionDAO {
         return null;
     }
 
+    /**
+     * Tìm giao dịch ví theo mã đồng thời đảm bảo thuộc sở hữu của người dùng.
+     *
+     * @param transactionId mã giao dịch ví
+     * @param userId mã người dùng cần xác thực
+     * @return {@link Optional} chứa giao dịch nếu tìm thấy
+     */
+    public Optional<WalletTransactions> findByIdForUser(int transactionId, int userId) {
+        String sql = """
+              SELECT wt.*
+              FROM wallet_transactions AS wt
+              JOIN wallets AS w ON w.id = wt.wallet_id
+              WHERE wt.id = ? AND w.user_id = ?
+              LIMIT 1
+              """;
+        try (Connection con = DBConnect.getConnection(); PreparedStatement ps = con.prepareStatement(sql)) {
+            ps.setInt(1, transactionId);
+            ps.setInt(2, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapTransaction(rs, false));
+                }
+            }
+        } catch (SQLException e) {
+            Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.SEVERE,
+                    "Lỗi liên quan đến lấy dữ liệu từ DB", e);
+        }
+        return Optional.empty();
+    }
+
     public static void main(String[] args) {
         WalletTransactionDAO wdao = new WalletTransactionDAO();
         List<WalletTransactions> list = wdao.getListWalletTransactionPaging(1, 1, 5, null, null, null, null, null);
         for (WalletTransactions walletTransactions : list) {
             System.out.println(walletTransactions);
         }
+    }
+
+    private WalletTransactions mapTransaction(ResultSet rs, boolean includeWallet) throws SQLException {
+        WalletTransactions wt = new WalletTransactions();
+        wt.setId(rs.getInt(COL_ID));
+        int walletId = rs.getInt(COL_WALLET_ID);
+        wt.setWalletId(walletId);
+        if (includeWallet) {
+            wt.setWallet(wdao.getWalletById(walletId));
+        }
+        Object relatedEntity = rs.getObject(COL_RELATED_ENTITY);
+        wt.setRelatedEntityId(relatedEntity == null ? null : ((Number) relatedEntity).intValue());
+        String s = rs.getString(COL_TRANSACTION_TYPE);
+        if (s != null) {
+            try {
+                wt.setTransactionType(TransactionType.fromDbValue(s));
+            } catch (IllegalArgumentException ex) {
+                Logger.getLogger(WalletTransactionDAO.class.getName()).log(Level.WARNING,
+                        "Không nhận diện được transaction_type {0}", s);
+            }
+        }
+        wt.setAmount(rs.getBigDecimal(COL_AMOUNT));
+        wt.setBalanceBefore(rs.getBigDecimal(COL_BALANCE_BEFORE));
+        wt.setBalanceAfter(rs.getBigDecimal(COL_BALANCE_AFTER));
+        wt.setNote(rs.getString(COL_NOTE));
+        Timestamp c = rs.getTimestamp(COL_CREATED_AT);
+        wt.setCreatedAt(c != null ? new java.util.Date(c.getTime()) : null);
+        return wt;
     }
 
     public int insertTransaction(Connection connection, int walletId, Integer relatedEntityId, TransactionType type,

--- a/MMO_Trader_Market/src/java/model/view/OrderWalletEvent.java
+++ b/MMO_Trader_Market/src/java/model/view/OrderWalletEvent.java
@@ -1,0 +1,70 @@
+package model.view;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+/**
+ * View model mô tả từng bước liên quan tới ví khi xử lý đơn hàng.
+ * Mỗi sự kiện tương ứng với hành động trong worker: đưa đơn vào hàng đợi,
+ * khóa ví, ghi nhận giao dịch... giúp giao diện trình bày luồng tiền dưới dạng
+ * timeline dễ hiểu cho người mua.
+ */
+public class OrderWalletEvent {
+
+    private final String code;
+    private final String title;
+    private final String description;
+    private final Date occurredAt;
+    private final BigDecimal amount;
+    private final BigDecimal balanceAfter;
+    private final String reference;
+    private final boolean primary;
+
+    public OrderWalletEvent(String code, String title, String description, Date occurredAt,
+            BigDecimal amount, BigDecimal balanceAfter, String reference, boolean primary) {
+        this.code = code;
+        this.title = title;
+        this.description = description;
+        this.occurredAt = copyDate(occurredAt);
+        this.amount = amount;
+        this.balanceAfter = balanceAfter;
+        this.reference = reference;
+        this.primary = primary;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Date getOccurredAt() {
+        return copyDate(occurredAt);
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public BigDecimal getBalanceAfter() {
+        return balanceAfter;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    private static Date copyDate(Date input) {
+        return input == null ? null : new Date(input.getTime());
+    }
+}

--- a/MMO_Trader_Market/src/java/model/view/PurchasePreviewResult.java
+++ b/MMO_Trader_Market/src/java/model/view/PurchasePreviewResult.java
@@ -1,0 +1,27 @@
+package model.view;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Kết quả kiểm tra nhanh trước khi tạo đơn hàng để giao diện quyết định có cho phép
+ * người mua tiếp tục quy trình thanh toán hay không.
+ */
+public record PurchasePreviewResult(
+        boolean ok,
+        boolean canPurchase,
+        boolean productAvailable,
+        boolean variantValid,
+        boolean hasInventory,
+        boolean hasCredentials,
+        boolean walletExists,
+        boolean walletActive,
+        boolean walletHasBalance,
+        int availableInventory,
+        int availableCredentials,
+        BigDecimal unitPrice,
+        BigDecimal totalPrice,
+        BigDecimal walletBalance,
+        List<String> blockers
+) {
+}

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -9,9 +9,13 @@ import model.OrderStatus;
 import model.Orders;
 import model.PaginatedResult;
 import model.Products;
+import model.TransactionType;
 import model.product.ProductVariantOption;
 import model.view.OrderDetailView;
 import model.view.OrderRow;
+import model.view.OrderWalletEvent;
+import model.view.PurchasePreviewResult;
+import model.WalletTransactions;
 import model.Wallets;
 import queue.OrderQueueProducer;
 import queue.memory.InMemoryOrderQueue;
@@ -19,8 +23,13 @@ import service.util.ProductVariantUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -47,6 +56,7 @@ public class OrderService {
     );
     // Bảng ánh xạ trạng thái sang nhãn tiếng Việt.
     private static final Map<OrderStatus, String> STATUS_LABELS = buildStatusLabels();
+    private static final Map<TransactionType, String> TRANSACTION_TYPE_LABELS = buildTransactionTypeLabels();
 
     // DAO quản lý đơn hàng.
     private final OrderDAO orderDAO;
@@ -397,6 +407,231 @@ public class OrderService {
     }
 
     /**
+     * Lấy thông tin giao dịch thanh toán gắn với đơn hàng (nếu có).
+     *
+     * @param order bản ghi đơn hàng cần tra cứu
+     * @return {@link Optional} chứa giao dịch nếu tìm thấy và thuộc về người mua
+     */
+    public Optional<WalletTransactions> getPaymentTransactionForOrder(Orders order) {
+        if (order == null) {
+            return Optional.empty();
+        }
+        Integer txId = order.getPaymentTransactionId();
+        Integer buyerId = order.getBuyerId();
+        if (txId == null || buyerId == null) {
+            return Optional.empty();
+        }
+        return walletTransactionDAO.findByIdForUser(txId, buyerId);
+    }
+
+    /**
+     * Xây dựng timeline mô tả các bước thao tác ví cho đơn hàng.
+     *
+     * @param order bản ghi đơn cần hiển thị
+     * @param paymentTxOpt giao dịch ví thực tế (nếu đã ghi nhận)
+     * @return danh sách sự kiện theo thứ tự thời gian
+     */
+    public List<OrderWalletEvent> buildWalletTimeline(Orders order, Optional<WalletTransactions> paymentTxOpt) {
+        if (order == null) {
+            return Collections.emptyList();
+        }
+        List<OrderWalletEvent> events = new ArrayList<>();
+        Date createdAt = copyDate(order.getCreatedAt());
+        Integer orderId = order.getId();
+        events.add(new OrderWalletEvent(
+                "QUEUE_ENQUEUED",
+                "Đưa vào hàng đợi xử lý",
+                "Người mua xác nhận \"Mua ngay\". Hệ thống tạo đơn và gửi thông điệp cho worker bất đồng bộ.",
+                createdAt,
+                null,
+                null,
+                buildSyntheticReference("Q", orderId, 1),
+                false));
+
+        Date walletStepTime = copyDate(order.getUpdatedAt());
+        if (walletStepTime == null) {
+            walletStepTime = createdAt;
+        }
+        StringBuilder walletDesc = new StringBuilder("Worker khóa ví người mua, kiểm tra trạng thái hoạt động và số dư trước khi trừ tiền.");
+        BigDecimal totalAmount = order.getTotalAmount();
+        if (totalAmount != null) {
+            walletDesc.append(' ').append("Tổng tiền cần thanh toán: ")
+                    .append(formatCurrency(totalAmount)).append(" đ.");
+        }
+        events.add(new OrderWalletEvent(
+                "WALLET_VALIDATED",
+                "Kiểm tra số dư ví",
+                walletDesc.toString(),
+                walletStepTime,
+                totalAmount,
+                null,
+                buildSyntheticReference("V", orderId, 2),
+                false));
+
+        if (paymentTxOpt.isPresent()) {
+            WalletTransactions tx = paymentTxOpt.get();
+            Date transactionTime = copyDate(tx.getCreatedAt());
+            if (transactionTime == null) {
+                transactionTime = walletStepTime;
+            }
+            TransactionType type = tx.getTransactionTypeEnum();
+            String typeLabel = getTransactionTypeLabel(type);
+            String normalizedTypeLabel = typeLabel == null
+                    ? "thanh toán"
+                    : typeLabel.toLowerCase(Locale.ROOT);
+            String desc = "Ghi nhận giao dịch " + normalizedTypeLabel + " và cập nhật số dư ví.";
+            events.add(new OrderWalletEvent(
+                    "PAYMENT_CAPTURED",
+                    "Trừ tiền ví",
+                    desc,
+                    transactionTime,
+                    tx.getAmount(),
+                    tx.getBalanceAfter(),
+                    tx.getId() == null ? null : "#" + tx.getId(),
+                    true));
+        } else {
+            events.add(new OrderWalletEvent(
+                    "PAYMENT_PENDING",
+                    "Chờ ghi nhận giao dịch",
+                    "Worker đang xử lý các bước trừ tiền và sẽ cập nhật mã giao dịch ngay khi hoàn tất.",
+                    walletStepTime,
+                    null,
+                    null,
+                    buildSyntheticReference("P", orderId, 3),
+                    true));
+        }
+
+        String status = order.getStatus();
+        if (status != null && !status.isBlank()) {
+            Date statusTime = copyDate(order.getUpdatedAt());
+            String statusLabel = getStatusLabel(status);
+            String desc = "Trạng thái đơn hàng hiện tại: " + statusLabel + ".";
+            events.add(new OrderWalletEvent(
+                    "ORDER_STATUS",
+                    "Cập nhật trạng thái đơn",
+                    desc,
+                    statusTime,
+                    null,
+                    null,
+                    buildSyntheticReference("S", orderId, 4),
+                    false));
+        }
+
+        return events;
+    }
+
+    /**
+     * Kiểm tra nhanh điều kiện mua hàng trước khi gửi yêu cầu tạo đơn.
+     *
+     * @param userId mã người mua (có thể {@code null} nếu chưa đăng nhập)
+     * @param productId mã sản phẩm cần mua
+     * @param quantity số lượng đặt mua
+     * @param variantCode mã biến thể (có thể {@code null})
+     * @return kết quả đánh giá tổng hợp
+     */
+    public PurchasePreviewResult previewPurchase(Integer userId, int productId, int quantity, String variantCode) {
+        List<String> blockers = new ArrayList<>();
+        if (quantity <= 0) {
+            blockers.add("Số lượng phải lớn hơn 0.");
+            return new PurchasePreviewResult(false, false, false, false, false, false, false, false, false,
+                    0, 0, null, null, null, List.copyOf(blockers));
+        }
+
+        Optional<Products> productOpt = productDAO.findAvailableById(productId);
+        if (productOpt.isEmpty()) {
+            blockers.add("Sản phẩm không khả dụng hoặc đã bị ẩn.");
+            return new PurchasePreviewResult(false, false, false, false, false, false, false, false, false,
+                    0, 0, null, null, null, List.copyOf(blockers));
+        }
+
+        Products product = productOpt.get();
+        String normalizedVariant = ProductVariantUtils.normalizeCode(variantCode);
+        List<ProductVariantOption> variants = ProductVariantUtils.parseVariants(product.getVariantSchema(),
+                product.getVariantsJson());
+        Optional<ProductVariantOption> variantOpt = ProductVariantUtils.findVariant(variants, normalizedVariant);
+        ProductVariantOption selectedVariant = variantOpt.orElse(null);
+
+        boolean variantRequired = ProductVariantUtils.hasVariants(product.getVariantSchema());
+        boolean variantValid = !variantRequired;
+        if (normalizedVariant != null) {
+            if (selectedVariant == null || !selectedVariant.isAvailable()) {
+                blockers.add("Biến thể sản phẩm không khả dụng.");
+            } else {
+                variantValid = true;
+            }
+        } else if (variantRequired) {
+            blockers.add("Vui lòng chọn biến thể sản phẩm.");
+        } else {
+            variantValid = true;
+        }
+
+        int availableInventory;
+        if (selectedVariant != null && selectedVariant.getInventoryCount() != null) {
+            availableInventory = Math.max(selectedVariant.getInventoryCount(), 0);
+        } else if (product.getInventoryCount() != null) {
+            availableInventory = Math.max(product.getInventoryCount(), 0);
+        } else {
+            availableInventory = 0;
+        }
+        boolean hasInventory = availableInventory >= quantity;
+        if (!hasInventory && variantValid) {
+            blockers.add("Tồn kho hiện tại không đủ đáp ứng số lượng yêu cầu.");
+        }
+
+        CredentialDAO.CredentialAvailability credentialAvailability = normalizedVariant == null
+                ? credentialDAO.fetchAvailability(productId)
+                : credentialDAO.fetchAvailability(productId, normalizedVariant);
+        int availableCredentials = Math.max(credentialAvailability.available(), 0);
+        boolean hasCredentials = availableCredentials >= quantity;
+        if (!hasCredentials && variantValid) {
+            blockers.add("Kho mã bàn giao chưa sẵn sàng đủ số lượng.");
+        }
+
+        BigDecimal unitPrice = ProductVariantUtils.resolveUnitPrice(product, variantOpt);
+        BigDecimal totalPrice = unitPrice == null ? null : unitPrice.multiply(BigDecimal.valueOf(quantity));
+
+        boolean walletExists = false;
+        boolean walletActive = false;
+        boolean walletHasBalance = false;
+        BigDecimal walletBalance = null;
+        if (userId == null) {
+            blockers.add("Vui lòng đăng nhập để kiểm tra số dư ví.");
+        } else if (userId > 0) {
+            Wallets wallet = walletsDAO.ensureUserWallet(userId);
+            if (wallet != null) {
+                walletExists = true;
+                walletActive = !Boolean.FALSE.equals(wallet.getStatus());
+                walletBalance = wallet.getBalance() == null ? BigDecimal.ZERO : wallet.getBalance();
+                if (!walletActive) {
+                    blockers.add("Ví của bạn đang bị khóa, vui lòng liên hệ hỗ trợ.");
+                } else if (totalPrice != null && walletBalance.compareTo(totalPrice) < 0) {
+                    blockers.add("Số dư ví không đủ để thanh toán đơn hàng.");
+                } else if (totalPrice != null) {
+                    walletHasBalance = true;
+                }
+            } else {
+                blockers.add("Không thể truy vấn ví của tài khoản.");
+            }
+        }
+
+        boolean ok = variantValid && hasInventory && hasCredentials;
+        boolean canPurchase = ok && walletHasBalance;
+        return new PurchasePreviewResult(ok, canPurchase, true, variantValid, hasInventory, hasCredentials,
+                walletExists, walletActive, walletHasBalance, availableInventory, availableCredentials, unitPrice,
+                totalPrice, walletBalance, List.copyOf(blockers));
+    }
+
+    /**
+     * Trả về nhãn tiếng Việt cho loại giao dịch ví.
+     */
+    public String getTransactionTypeLabel(TransactionType type) {
+        if (type == null) {
+            return "Không xác định";
+        }
+        return TRANSACTION_TYPE_LABELS.getOrDefault(type, type.getDbValue());
+    }
+
+    /**
      * Chuẩn hóa trạng thái đầu vào (đầu chữ hoa, phần còn lại chữ thường) và
      * kiểm tra hợp lệ.
      */
@@ -427,6 +662,37 @@ public class OrderService {
         labels.put(OrderStatus.FAILED, "Thất bại");
         labels.put(OrderStatus.REFUNDED, "Đã hoàn tiền");
         labels.put(OrderStatus.DISPUTED, "Khiếu nại");
+        return labels;
+    }
+
+    private static Date copyDate(Date input) {
+        return input == null ? null : new Date(input.getTime());
+    }
+
+    private static String buildSyntheticReference(String prefix, Integer orderId, int step) {
+        if (prefix == null || orderId == null) {
+            return null;
+        }
+        int normalized = Math.max(orderId, 1);
+        String base = Integer.toString(normalized, 36).toUpperCase();
+        return prefix + '-' + base + '-' + step;
+    }
+
+    private static String formatCurrency(BigDecimal amount) {
+        NumberFormat format = NumberFormat.getNumberInstance(new Locale("vi", "VN"));
+        format.setMinimumFractionDigits(0);
+        format.setMaximumFractionDigits(2);
+        return format.format(amount);
+    }
+
+    private static Map<TransactionType, String> buildTransactionTypeLabels() {
+        Map<TransactionType, String> labels = new EnumMap<>(TransactionType.class);
+        labels.put(TransactionType.PURCHASE, "Thanh toán đơn hàng");
+        labels.put(TransactionType.DEPOSIT, "Nạp tiền vào ví");
+        labels.put(TransactionType.WITHDRAWAL, "Rút tiền");
+        labels.put(TransactionType.REFUND, "Hoàn tiền");
+        labels.put(TransactionType.FEE, "Phí giao dịch");
+        labels.put(TransactionType.PAYOUT, "Chi trả");
         return labels;
     }
 


### PR DESCRIPTION
## Summary
- add a wallet-event JSON endpoint and replace the order detail timeline markup with a JS-driven layout that fetches the data
- implement purchase preview logic to validate inventory, credentials, and wallet balance and expose it via the product detail controller
- call the new availability API from the product detail page to update the buy button state and surface wallet/inventory guidance
