### PR TITLE
Add seller credential generator and disable automatic seeding

### DIFF
--- a/MMO_Trader_Market/src/java/controller/seller/SellerGenerateCredentialController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerGenerateCredentialController.java
@@ -1,0 +1,67 @@
+package controller.seller;
+
+import dao.order.CredentialDAO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Cho phép người bán chủ động sinh thêm credential ảo cho sản phẩm trước khi mở
+ * bán.
+ */
+@WebServlet(name = "SellerGenerateCredentialController", urlPatterns = {"/seller/credentials/generate"})
+public class SellerGenerateCredentialController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(SellerGenerateCredentialController.class.getName());
+
+    private final CredentialDAO credentialDAO = new CredentialDAO();
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+        HttpSession session = request.getSession();
+        String productIdRaw = request.getParameter("productId");
+        String quantityRaw = request.getParameter("quantity");
+        String variantCode = request.getParameter("variantCode");
+        try {
+            int productId = Integer.parseInt(productIdRaw);
+            int quantity = Integer.parseInt(quantityRaw);
+            if (productId <= 0 || quantity <= 0) {
+                throw new IllegalArgumentException("Tham số không hợp lệ");
+            }
+            int inserted = credentialDAO.generateFakeCredentials(productId, variantCode, quantity);
+            if (inserted > 0) {
+                String normalizedVariant = variantCode == null ? null : variantCode.trim();
+                if (normalizedVariant != null && normalizedVariant.isEmpty()) {
+                    normalizedVariant = null;
+                }
+                StringBuilder message = new StringBuilder();
+                message.append("Đã sinh ").append(inserted).append(" credential ảo cho sản phẩm #").append(productId);
+                if (normalizedVariant != null) {
+                    message.append(" (biến thể ").append(normalizedVariant).append(")");
+                }
+                session.setAttribute("sellerInventoryFlashSuccess", message.append('.').toString());
+            } else {
+                session.setAttribute("sellerInventoryFlashError",
+                        "Không thể sinh credential ảo, vui lòng thử lại sau.");
+            }
+        } catch (NumberFormatException | IllegalArgumentException ex) {
+            session.setAttribute("sellerInventoryFlashError",
+                    "Tham số không hợp lệ, vui lòng kiểm tra mã sản phẩm và số lượng.");
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Không thể sinh credential ảo", ex);
+            session.setAttribute("sellerInventoryFlashError",
+                    "Hệ thống không thể sinh credential ảo, vui lòng thử lại sau.");
+        }
+        response.sendRedirect(request.getContextPath() + "/seller/inventory");
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/seller/SellerInventoryController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerInventoryController.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 
 /**
@@ -19,6 +20,19 @@ public class SellerInventoryController extends SellerBaseController {
             throws ServletException, IOException {
         if (!ensureSellerAccess(request, response)) {
             return;
+        }
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            Object success = session.getAttribute("sellerInventoryFlashSuccess");
+            if (success instanceof String) {
+                request.setAttribute("flashSuccess", success);
+            }
+            Object error = session.getAttribute("sellerInventoryFlashError");
+            if (error instanceof String) {
+                request.setAttribute("flashError", error);
+            }
+            session.removeAttribute("sellerInventoryFlashSuccess");
+            session.removeAttribute("sellerInventoryFlashError");
         }
         request.setAttribute("pageTitle", "Cập nhật kho - Quản lý cửa hàng");
         request.setAttribute("bodyClass", "layout");

--- a/MMO_Trader_Market/src/java/service/OrderService.java
+++ b/MMO_Trader_Market/src/java/service/OrderService.java
@@ -230,14 +230,14 @@ public class OrderService {
             }
         }
 
-        // 3. Đối chiếu và tự động bổ sung credential theo biến thể nhằm đảm bảo khi worker chạy sẽ có dữ liệu bàn giao.
-        CredentialDAO.CredentialAvailability credentialAvailability = credentialDAO
-                .ensureAvailabilityForOrder(productId, resolvedVariantCode, quantity);
-        if (resolvedVariantCode != null) {
-            if (credentialAvailability.available() < quantity) {
+        // 3. Kiểm tra tồn kho credential trước khi cho phép đặt mua.
+        CredentialDAO.CredentialAvailability credentialAvailability = resolvedVariantCode != null
+                ? credentialDAO.fetchAvailability(productId, resolvedVariantCode)
+                : credentialDAO.fetchAvailability(productId);
+        if (credentialAvailability.available() < quantity) {
+            if (resolvedVariantCode != null) {
                 throw new IllegalStateException("Biến thể sản phẩm tạm thời hết mã bàn giao, vui lòng thử lại sau.");
             }
-        } else if (credentialAvailability.available() < quantity) {
             throw new IllegalStateException("Sản phẩm tạm thời hết mã bàn giao, vui lòng thử lại sau.");
         }
 

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/inventory.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/inventory.jsp
@@ -9,6 +9,41 @@
 <main class="layout__content seller-page">
     <section class="panel">
         <div class="panel__header">
+            <h2 class="panel__title">Sinh credential ảo</h2>
+            <p class="panel__subtitle">Tạo nhanh dữ liệu bàn giao để kiểm thử luồng mua hàng trước khi kết nối hệ thống thực tế.</p>
+        </div>
+        <div class="panel__body">
+            <c:if test="${not empty flashSuccess}">
+                <div class="alert alert--success" role="status">${flashSuccess}</div>
+            </c:if>
+            <c:if test="${not empty flashError}">
+                <div class="alert alert--danger" role="alert">${flashError}</div>
+            </c:if>
+            <form method="post" action="${pageContext.request.contextPath}/seller/credentials/generate"
+                  style="display:flex;flex-wrap:wrap;gap:16px;align-items:flex-end;">
+                <div class="form-card__field" style="min-width:200px;">
+                    <label for="productId">Mã sản phẩm *</label>
+                    <input id="productId" name="productId" type="number" min="1" required class="form-control"
+                           placeholder="Ví dụ: 1001">
+                </div>
+                <div class="form-card__field" style="min-width:200px;">
+                    <label for="variantCode">Biến thể (tùy chọn)</label>
+                    <input id="variantCode" name="variantCode" type="text" class="form-control"
+                           placeholder="VD: vip-30ngay">
+                </div>
+                <div class="form-card__field" style="min-width:160px;">
+                    <label for="quantity">Số lượng *</label>
+                    <input id="quantity" name="quantity" type="number" min="1" max="500" value="10" required
+                           class="form-control">
+                </div>
+                <div class="form-card__field" style="margin-top:22px;">
+                    <button type="submit" class="button button--primary">Sinh credential</button>
+                </div>
+            </form>
+        </div>
+    </section>
+    <section class="panel">
+        <div class="panel__header">
             <h2 class="panel__title">Tồn kho tổng quan</h2>
             <p class="panel__subtitle">Dữ liệu mô phỏng phục vụ giao diện quản lý, sẽ kết nối với API thực tế trong giai đoạn kế tiếp.</p>
         </div>


### PR DESCRIPTION
## Summary
- add a seller-only endpoint and UI form to manually generate fake product credentials for testing
- expose a DAO helper for credential generation and surface flash messages on the inventory page
- stop the order flow and async worker from auto-seeding credentials when stock is low