### PR TITLE
Add database support for order dispute reporting and escrow pause

### DIFF
--- a/DB_v1.sql
+++ b/DB_v1.sql
@@ -197,6 +197,11 @@ CREATE TABLE `orders` (
   `idempotency_key` varchar(36) DEFAULT NULL UNIQUE,
   `variant_code` varchar(100) DEFAULT NULL,
   `hold_until` timestamp NULL DEFAULT NULL,
+  `escrow_original_release_at` timestamp NULL DEFAULT NULL COMMENT 'Mốc giải ngân escrow ban đầu trước khi phát sinh khiếu nại',
+  `escrow_release_at` timestamp NULL DEFAULT NULL COMMENT 'Thời điểm dự kiến giải ngân tự động cho seller khi không có khiếu nại',
+  `escrow_status` enum('Scheduled','Paused','Released','Cancelled') NOT NULL DEFAULT 'Scheduled' COMMENT 'Trạng thái giữ tiền escrow của đơn',
+  `escrow_paused_at` timestamp NULL DEFAULT NULL COMMENT 'Mốc thời gian hệ thống dừng đếm escrow do khiếu nại/report',
+  `escrow_remaining_seconds` int DEFAULT NULL COMMENT 'Số giây escrow còn lại tại thời điểm tạm dừng để hoàn trả khi tiếp tục',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
@@ -258,16 +263,35 @@ CREATE TABLE `withdrawal_request_reasons_map` (
 -- =================================================================
 -- Section 4: Support & Communication
 -- =================================================================
+-- Bảng dispute mở rộng để lưu report đơn hàng (kèm phân loại, ảnh bằng chứng, thông tin escrow).
 DROP TABLE IF EXISTS `disputes`;
 CREATE TABLE `disputes` (
     `id` int NOT NULL AUTO_INCREMENT,
     `order_id` int NOT NULL UNIQUE,
+    `order_reference_code` varchar(50) NOT NULL COMMENT 'Mã đơn hiển thị cho admin (có thể trùng mã hiển thị trên UI)',
     `reporter_id` int NOT NULL,
     `resolved_by_admin_id` int DEFAULT NULL,
-    `reason` text NOT NULL,
-    `status` enum('Open','ResolvedWithRefund','ResolvedWithoutRefund','Closed') NOT NULL DEFAULT 'Open',
+    `issue_type` enum('ACCOUNT_NOT_WORKING','ACCOUNT_DUPLICATED','ACCOUNT_EXPIRED','ACCOUNT_MISSING','OTHER') NOT NULL COMMENT 'Loại vấn đề chính do buyer chọn',
+    `custom_issue_title` varchar(255) DEFAULT NULL COMMENT 'Tiêu đề bổ sung khi buyer chọn loại Khác',
+    `reason` text NOT NULL COMMENT 'Mô tả chi tiết vấn đề và hướng xử lý mong muốn',
+    `order_snapshot_json` json DEFAULT NULL COMMENT 'Ảnh chụp thông tin đơn tại thời điểm report để admin tham khảo',
+    `status` enum('Open','InReview','ResolvedWithRefund','ResolvedWithoutRefund','Closed','Cancelled') NOT NULL DEFAULT 'Open',
+    `escrow_paused_at` timestamp NULL DEFAULT NULL COMMENT 'Thời điểm hệ thống đóng băng escrow do report',
+    `escrow_resolved_at` timestamp NULL DEFAULT NULL COMMENT 'Thời điểm escrow được mở lại/giải quyết',
+    `resolution_note` text DEFAULT NULL COMMENT 'Ghi chú xử lý của admin',
     `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_disputes_order_reference_code` (`order_reference_code`)
+) ENGINE=InnoDB;
+
+DROP TABLE IF EXISTS `dispute_attachments`;
+-- Lưu trữ ảnh bằng chứng mà buyer gửi kèm report.
+CREATE TABLE `dispute_attachments` (
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `dispute_id` int NOT NULL,
+    `file_url` varchar(512) NOT NULL COMMENT 'Đường dẫn tới ảnh bằng chứng (trước khi mở khóa credential)',
+    `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
@@ -347,15 +371,16 @@ ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_buyer_id` FOREIGN KEY (`buyer_id`
 ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_product_id` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`);
 ALTER TABLE `orders` ADD CONSTRAINT `fk_orders_payment_transaction_id` FOREIGN KEY (`payment_transaction_id`) REFERENCES `wallet_transactions` (`id`);
 
+ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_order_id` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`);
+ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_reporter_id` FOREIGN KEY (`reporter_id`) REFERENCES `users` (`id`);
+ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_admin_id` FOREIGN KEY (`resolved_by_admin_id`) REFERENCES `users` (`id`);
+ALTER TABLE `dispute_attachments` ADD CONSTRAINT `fk_dispute_attachments_dispute_id` FOREIGN KEY (`dispute_id`) REFERENCES `disputes` (`id`) ON DELETE CASCADE;
+
 ALTER TABLE `deposit_requests` ADD CONSTRAINT `fk_deposits_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 
 ALTER TABLE `withdrawal_requests` ADD CONSTRAINT `fk_withdrawals_user_id` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
 ALTER TABLE `withdrawal_request_reasons_map` ADD CONSTRAINT `fk_map_request_id` FOREIGN KEY (`request_id`) REFERENCES `withdrawal_requests` (`id`);
 ALTER TABLE `withdrawal_request_reasons_map` ADD CONSTRAINT `fk_map_reason_id` FOREIGN KEY (`reason_id`) REFERENCES `withdrawal_rejection_reasons` (`id`);
-
-ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_order_id` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`);
-ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_reporter_id` FOREIGN KEY (`reporter_id`) REFERENCES `users` (`id`);
-ALTER TABLE `disputes` ADD CONSTRAINT `fk_disputes_admin_id` FOREIGN KEY (`resolved_by_admin_id`) REFERENCES `users` (`id`);
 
 ALTER TABLE `messages` ADD CONSTRAINT `fk_messages_conversation_id` FOREIGN KEY (`conversation_id`) REFERENCES `conversations` (`id`);
 ALTER TABLE `messages` ADD CONSTRAINT `fk_messages_sender_id` FOREIGN KEY (`sender_id`) REFERENCES `users` (`id`);
@@ -377,6 +402,10 @@ CREATE INDEX `idx_products_type_subtype` ON `products`(`product_type`,`product_s
 CREATE INDEX `idx_products_status_created` ON `products`(`status`,`created_at`);
 CREATE INDEX `idx_orders_buyer_id` ON `orders`(`buyer_id`);
 CREATE INDEX `idx_orders_status` ON `orders`(`status`);
+CREATE INDEX `idx_orders_escrow_status` ON `orders`(`escrow_status`);
+CREATE INDEX `idx_disputes_status` ON `disputes`(`status`);
+CREATE INDEX `idx_disputes_issue_type` ON `disputes`(`issue_type`);
+CREATE INDEX `idx_dispute_attachments_dispute_id` ON `dispute_attachments`(`dispute_id`);
 CREATE INDEX `idx_wallet_transactions_wallet_id` ON `wallet_transactions`(`wallet_id`);
 CREATE INDEX `idx_wallet_transactions_type` ON `wallet_transactions`(`transaction_type`);
 CREATE INDEX `idx_deposit_requests_status` ON `deposit_requests`(`status`);
@@ -636,9 +665,9 @@ INSERT INTO `wallet_transactions` (`id`,`wallet_id`,`related_entity_id`,`transac
  (4,2,1,'Withdrawal',-120000.0000,450000.0000,330000.0000,'Rút tiền về Vietcombank','2024-01-26 09:40:00');
 
 -- Đơn hàng mẫu minh họa trạng thái Completed và Disputed
-INSERT INTO `orders` (`id`,`buyer_id`,`product_id`,`quantity`,`unit_price`,`payment_transaction_id`,`total_amount`,`status`,`variant_code`,`idempotency_key`,`hold_until`,`created_at`,`updated_at`) VALUES
- (5001,3,1001,1,250000.0000,2,250000.0000,'Completed','gmail-basic-1m','ORDER-5001-KEY','2024-01-23 12:00:00','2024-01-20 10:45:00','2024-01-20 12:05:00'),
- (5002,3,1002,1,185000.0000,NULL,185000.0000,'Disputed','sp-12m','ORDER-5002-KEY','2024-02-01 00:00:00','2024-01-26 09:00:00','2024-01-27 08:10:00');
+INSERT INTO `orders` (`id`,`buyer_id`,`product_id`,`quantity`,`unit_price`,`payment_transaction_id`,`total_amount`,`status`,`variant_code`,`idempotency_key`,`hold_until`,`escrow_original_release_at`,`escrow_release_at`,`escrow_status`,`escrow_paused_at`,`escrow_remaining_seconds`,`created_at`,`updated_at`) VALUES
+ (5001,3,1001,1,250000.0000,2,250000.0000,'Completed','gmail-basic-1m','ORDER-5001-KEY','2024-01-23 12:00:00','2024-01-23 12:00:00','2024-01-23 12:00:00','Released',NULL,NULL,'2024-01-20 10:45:00','2024-01-20 12:05:00'),
+ (5002,3,1002,1,185000.0000,NULL,185000.0000,'Disputed','sp-12m','ORDER-5002-KEY','2024-02-01 00:00:00','2024-02-01 00:00:00','2024-02-01 00:00:00','Paused','2024-01-27 08:10:00',402600,'2024-01-26 09:00:00','2024-01-27 08:10:00');
 
 -- Withdrawals
 INSERT INTO `withdrawal_rejection_reasons` (`id`,`reason_code`,`description`,`is_active`) VALUES
@@ -652,8 +681,12 @@ INSERT INTO `withdrawal_requests` (`id`,`user_id`,`amount`,`bank_account_info`,`
 INSERT INTO `withdrawal_request_reasons_map` (`request_id`,`reason_id`) VALUES (2,2);
 
 -- Support / Chat
-INSERT INTO `disputes` (`id`,`order_id`,`reporter_id`,`resolved_by_admin_id`,`reason`,`status`,`created_at`,`updated_at`) VALUES
- (1,5002,3,NULL,'Tài khoản Spotify không hoạt động','Open','2024-01-27 08:10:00','2024-01-27 08:10:00');
+INSERT INTO `disputes` (`id`,`order_id`,`order_reference_code`,`reporter_id`,`resolved_by_admin_id`,`issue_type`,`custom_issue_title`,`reason`,`order_snapshot_json`,`status`,`escrow_paused_at`,`escrow_resolved_at`,`resolution_note`,`created_at`,`updated_at`) VALUES
+ (1,5002,'ORD-5002',3,NULL,'ACCOUNT_NOT_WORKING',NULL,'Tài khoản Spotify không hoạt động',JSON_OBJECT('product_name','Spotify Premium 12 tháng','quantity',1,'buyer_email','buyer001@example.com'),'Open','2024-01-27 08:10:00',NULL,NULL,'2024-01-27 08:10:00','2024-01-27 08:10:00');
+
+INSERT INTO `dispute_attachments` (`id`,`dispute_id`,`file_url`,`created_at`) VALUES
+ (1,1,'https://cdn.mmo.local/disputes/5002/proof-1.png','2024-01-27 08:11:00'),
+ (2,1,'https://cdn.mmo.local/disputes/5002/proof-2.png','2024-01-27 08:11:30');
 
 INSERT INTO `conversations` (`id`,`related_order_id`,`related_product_id`,`created_at`) VALUES
  (1,5002,1002,'2024-01-27 08:00:00');


### PR DESCRIPTION
## Summary
- extend the `orders` table with escrow freeze tracking fields that keep the original release time and remaining seconds when a dispute pauses payment
- widen the `disputes` schema with structured issue types, metadata, admin notes, and a snapshot of the reported order, plus add attachment storage and supporting indexes
- seed example data and constraints to reflect the new reporting workflow and ensure dispute attachments cascade correctly

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691024a8a2f48320ab4437fdd040a1f3)