### PR TITLE
Route pending email verification through dedicated page

### DIFF
--- a/MMO_Trader_Market/src/java/controller/auth/EmailVerificationController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/EmailVerificationController.java
@@ -26,11 +26,37 @@ public class EmailVerificationController extends BaseController {
     private final UserService userService = new UserService(new UserDAO()); //thực thi logic xác thực mã.
 
     @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            moveFlash(session, request, "pendingVerificationEmail", "verificationEmail");
+            moveFlash(session, request, "verificationNotice", "verificationNotice");
+            moveFlash(session, request, "verificationError", "verificationError");
+            moveFlash(session, request, "verificationSuccess", "success");
+        }
+
+        String emailParam = request.getParameter("email");
+        if (emailParam != null && !emailParam.trim().isEmpty()) {
+            request.setAttribute("verificationEmail", emailParam.trim().toLowerCase());
+        }
+
+        ensureDefaultNotice(request);
+        forward(request, response, "auth/verify-email");
+    }
+
+    @Override
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String email = request.getParameter("email");
         String code = request.getParameter("verificationCode");
+        String action = request.getParameter("action");
         String normalizedEmail = email == null ? "" : email.trim().toLowerCase();
+
+        if ("resend".equals(action)) {
+            handleResend(request, response, normalizedEmail);
+            return;
+        }
 
         try {
             boolean activated = userService.verifyEmailCode(normalizedEmail, code);
@@ -38,38 +64,102 @@ public class EmailVerificationController extends BaseController {
             session.setAttribute("newUserEmail", normalizedEmail); //prefill ô email ở trang login
             session.setAttribute("verificationSuccess",
                     activated
-                            ? "Xác thực email thành công! Bạn có thể đăng nhập." 
-                            : "Email đã được xác thực trước đó. Vui lòng đăng nhập."); 
+                            ? "Xác thực email thành công! Bạn có thể đăng nhập."
+                            : "Email đã được xác thực trước đó. Vui lòng đăng nhập.");
             response.sendRedirect(request.getContextPath() + "/auth");
         } catch (IllegalArgumentException e) {
             prepareErrorState(request, normalizedEmail, e.getMessage(), null);
-            forward(request, response, "auth/login");
+            forward(request, response, "auth/verify-email");
         } catch (IllegalStateException e) {
             prepareErrorState(request, normalizedEmail, e.getMessage(), null);
-            forward(request, response, "auth/login");
+            forward(request, response, "auth/verify-email");
         } catch (RuntimeException e) {
             String errorId = UUID.randomUUID().toString();
             LOGGER.log(Level.SEVERE, "Unexpected error during email verification, errorId=" + errorId, e);
             prepareErrorState(request, normalizedEmail,
                     "Hệ thống đang gặp sự cố. Mã lỗi: " + errorId,
                     "verificationError");
-            forward(request, response, "auth/login");
+            forward(request, response, "auth/verify-email");
         }
     }
-// chuẩn bị state lỗi , giữ lại dữ liệu ng dùng vừa nhập
+
+    /**
+     * Xử lý yêu cầu gửi lại mã xác thực từ phía người dùng.
+     *
+     * @param request         {@link HttpServletRequest} hiện tại.
+     * @param response        {@link HttpServletResponse} hiện tại.
+     * @param normalizedEmail Email đã được chuẩn hóa.
+     * @throws ServletException nếu xảy ra lỗi servlet trong quá trình forward.
+     * @throws IOException      nếu xảy ra lỗi I/O khi forward.
+     */
+    private void handleResend(HttpServletRequest request, HttpServletResponse response, String normalizedEmail)
+            throws ServletException, IOException {
+        if (normalizedEmail == null || normalizedEmail.isBlank()) {
+            prepareErrorState(request, normalizedEmail, "Vui lòng nhập email hợp lệ để gửi lại mã.", null);
+            forward(request, response, "auth/verify-email");
+            return;
+        }
+
+        try {
+            userService.resendVerificationCode(normalizedEmail);
+            request.setAttribute("verificationEmail", normalizedEmail);
+            request.setAttribute("success", "Chúng tôi đã gửi lại mã xác thực đến " + normalizedEmail + ".");
+            String codeValue = request.getParameter("verificationCode");
+            if (codeValue != null && !codeValue.isBlank()) {
+                request.setAttribute("enteredVerificationCode", codeValue.trim());
+            }
+            ensureDefaultNotice(request);
+            forward(request, response, "auth/verify-email");
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            prepareErrorState(request, normalizedEmail, e.getMessage(), null);
+            forward(request, response, "auth/verify-email");
+        } catch (RuntimeException e) {
+            String errorId = UUID.randomUUID().toString();
+            LOGGER.log(Level.SEVERE, "Unexpected error when resending verification code, errorId=" + errorId, e);
+            prepareErrorState(request, normalizedEmail,
+                    "Hệ thống không thể gửi lại mã xác thực lúc này. Mã lỗi: " + errorId,
+                    "verificationError");
+            forward(request, response, "auth/verify-email");
+        }
+    }
+
+    /**
+     * Di chuyển dữ liệu từ session xuống request để hiển thị dạng flash message.
+     */
+    private void moveFlash(HttpSession session, HttpServletRequest request, String sessionKey, String requestKey) {
+        Object value = session.getAttribute(sessionKey);
+        if (value != null) {
+            request.setAttribute(requestKey, value);
+            session.removeAttribute(sessionKey);
+        }
+    }
+
+    /**
+     * Chuẩn hóa thông điệp hướng dẫn hiển thị trên màn hình xác thực.
+     */
+    private void ensureDefaultNotice(HttpServletRequest request) {
+        Object existing = request.getAttribute("verificationNotice");
+        Object email = request.getAttribute("verificationEmail");
+        if (existing == null) {
+            if (email instanceof String emailStr && !emailStr.isBlank()) {
+                request.setAttribute("verificationNotice", "Vui lòng nhập mã xác thực đã gửi tới " + emailStr + ".");
+            } else {
+                request.setAttribute("verificationNotice", "Vui lòng nhập mã xác thực đã được gửi tới email của bạn.");
+            }
+        }
+    }
+
+    /**
+     * Chuẩn bị trạng thái lỗi và giữ lại dữ liệu người dùng vừa nhập để hiển thị lại.
+     */
     private void prepareErrorState(HttpServletRequest request, String email, String message, String attributeOverride) {
-        String attribute = attributeOverride == null ? "verificationError" : attributeOverride; 
+        String attribute = attributeOverride == null ? "verificationError" : attributeOverride;
         request.setAttribute(attribute, message);
-        request.setAttribute("showVerificationModal", true);
-        request.setAttribute("verificationEmail", email); //JSP/FE mở modal xác thực
-        String notice = (email == null || email.isBlank())
-                ? "Vui lòng nhập mã xác thực đã được gửi tới email của bạn."
-                : "Vui lòng nhập mã xác thực đã gửi tới " + email + ".";
-        request.setAttribute("verificationNotice", notice);
-        request.setAttribute("prefillEmail", email);
-        String codeValue = request.getParameter("verificationCode"); //Lấy lại mã xác thực người dùng
+        request.setAttribute("verificationEmail", email);
+        ensureDefaultNotice(request);
+        String codeValue = request.getParameter("verificationCode");
         if (codeValue != null) {
-            request.setAttribute("enteredVerificationCode", codeValue.trim()); //Nếu có → giữ lại vào request,hiển thị lại trong ô mã
+            request.setAttribute("enteredVerificationCode", codeValue.trim());
         }
     }
 }

--- a/MMO_Trader_Market/src/java/controller/auth/ForgotPasswordController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/ForgotPasswordController.java
@@ -30,10 +30,18 @@ public class ForgotPasswordController extends BaseController {
     protected void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         String email = request.getParameter("email");
+        String action = request.getParameter("action"); // xác định gửi mới hay gửi lại
+        String normalizedEmail = email == null ? null : email.trim(); // chuẩn hóa email trước khi xử lý
+        boolean allowResend = false;
         try {
             String resetBaseUrl = buildResetBaseUrl(request); // tạo dd
-            userService.requestPasswordReset(email, resetBaseUrl); //tạo yêu cầu đặt lại mật khẩu
-            request.setAttribute("success", "Đã gửi email đặt lại mật khẩu. Vui lòng kiểm tra hộp thư của bạn");
+            userService.requestPasswordReset(normalizedEmail, resetBaseUrl); //tạo yêu cầu đặt lại mật khẩu
+            allowResend = true;
+            if ("resend".equals(action)) {
+                request.setAttribute("success", "Đã gửi lại email đặt lại mật khẩu. Vui lòng kiểm tra hộp thư của bạn");
+            } else {
+                request.setAttribute("success", "Đã gửi email đặt lại mật khẩu. Vui lòng kiểm tra hộp thư của bạn");
+            }
         } catch (IllegalArgumentException | IllegalStateException e) {
             request.setAttribute("error", e.getMessage());
         } catch (RuntimeException e) {
@@ -41,7 +49,8 @@ public class ForgotPasswordController extends BaseController {
             LOGGER.log(Level.SEVERE, "Unexpected error when requesting password reset, errorId=" + errorId, e);
             request.setAttribute("error", "Hệ thống đang gặp sự cố. Mã lỗi: " + errorId);
         }
-        request.setAttribute("email", email);
+        request.setAttribute("allowResend", allowResend);
+        request.setAttribute("email", normalizedEmail);
         forward(request, response, "auth/forgot-password");
     }
 

--- a/MMO_Trader_Market/src/java/controller/auth/RegisterController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/RegisterController.java
@@ -57,14 +57,12 @@ public class RegisterController extends BaseController {
         try {
             Users createdUser = userService.registerNewUser(email, name, password, confirmPassword);
             HttpSession session = request.getSession();
-            session.setAttribute("registerSuccess",
-                    "Tạo tài khoản thành công! Vui lòng kiểm tra email để kích hoạt tài khoản."); //flash scope để mang thông điệp qua redirect
-            session.setAttribute("newUserEmail", createdUser.getEmail());
+            session.setAttribute("verificationSuccess",
+                    "Tạo tài khoản thành công! Vui lòng kiểm tra email để kích hoạt tài khoản.");
             session.setAttribute("pendingVerificationEmail", createdUser.getEmail());
-            session.setAttribute("showVerificationModal", Boolean.TRUE);
             session.setAttribute("verificationNotice",
                     "Chúng tôi đã gửi mã xác thực đến " + createdUser.getEmail() + ". Vui lòng kiểm tra hộp thư.");
-            response.sendRedirect(request.getContextPath() + "/auth");
+            response.sendRedirect(request.getContextPath() + "/verify-email");
             return;
         } catch (IllegalArgumentException | IllegalStateException e) {
             request.setAttribute("error", e.getMessage());

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/forgot-password.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/forgot-password.jsp
@@ -1,4 +1,4 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Quên mật khẩu" />
 <c:set var="bodyClass" value="layout layout--center" />
@@ -7,6 +7,29 @@
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content">
+    <!-- Styling for resend hint placed near the email field -->
+    <style>
+        .form-card__hint {
+            margin-top: 8px;
+            font-size: 0.95rem;
+            color: #0f172a;
+        }
+
+        .form-card__link-button {
+            background: transparent;
+            border: none;
+            color: #2563eb;
+            cursor: pointer;
+            padding: 0;
+            font: inherit;
+            text-decoration: underline;
+        }
+
+        .form-card__link-button:hover,
+        .form-card__link-button:focus {
+            color: #1d4ed8;
+        }
+    </style>
     <c:if test="${not empty error}">
         <div class="alert alert--error"><c:out value="${error}" /></div>
     </c:if>
@@ -17,6 +40,14 @@
         <label class="form-card__label" for="email">Email đã đăng ký</label>
         <input class="form-card__input" id="email" name="email" type="email"
                placeholder="example@email.com" value="<c:out value='${email}'/>" required>
+        <c:if test="${allowResend}">
+            <p class="form-card__hint">
+                Hệ thống đã gửi mail! Nếu chưa hãy
+                <button class="form-card__link-button" type="submit" name="action" value="resend">
+                    gửi lại
+                </button>.
+            </p>
+        </c:if>
         <button class="button button--primary" type="submit">Gửi link đặt lại mật khẩu</button>
     </form>
     <section class="guide-link">

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/login.jsp
@@ -1,4 +1,4 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng nhập" />
 <c:set var="bodyClass" value="layout layout--auth" />
@@ -6,139 +6,6 @@
 <%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
 <%@ include file="/WEB-INF/views/shared/header.jspf" %>
 <main class="layout__content auth-page">
-    <style>
-        .verification-modal {
-            position: fixed;
-            inset: 0;
-            display: none;
-            align-items: center;
-            justify-content: center;
-            padding: 16px;
-            z-index: 999;
-        }
-
-        .verification-modal.is-visible {
-            display: flex;
-        }
-
-        .verification-modal__backdrop {
-            position: absolute;
-            inset: 0;
-            background: rgba(15, 23, 42, 0.55);
-        }
-
-        .verification-modal__dialog {
-            position: relative;
-            background: #ffffff;
-            border-radius: 16px;
-            padding: 32px;
-            width: min(420px, 100%);
-            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.25);
-            z-index: 1;
-        }
-
-        .verification-modal__close {
-            position: absolute;
-            top: 12px;
-            right: 12px;
-            border: none;
-            background: transparent;
-            font-size: 1.5rem;
-            line-height: 1;
-            cursor: pointer;
-            color: #475569;
-        }
-
-        .verification-modal__title {
-            margin: 0 0 12px;
-            font-size: 1.5rem;
-            font-weight: 600;
-            color: #0f172a;
-        }
-
-        .verification-modal__description {
-            margin: 0 0 16px;
-            color: #4b5563;
-            line-height: 1.5;
-        }
-
-        .verification-modal__notice {
-            margin-bottom: 16px;
-            padding: 12px 14px;
-            border-radius: 10px;
-            background: #eff6ff;
-            color: #1d4ed8;
-            font-size: 0.95rem;
-        }
-
-        .verification-modal__error {
-            margin-bottom: 16px;
-            padding: 12px 14px;
-            border-radius: 10px;
-            background: #fee2e2;
-            color: #b91c1c;
-            font-size: 0.95rem;
-        }
-
-        .verification-modal__email {
-            margin: 0 0 8px;
-            color: #0f172a;
-            font-weight: 600;
-        }
-
-        .verification-modal__form {
-            display: flex;
-            flex-direction: column;
-            gap: 16px;
-        }
-
-        .verification-modal__field label {
-            display: block;
-            font-weight: 600;
-            color: #0f172a;
-            margin-bottom: 6px;
-        }
-
-        .verification-modal__input {
-            width: 100%;
-            padding: 12px 14px;
-            border-radius: 10px;
-            border: 1px solid #cbd5f5;
-            font-size: 1rem;
-            color: #0f172a;
-        }
-
-        .verification-modal__input:focus {
-            outline: none;
-            border-color: #6366f1;
-            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
-        }
-
-        .verification-modal__actions {
-            display: flex;
-            gap: 12px;
-            justify-content: flex-end;
-            margin-top: 8px;
-        }
-
-        .verification-modal__actions .button {
-            flex: 1;
-        }
-
-        @media (max-width: 480px) {
-            .verification-modal__dialog {
-                padding: 24px;
-            }
-
-            .verification-modal__actions {
-                flex-direction: column;
-            }
-
-            .verification-modal__actions .button {
-                width: 100%;
-            }
-        }
-    </style>
     <div class="auth-page__inner">
         <header class="auth-page__header">
             <h1>Đăng nhập</h1>
@@ -177,49 +44,7 @@
             </div>
         </form>
     </div>
-    <div class="verification-modal${showVerificationModal ? ' is-visible' : ''}" id="emailVerificationModal">
-        <div class="verification-modal__backdrop" data-modal-close></div>
-        <div class="verification-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="verificationModalTitle">
-            <button type="button" class="verification-modal__close" data-modal-close aria-label="Đóng">&times;</button>
-            <h2 class="verification-modal__title" id="verificationModalTitle">Xác thực email</h2>
-            <p class="verification-modal__description">Nhập mã xác thực đã được gửi đến hộp thư của bạn để kích hoạt tài khoản.</p>
-            <c:if test="${not empty verificationNotice}">
-                <div class="verification-modal__notice"><c:out value="${verificationNotice}" /></div>
-            </c:if>
-            <c:if test="${not empty verificationError}">
-                <div class="verification-modal__error"><c:out value="${verificationError}" /></div>
-            </c:if>
-            <p class="verification-modal__email">Email: <strong><c:out value="${verificationEmail}" /></strong></p>
-            <form method="post" action="<c:url value='/verify-email' />" class="verification-modal__form">
-                <input type="hidden" name="email" value="<c:out value='${verificationEmail}' />">
-                <div class="verification-modal__field">
-                    <label for="verificationCode">Mã xác thực</label>
-                    <input class="verification-modal__input" id="verificationCode" name="verificationCode" type="text"
-                           value="<c:out value='${enteredVerificationCode}' />"
-                           placeholder="Nhập mã 6 chữ số" required>
-                </div>
-                <div class="verification-modal__actions">
-                    <button class="button button--ghost" type="button" data-modal-close>Để sau</button>
-                    <button class="button button--primary" type="submit">Xác thực</button>
-                </div>
-            </form>
-        </div>
-    </div>
 </main>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
-<script>
-    (function () {
-        const modal = document.getElementById('emailVerificationModal');
-        if (!modal) {
-            return;
-        }
-        const closeButtons = modal.querySelectorAll('[data-modal-close]');
-        closeButtons.forEach(function (btn) {
-            btn.addEventListener('click', function () {
-                modal.classList.remove('is-visible');
-            });
-        });
-    })();
-</script>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
@@ -1,4 +1,4 @@
-<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" language="java" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <c:set var="pageTitle" value="MMO Trader Market - Đăng ký" />
 <c:set var="bodyClass" value="layout layout--auth" />

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/verify-email.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/verify-email.jsp
@@ -1,0 +1,81 @@
+<%@ page contentType="text/html;charset=UTF-8" pageEncoding="UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<c:set var="pageTitle" value="MMO Trader Market - Xác thực email" />
+<c:set var="bodyClass" value="layout layout--auth" />
+<c:set var="headerModifier" value="layout__header--auth" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<main class="layout__content auth-page">
+    <style>
+        .form-card__hint {
+            margin-top: 8px;
+            font-size: 0.95rem;
+            color: #0f172a;
+        }
+
+        .form-card__link-button {
+            background: transparent;
+            border: none;
+            color: #2563eb;
+            cursor: pointer;
+            padding: 0;
+            font: inherit;
+            text-decoration: underline;
+        }
+
+        .form-card__link-button:hover,
+        .form-card__link-button:focus {
+            color: #1d4ed8;
+        }
+    </style>
+    <div class="auth-page__inner">
+        <header class="auth-page__header">
+            <h1>Xác thực email</h1>
+            <p>Nhập mã gồm 6 chữ số đã được gửi tới hộp thư của bạn để kích hoạt tài khoản.</p>
+        </header>
+        <c:if test="${not empty success}">
+            <div class="alert alert--success auth-page__alert"><c:out value="${success}" /></div>
+        </c:if>
+        <c:if test="${not empty verificationError}">
+            <div class="alert alert--error auth-page__alert"><c:out value="${verificationError}" /></div>
+        </c:if>
+        <c:if test="${not empty verificationNotice}">
+            <div class="alert alert--info auth-page__alert"><c:out value="${verificationNotice}" /></div>
+        </c:if>
+        <form method="post" action="<c:url value='/verify-email' />" class="form-card auth-page__form" id="verificationForm">
+            <div class="form-card__field">
+                <label class="form-card__label" for="verificationEmail">Email đã đăng ký</label>
+                <input class="form-card__input" id="verificationEmail" name="email" type="email"
+                       placeholder="example@email.com" value="<c:out value='${verificationEmail}'/>" required>
+            </div>
+            <div class="form-card__field">
+                <label class="form-card__label" for="verificationCode">Mã xác thực</label>
+                <input class="form-card__input" id="verificationCode" name="verificationCode" type="text"
+                       inputmode="numeric" pattern="[0-9]{6}" maxlength="6"
+                       value="<c:out value='${enteredVerificationCode}'/>" placeholder="Nhập mã 6 chữ số" required>
+            </div>
+            <p class="form-card__hint">
+                Hệ thống đã gửi mã! Nếu chưa hãy
+                <button class="form-card__link-button" type="submit" name="action" value="resend" formnovalidate>
+                    gửi lại
+                </button>.
+            </p>
+            <div class="form-card__actions-row">
+                <button class="button button--primary" type="submit">Xác thực</button>
+            </div>
+        </form>
+        <section class="guide-link">
+            <a class="button button--ghost" href="<c:url value='/auth' />">Quay lại đăng nhập</a>
+        </section>
+    </div>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<script>
+    (function () {
+        const codeInput = document.getElementById('verificationCode');
+        if (codeInput) {
+            codeInput.focus();
+        }
+    })();
+</script>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>


### PR DESCRIPTION
## Summary
- redirect pending verification flows from login and registration straight to the new verify-email page
- expand the email verification controller to serve the page, preserve errors, and handle resend requests without blocking the user
- add the dedicated verification JSP and set UTF-8 page encoding on the auth views to fix Vietnamese text rendering issues

## Testing
- not run (UI changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69102b71ce748320a5f8d1dd760d6bf4)