### PR TITLE
Send reset and verification emails asynchronously

### DIFF
--- a/MMO_Trader_Market/src/java/service/UserService.java
+++ b/MMO_Trader_Market/src/java/service/UserService.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 import model.PasswordResetToken;
 import model.Users;
 import units.HashPassword;
+import units.AsyncEmailSender;
 import units.SendMail;
 
 import java.security.SecureRandom;
@@ -419,11 +420,7 @@ public class UserService {
                 + " 24 giờ:\n" + resetLink + "\n\n"
                 + "Nếu bạn không thực hiện yêu cầu này, hãy bỏ qua email.\n\n"
                 + "Trân trọng,\nĐội ngũ MMO Trader Market";
-        try {
-            SendMail.sendMail(email, subject, body);
-        } catch (Exception e) {
-            throw new IllegalStateException("Không thể gửi email đặt lại mật khẩu. Vui lòng thử lại sau.", e);
-        }
+        AsyncEmailSender.send(email, subject, body);
     }
 
     private void sendVerificationEmail(String email, String name, String code) {
@@ -436,11 +433,7 @@ public class UserService {
                 + "Mã sẽ không thay đổi cho tới khi bạn kích hoạt thành công.\n\n"
                 + "Nếu bạn không yêu cầu tạo tài khoản, hãy bỏ qua email này.\n\n"
                 + "Trân trọng,\nĐội ngũ MMO Trader Market";
-        try {
-            SendMail.sendMail(email, subject, body);
-        } catch (Exception e) {
-            throw new IllegalStateException("Không thể gửi email xác thực", e);
-        }
+        AsyncEmailSender.send(email, subject, body);
     }
 
     private String resolveDisplayName(String email, String name) {

--- a/MMO_Trader_Market/src/java/units/AsyncEmailSender.java
+++ b/MMO_Trader_Market/src/java/units/AsyncEmailSender.java
@@ -1,0 +1,54 @@
+package units;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Dispatches transactional emails in the background so HTTP requests can return immediately.
+ */
+public final class AsyncEmailSender {
+
+    private static final Logger LOGGER = Logger.getLogger(AsyncEmailSender.class.getName());
+    private static final ExecutorService EMAIL_EXECUTOR = Executors.newFixedThreadPool(2, new DaemonThreadFactory());
+
+    private AsyncEmailSender() {
+        // Utility class
+    }
+
+    /**
+     * Submit an email-sending task to the background executor.
+     *
+     * @param toEmail recipient email address
+     * @param subject email subject line
+     * @param body    email body content
+     */
+    public static void send(String toEmail, String subject, String body) {
+        String normalizedRecipient = Objects.requireNonNull(toEmail, "Recipient email is required").trim();
+        EMAIL_EXECUTOR.submit(() -> {
+            try {
+                SendMail.sendMail(normalizedRecipient, subject, body);
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, "Failed to send email asynchronously to " + normalizedRecipient, e);
+            }
+        });
+    }
+
+    /**
+     * Custom thread factory to ensure background threads do not block application shutdown.
+     */
+    private static final class DaemonThreadFactory implements ThreadFactory {
+
+        private int threadIndex = 0;
+
+        @Override
+        public synchronized Thread newThread(Runnable r) {
+            Thread thread = new Thread(r, "async-email-sender-" + (++threadIndex));
+            thread.setDaemon(true);
+            return thread;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an asynchronous email sender utility with a background executor
- update password reset and verification flows to dispatch emails without blocking the response

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910cd0a1c3883208aa6421226877abe)