### PR TITLE
Consolidate VNPAY transaction schema into main dump

### DIFF
--- a/DB_v1.sql
+++ b/DB_v1.sql
@@ -247,6 +247,23 @@ CREATE TABLE `deposit_requests` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB;
 
+-- =================================================================
+-- VNPAY audit trail for wallet deposits (linked via deposit_request)
+-- =================================================================
+DROP TABLE IF EXISTS `vnpay_transaction`;
+CREATE TABLE `vnpay_transaction` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `deposit_request_id` int NOT NULL,
+  `link_data` json NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `vnpay_status` varchar(16) NOT NULL DEFAULT 'pending',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_vnpay_tx_deposit` (`deposit_request_id`),
+  CONSTRAINT `fk_vnpay_tx_deposit` FOREIGN KEY (`deposit_request_id`)
+    REFERENCES `deposit_requests`(`id`)
+    ON DELETE CASCADE
+) ENGINE=InnoDB;
+
 DROP TABLE IF EXISTS `withdrawal_requests`;
 CREATE TABLE `withdrawal_requests` (
   `id` int NOT NULL AUTO_INCREMENT,

--- a/MMO_Trader_Market/src/conf/database.properties
+++ b/MMO_Trader_Market/src/conf/database.properties
@@ -25,3 +25,12 @@ upload.kyc.absolute=D:/DH_FPT/Ky_7/SWP391_MMO_Project/MMO_Trader_Market/web/asse
 upload.avatar.relative=/assets/images/avata
 upload.avatar.absolute=D:/DH_FPT/Ky_7/SWP391_MMO_Project/MMO_Trader_Market/web/assets/images/avata
 
+# VNPAY sandbox configuration. Values can be overridden via environment variables
+# or JVM system properties (for example VNPAY_TMN_CODE / -Dvnpay.tmnCode).
+vnpay.tmnCode=YOUR_SANDBOX_TMN_CODE
+vnpay.hashSecret=YOUR_SANDBOX_HASH_SECRET
+vnpay.payUrl=https://sandbox.vnpayment.vn/paymentv2/vpcpay.html
+vnpay.queryUrl=https://sandbox.vnpayment.vn/merchant_webapi/api/transaction
+vnpay.returnUrl=http://localhost:9999/MMO_Trader_Market/wallet/vnpay/return
+vnpay.ipnUrl=http://localhost:9999/MMO_Trader_Market/wallet/vnpay/ipn
+

--- a/MMO_Trader_Market/src/java/conf/VnpayConfig.java
+++ b/MMO_Trader_Market/src/java/conf/VnpayConfig.java
@@ -1,0 +1,112 @@
+package conf;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Locale;
+import java.util.Objects;
+
+/**
+ * Immutable configuration holder for VNPAY integration. Values are resolved
+ * from {@link AppConfig} so they can be overridden via environment variables or
+ * JVM system properties without rebuilding the application.
+ */
+public final class VnpayConfig {
+
+    private static final Duration PAYMENT_TIMEOUT = Duration.ofMinutes(15);
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Ho_Chi_Minh");
+
+    private final String tmnCode;
+    private final String hashSecret;
+    private final String payUrl;
+    private final String queryUrl;
+    private final String returnUrl;
+    private final String ipnUrl;
+
+    private VnpayConfig(String tmnCode, String hashSecret, String payUrl,
+            String queryUrl, String returnUrl, String ipnUrl) {
+        this.tmnCode = Objects.requireNonNull(tmnCode, "tmnCode must not be null");
+        this.hashSecret = Objects.requireNonNull(hashSecret, "hashSecret must not be null");
+        this.payUrl = Objects.requireNonNull(payUrl, "payUrl must not be null");
+        this.queryUrl = Objects.requireNonNull(queryUrl, "queryUrl must not be null");
+        this.returnUrl = Objects.requireNonNull(returnUrl, "returnUrl must not be null");
+        this.ipnUrl = Objects.requireNonNull(ipnUrl, "ipnUrl must not be null");
+    }
+
+    /**
+     * Builds a configuration instance using {@link AppConfig} as the backing
+     * source.
+     *
+     * @return configuration resolved from properties and environment variables
+     */
+    public static VnpayConfig fromAppConfig() {
+        return new VnpayConfig(
+                AppConfig.get("vnpay.tmnCode"),
+                AppConfig.get("vnpay.hashSecret"),
+                AppConfig.get("vnpay.payUrl"),
+                AppConfig.get("vnpay.queryUrl"),
+                AppConfig.get("vnpay.returnUrl"),
+                AppConfig.get("vnpay.ipnUrl"));
+    }
+
+    /**
+     * Factory primarily used by tests to create a configuration with
+     * deterministic values.
+     */
+    public static VnpayConfig of(String tmnCode, String hashSecret, String payUrl,
+            String queryUrl, String returnUrl, String ipnUrl) {
+        return new VnpayConfig(tmnCode, hashSecret, payUrl, queryUrl, returnUrl, ipnUrl);
+    }
+
+    public String tmnCode() {
+        return tmnCode;
+    }
+
+    public String hashSecret() {
+        return hashSecret;
+    }
+
+    public String payUrl() {
+        return payUrl;
+    }
+
+    public String queryUrl() {
+        return queryUrl;
+    }
+
+    public String returnUrl() {
+        return returnUrl;
+    }
+
+    public String ipnUrl() {
+        return ipnUrl;
+    }
+
+    /**
+     * VNPAY expects payment requests and timestamps to be aligned with the
+     * Vietnam time-zone.
+     *
+     * @return zone identifier fixed to Asia/Ho_Chi_Minh
+     */
+    public ZoneId zoneId() {
+        return ZONE_ID;
+    }
+
+    /**
+     * Payment URLs expire after a fixed 15 minute window.
+     *
+     * @return timeout duration used for {@code vnp_ExpireDate}
+     */
+    public Duration paymentTimeout() {
+        return PAYMENT_TIMEOUT;
+    }
+
+    /**
+     * Default locale used for VNPAY requests when the caller does not specify
+     * one explicitly.
+     *
+     * @return Vietnamese locale by default
+     */
+    public Locale defaultLocale() {
+        return Locale.forLanguageTag("vi-VN");
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/wallet/VnpayIpnController.java
+++ b/MMO_Trader_Market/src/java/controller/wallet/VnpayIpnController.java
@@ -1,0 +1,69 @@
+package controller.wallet;
+
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import service.wallet.WalletTopUpService;
+import service.wallet.WalletTopUpServiceFactory;
+import service.wallet.dto.IpnResult;
+
+/**
+ * Receives the server-to-server IPN callback from VNPAY and updates the wallet
+ * state accordingly.
+ */
+@WebServlet(name = "VnpayIpnController", urlPatterns = {"/wallet/vnpay/ipn"})
+public class VnpayIpnController extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(VnpayIpnController.class.getName());
+    private final transient Gson gson = new Gson();
+    private transient WalletTopUpService walletTopUpService;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        walletTopUpService = WalletTopUpServiceFactory.createDefault();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        Map<String, String> params = extractParams(request);
+        String remoteIp = resolveClientIp(request);
+        String rawQuery = request.getQueryString();
+
+        LOGGER.log(Level.INFO, "Nhận IPN từ VNPAY: txnRef={0}, ip={1}",
+                new Object[]{params.get("vnp_TxnRef"), remoteIp});
+
+        IpnResult result = walletTopUpService.handleIpn(params, rawQuery, remoteIp);
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(gson.toJson(Map.of(
+                "RspCode", result.getRspCode(),
+                "Message", result.getMessage())));
+    }
+
+    private Map<String, String> extractParams(HttpServletRequest request) {
+        Map<String, String> params = new HashMap<>();
+        request.getParameterMap().forEach((key, values) -> {
+            if (values != null && values.length > 0) {
+                params.put(key, values[0]);
+            }
+        });
+        return params;
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/wallet/VnpayReturnController.java
+++ b/MMO_Trader_Market/src/java/controller/wallet/VnpayReturnController.java
@@ -1,0 +1,81 @@
+package controller.wallet;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import service.wallet.WalletTopUpService;
+import service.wallet.WalletTopUpServiceFactory;
+
+/**
+ * Handles the user-facing return URL after a VNPAY payment attempt. No database
+ * mutation happens in this servlet.
+ */
+@WebServlet(name = "VnpayReturnController", urlPatterns = {"/wallet/vnpay/return"})
+public class VnpayReturnController extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(VnpayReturnController.class.getName());
+    private transient WalletTopUpService walletTopUpService;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        walletTopUpService = WalletTopUpServiceFactory.createDefault();
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        Map<String, String> params = extractParams(request);
+        boolean checksumValid = walletTopUpService.verifyChecksum(params);
+
+        String responseCode = params.getOrDefault("vnp_ResponseCode", "");
+        String transactionStatus = params.getOrDefault("vnp_TransactionStatus", "");
+        String txnRef = params.get("vnp_TxnRef");
+        String amountRaw = params.get("vnp_Amount");
+        BigDecimal amount = parseAmount(amountRaw);
+
+        boolean success = checksumValid && "00".equals(responseCode) && "00".equals(transactionStatus);
+
+        request.setAttribute("checksumValid", checksumValid);
+        request.setAttribute("paymentSuccess", success);
+        request.setAttribute("txnRef", txnRef);
+        request.setAttribute("responseCode", responseCode);
+        request.setAttribute("transactionStatus", transactionStatus);
+        request.setAttribute("amount", amount);
+
+        if (!checksumValid) {
+            LOGGER.log(Level.WARNING, "Return URL checksum không hợp lệ cho giao dịch {0}", txnRef);
+        }
+
+        request.getRequestDispatcher("/WEB-INF/views/wallet/vnpay-return.jsp").forward(request, response);
+    }
+
+    private Map<String, String> extractParams(HttpServletRequest request) {
+        Map<String, String> params = new HashMap<>();
+        request.getParameterMap().forEach((key, values) -> {
+            if (values != null && values.length > 0) {
+                params.put(key, values[0]);
+            }
+        });
+        return params;
+    }
+
+    private BigDecimal parseAmount(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            return new BigDecimal(raw).divide(BigDecimal.valueOf(100));
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/wallet/WalletTopUpController.java
+++ b/MMO_Trader_Market/src/java/controller/wallet/WalletTopUpController.java
@@ -1,0 +1,106 @@
+package controller.wallet;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import service.wallet.WalletTopUpService;
+import service.wallet.WalletTopUpServiceFactory;
+import service.wallet.dto.CreatePaymentResult;
+
+/**
+ * Handles API requests that create a VNPAY payment URL for wallet top-ups.
+ */
+@WebServlet(name = "WalletTopUpController", urlPatterns = {"/wallet/deposit/create"})
+public class WalletTopUpController extends HttpServlet {
+
+    private static final Logger LOGGER = Logger.getLogger(WalletTopUpController.class.getName());
+    private final transient Gson gson = new Gson();
+    private transient WalletTopUpService walletTopUpService;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        walletTopUpService = WalletTopUpServiceFactory.createDefault();
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        Integer userId = session == null ? null : (Integer) session.getAttribute("userId");
+        if (userId == null) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            writeJson(response, Map.of("error", "Bạn cần đăng nhập để nạp tiền"));
+            return;
+        }
+
+        JsonObject payload;
+        try {
+            payload = JsonParser.parseReader(request.getReader()).getAsJsonObject();
+        } catch (Exception ex) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            writeJson(response, Map.of("error", "Payload không hợp lệ"));
+            return;
+        }
+
+        if (!payload.has("amount")) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            writeJson(response, Map.of("error", "Thiếu trường amount"));
+            return;
+        }
+
+        long amount;
+        try {
+            amount = payload.get("amount").getAsLong();
+        } catch (NumberFormatException | UnsupportedOperationException | ClassCastException ex) {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            writeJson(response, Map.of("error", "Giá trị amount không hợp lệ"));
+            return;
+        }
+
+        String note = payload.has("note") && !payload.get("note").isJsonNull()
+                ? payload.get("note").getAsString() : null;
+
+        Locale locale = request.getLocale();
+        String clientIp = resolveClientIp(request);
+
+        try {
+            CreatePaymentResult result = walletTopUpService.createPaymentUrl(userId, amount, note, locale, clientIp);
+            writeJson(response, Map.of("paymentUrl", result.getPaymentUrl(),
+                    "txnRef", result.getTxnRef(),
+                    "depositRequestId", result.getDepositRequestId()));
+        } catch (IllegalArgumentException ex) {
+            LOGGER.log(Level.WARNING, "Tạo URL nạp tiền thất bại: {0}", ex.getMessage());
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            writeJson(response, Map.of("error", ex.getMessage()));
+        } catch (Exception ex) {
+            LOGGER.log(Level.SEVERE, "Lỗi hệ thống khi tạo URL nạp tiền", ex);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            writeJson(response, Map.of("error", "Không thể tạo URL nạp tiền, vui lòng thử lại"));
+        }
+    }
+
+    private void writeJson(HttpServletResponse response, Map<String, ?> payload) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(gson.toJson(payload));
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (forwarded != null && !forwarded.isBlank()) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/MMO_Trader_Market/src/java/controller/wallet/WalletTopUpPageController.java
+++ b/MMO_Trader_Market/src/java/controller/wallet/WalletTopUpPageController.java
@@ -1,0 +1,28 @@
+package controller.wallet;
+
+import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+/**
+ * Renders the JSP page that allows users to initiate a wallet top-up via VNPAY.
+ */
+@WebServlet(name = "WalletTopUpPageController", urlPatterns = {"/wallet/deposit"})
+public class WalletTopUpPageController extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        Integer userId = session == null ? null : (Integer) session.getAttribute("userId");
+        if (userId == null) {
+            response.sendRedirect(request.getContextPath() + "/auth");
+            return;
+        }
+        request.getRequestDispatcher("/WEB-INF/views/wallet/deposit.jsp").forward(request, response);
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/DepositRequestRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/DepositRequestRepository.java
@@ -1,0 +1,24 @@
+package dao.wallet;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Optional;
+import model.DepositRequests;
+
+/**
+ * Data access abstraction dedicated to {@code deposit_requests}. Separating the
+ * repository contract allows the service layer to be unit-tested without
+ * touching the real database.
+ */
+public interface DepositRequestRepository {
+
+    DepositRequests insert(Connection connection, int userId, BigDecimal amount,
+            String qrContent, String idempotencyKey, Instant expiresAt) throws SQLException;
+
+    Optional<DepositRequests> findByTxnRef(Connection connection, String txnRef,
+            boolean forUpdate) throws SQLException;
+
+    void updateStatus(Connection connection, int id, String status) throws SQLException;
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/JdbcDepositRequestRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/JdbcDepositRequestRepository.java
@@ -1,0 +1,114 @@
+package dao.wallet;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import model.DepositRequests;
+
+/**
+ * JDBC implementation of {@link DepositRequestRepository}.
+ */
+public class JdbcDepositRequestRepository implements DepositRequestRepository {
+
+    private static final Logger LOGGER = Logger.getLogger(JdbcDepositRequestRepository.class.getName());
+
+    @Override
+    public DepositRequests insert(Connection connection, int userId, BigDecimal amount,
+            String qrContent, String idempotencyKey, Instant expiresAt) throws SQLException {
+        final String sql = """
+                INSERT INTO deposit_requests (user_id, amount, qr_content, idempotency_key, status, expires_at)
+                VALUES (?, ?, ?, ?, 'Pending', ?)
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, userId);
+            ps.setBigDecimal(2, amount);
+            ps.setString(3, qrContent);
+            if (idempotencyKey == null || idempotencyKey.isBlank()) {
+                ps.setNull(4, Types.VARCHAR);
+            } else {
+                ps.setString(4, idempotencyKey);
+            }
+            ps.setTimestamp(5, Timestamp.from(expiresAt));
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    int id = rs.getInt(1);
+                    return findById(connection, id).orElseThrow(() -> new SQLException("Missing deposit request after insert"));
+                }
+            }
+        }
+        throw new SQLException("Không thể tạo yêu cầu nạp tiền mới");
+    }
+
+    @Override
+    public Optional<DepositRequests> findByTxnRef(Connection connection, String txnRef,
+            boolean forUpdate) throws SQLException {
+        String sql = """
+                SELECT * FROM deposit_requests
+                WHERE idempotency_key = ?
+                """ + (forUpdate ? " FOR UPDATE" : "");
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, txnRef);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public void updateStatus(Connection connection, int id, String status) throws SQLException {
+        final String sql = "UPDATE deposit_requests SET status = ?, admin_note = NULL WHERE id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, status);
+            ps.setInt(2, id);
+            ps.executeUpdate();
+        }
+    }
+
+    private Optional<DepositRequests> findById(Connection connection, int id) {
+        final String sql = "SELECT * FROM deposit_requests WHERE id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể truy vấn deposit_requests", ex);
+        }
+        return Optional.empty();
+    }
+
+    private DepositRequests mapRow(ResultSet rs) throws SQLException {
+        DepositRequests request = new DepositRequests();
+        request.setId(rs.getInt("id"));
+        request.setUserId(rs.getInt("user_id"));
+        request.setAmount(rs.getBigDecimal("amount"));
+        request.setQrContent(rs.getString("qr_content"));
+        request.setIdempotencyKey(rs.getString("idempotency_key"));
+        request.setStatus(rs.getString("status"));
+        Timestamp expires = rs.getTimestamp("expires_at");
+        if (expires != null) {
+            request.setExpiresAt(new java.util.Date(expires.getTime()));
+        }
+        Timestamp created = rs.getTimestamp("created_at");
+        if (created != null) {
+            request.setCreatedAt(new java.util.Date(created.getTime()));
+        }
+        request.setAdminNote(rs.getString("admin_note"));
+        return request;
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/JdbcVnpayTransactionRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/JdbcVnpayTransactionRepository.java
@@ -1,0 +1,97 @@
+package dao.wallet;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.Optional;
+import model.VnpayTransaction;
+
+/**
+ * JDBC persistence for {@link VnpayTransaction} records.
+ */
+public class JdbcVnpayTransactionRepository implements VnpayTransactionRepository {
+
+    @Override
+    public VnpayTransaction insert(Connection connection, int depositRequestId,
+            String linkData) throws SQLException {
+        final String sql = """
+                INSERT INTO vnpay_transaction (deposit_request_id, link_data, vnpay_status)
+                VALUES (?, CAST(? AS JSON), 'pending')
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)) {
+            ps.setInt(1, depositRequestId);
+            ps.setString(2, linkData);
+            ps.executeUpdate();
+            try (ResultSet rs = ps.getGeneratedKeys()) {
+                if (rs.next()) {
+                    int id = rs.getInt(1);
+                    return findById(connection, id).orElseThrow(() -> new SQLException("Missing VNPAY transaction after insert"));
+                }
+            }
+        }
+        throw new SQLException("Không thể lưu giao dịch VNPAY");
+    }
+
+    @Override
+    public void updateStatusAndPayload(Connection connection, int depositRequestId,
+            String status, String linkData) throws SQLException {
+        final String sql = """
+                UPDATE vnpay_transaction
+                SET vnpay_status = ?, link_data = CAST(? AS JSON)
+                WHERE deposit_request_id = ?
+                """;
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, status);
+            ps.setString(2, linkData);
+            ps.setInt(3, depositRequestId);
+            ps.executeUpdate();
+        }
+    }
+
+    @Override
+    public Optional<VnpayTransaction> findByDepositRequestId(Connection connection,
+            int depositRequestId, boolean forUpdate) throws SQLException {
+        final String sql = """
+                SELECT * FROM vnpay_transaction
+                WHERE deposit_request_id = ?
+                """ + (forUpdate ? " FOR UPDATE" : "");
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, depositRequestId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<VnpayTransaction> findById(Connection connection, int id) throws SQLException {
+        final String sql = "SELECT * FROM vnpay_transaction WHERE id = ?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRow(rs));
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private VnpayTransaction mapRow(ResultSet rs) throws SQLException {
+        VnpayTransaction tx = new VnpayTransaction();
+        tx.setId(rs.getInt("id"));
+        tx.setDepositRequestId(rs.getInt("deposit_request_id"));
+        tx.setLinkData(rs.getString("link_data"));
+        Timestamp created = rs.getTimestamp("created_at");
+        if (created != null) {
+            tx.setCreatedAt(new java.util.Date(created.getTime()));
+        }
+        tx.setVnpayStatus(rs.getString("vnpay_status"));
+        return tx;
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/JdbcWalletRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/JdbcWalletRepository.java
@@ -1,0 +1,30 @@
+package dao.wallet;
+
+import dao.user.WalletsDAO;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import model.Wallets;
+
+/**
+ * Adapter bridging {@link WalletsDAO} with the {@link WalletRepository}
+ * contract.
+ */
+public class JdbcWalletRepository implements WalletRepository {
+
+    private final WalletsDAO delegate;
+
+    public JdbcWalletRepository(WalletsDAO delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Wallets lockWalletForUser(Connection connection, int userId) throws SQLException {
+        return delegate.lockWalletForUpdate(connection, userId);
+    }
+
+    @Override
+    public boolean updateBalance(Connection connection, int walletId, BigDecimal newBalance) throws SQLException {
+        return delegate.updateBalance(connection, walletId, newBalance);
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/JdbcWalletTransactionRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/JdbcWalletTransactionRepository.java
@@ -1,0 +1,27 @@
+package dao.wallet;
+
+import dao.user.WalletTransactionDAO;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import model.TransactionType;
+
+/**
+ * JDBC backed implementation for writing wallet transaction records.
+ */
+public class JdbcWalletTransactionRepository implements WalletTransactionRepository {
+
+    private final WalletTransactionDAO delegate;
+
+    public JdbcWalletTransactionRepository(WalletTransactionDAO delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int insertTransaction(Connection connection, int walletId, Integer relatedEntityId,
+            TransactionType type, BigDecimal amount, BigDecimal balanceBefore,
+            BigDecimal balanceAfter, String note) throws SQLException {
+        return delegate.insertTransaction(connection, walletId, relatedEntityId, type,
+                amount, balanceBefore, balanceAfter, note);
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/VnpayTransactionRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/VnpayTransactionRepository.java
@@ -1,0 +1,21 @@
+package dao.wallet;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+import model.VnpayTransaction;
+
+/**
+ * Repository abstraction to keep track of payload exchanges with VNPAY.
+ */
+public interface VnpayTransactionRepository {
+
+    VnpayTransaction insert(Connection connection, int depositRequestId,
+            String linkData) throws SQLException;
+
+    void updateStatusAndPayload(Connection connection, int depositRequestId,
+            String status, String linkData) throws SQLException;
+
+    Optional<VnpayTransaction> findByDepositRequestId(Connection connection,
+            int depositRequestId, boolean forUpdate) throws SQLException;
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/WalletRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/WalletRepository.java
@@ -1,0 +1,17 @@
+package dao.wallet;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import model.Wallets;
+
+/**
+ * Minimal repository abstraction for wallet operations used during top-up
+ * processing.
+ */
+public interface WalletRepository {
+
+    Wallets lockWalletForUser(Connection connection, int userId) throws SQLException;
+
+    boolean updateBalance(Connection connection, int walletId, BigDecimal newBalance) throws SQLException;
+}

--- a/MMO_Trader_Market/src/java/dao/wallet/WalletTransactionRepository.java
+++ b/MMO_Trader_Market/src/java/dao/wallet/WalletTransactionRepository.java
@@ -1,0 +1,16 @@
+package dao.wallet;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import model.TransactionType;
+
+/**
+ * Abstraction around persistence of {@code wallet_transactions}.
+ */
+public interface WalletTransactionRepository {
+
+    int insertTransaction(Connection connection, int walletId, Integer relatedEntityId,
+            TransactionType type, BigDecimal amount, BigDecimal balanceBefore,
+            BigDecimal balanceAfter, String note) throws SQLException;
+}

--- a/MMO_Trader_Market/src/java/model/DepositRequests.java
+++ b/MMO_Trader_Market/src/java/model/DepositRequests.java
@@ -15,6 +15,9 @@ public class DepositRequests {
     private Date createdAt;
     private String adminNote;
 
+    public DepositRequests() {
+    }
+
     public DepositRequests(Integer id, Integer userId, BigDecimal amount, String qrContent, String idempotencyKey, String status, Date expiresAt, Date createdAt, String adminNote) {
         this.id = id;
         this.userId = userId;

--- a/MMO_Trader_Market/src/java/model/VnpayTransaction.java
+++ b/MMO_Trader_Market/src/java/model/VnpayTransaction.java
@@ -1,0 +1,55 @@
+package model;
+
+import java.util.Date;
+
+/**
+ * Domain model representing the {@code vnpay_transaction} audit table.
+ */
+public class VnpayTransaction {
+
+    private Integer id;
+    private Integer depositRequestId;
+    private String linkData;
+    private Date createdAt;
+    private String vnpayStatus;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getDepositRequestId() {
+        return depositRequestId;
+    }
+
+    public void setDepositRequestId(Integer depositRequestId) {
+        this.depositRequestId = depositRequestId;
+    }
+
+    public String getLinkData() {
+        return linkData;
+    }
+
+    public void setLinkData(String linkData) {
+        this.linkData = linkData;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getVnpayStatus() {
+        return vnpayStatus;
+    }
+
+    public void setVnpayStatus(String vnpayStatus) {
+        this.vnpayStatus = vnpayStatus;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/wallet/ConnectionProvider.java
+++ b/MMO_Trader_Market/src/java/service/wallet/ConnectionProvider.java
@@ -1,0 +1,14 @@
+package service.wallet;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Allows {@link service.wallet.WalletTopUpService} to obtain JDBC connections
+ * in a testable way.
+ */
+@FunctionalInterface
+public interface ConnectionProvider {
+
+    Connection getConnection() throws SQLException;
+}

--- a/MMO_Trader_Market/src/java/service/wallet/VnpayGateway.java
+++ b/MMO_Trader_Market/src/java/service/wallet/VnpayGateway.java
@@ -1,0 +1,113 @@
+package service.wallet;
+
+import conf.VnpayConfig;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import utils.crypto.HmacUtils;
+
+/**
+ * Helper responsible for constructing signed VNPAY requests and validating the
+ * checksum returned by the gateway.
+ */
+public class VnpayGateway {
+
+    private static final Logger LOGGER = Logger.getLogger(VnpayGateway.class.getName());
+    private static final DateTimeFormatter VNP_DATETIME = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private final VnpayConfig config;
+
+    public VnpayGateway(VnpayConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Prepares the core parameter set expected by VNPAY.
+     */
+    public Map<String, String> createPaymentParams(String txnRef, long amountVnd, String orderInfo,
+            String orderType, String clientIp, Locale locale, LocalDateTime createdAt,
+            LocalDateTime expiresAt) {
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("vnp_Version", "2.1.0");
+        params.put("vnp_Command", "pay");
+        params.put("vnp_TmnCode", config.tmnCode());
+        params.put("vnp_Amount", String.valueOf(amountVnd * 100));
+        params.put("vnp_CurrCode", "VND");
+        params.put("vnp_Locale", locale != null && "en".equalsIgnoreCase(locale.getLanguage()) ? "en" : "vn");
+        params.put("vnp_OrderInfo", orderInfo);
+        params.put("vnp_OrderType", orderType);
+        params.put("vnp_ReturnUrl", config.returnUrl());
+        params.put("vnp_IpAddr", clientIp);
+        params.put("vnp_TxnRef", txnRef);
+        params.put("vnp_CreateDate", VNP_DATETIME.format(createdAt));
+        params.put("vnp_ExpireDate", VNP_DATETIME.format(expiresAt));
+        return params;
+    }
+
+    /**
+     * Builds a fully signed payment URL.
+     */
+    public String buildPaymentUrl(String txnRef, long amountVnd, String orderInfo,
+            String orderType, String clientIp, Locale locale, LocalDateTime createdAt,
+            LocalDateTime expiresAt) {
+        Map<String, String> params = createPaymentParams(txnRef, amountVnd, orderInfo, orderType,
+                clientIp, locale, createdAt, expiresAt);
+        Map<String, String> sortedParams = new TreeMap<>(params);
+        String queryString = buildQuery(sortedParams);
+        String secureHash = HmacUtils.hmacSha512(config.hashSecret(), queryString);
+        try {
+            return config.payUrl() + "?" + queryString
+                    + "&vnp_SecureHashType=HmacSHA512"
+                    + "&vnp_SecureHash=" + URLEncoder.encode(secureHash, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể mã hóa URL VNPAY", ex);
+            throw new IllegalStateException("Failed to encode VNPAY URL", ex);
+        }
+    }
+
+    /**
+     * Validates the checksum attached to a VNPAY callback.
+     */
+    public boolean isChecksumValid(Map<String, String> params) {
+        String secureHash = params.get("vnp_SecureHash");
+        if (secureHash == null) {
+            return false;
+        }
+        Map<String, String> filtered = new TreeMap<>();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String key = entry.getKey();
+            if ("vnp_SecureHash".equalsIgnoreCase(key) || "vnp_SecureHashType".equalsIgnoreCase(key)) {
+                continue;
+            }
+            filtered.put(key, entry.getValue());
+        }
+        String recalculated = HmacUtils.hmacSha512(config.hashSecret(), buildQuery(filtered));
+        return secureHash.equalsIgnoreCase(recalculated);
+    }
+
+    private String buildQuery(Map<String, String> params) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (!first) {
+                builder.append('&');
+            }
+            first = false;
+            try {
+                builder.append(URLEncoder.encode(entry.getKey(), "UTF-8"))
+                        .append('=')
+                        .append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+            } catch (UnsupportedEncodingException ex) {
+                throw new IllegalStateException("UTF-8 not supported", ex);
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/MMO_Trader_Market/src/java/service/wallet/WalletTopUpService.java
+++ b/MMO_Trader_Market/src/java/service/wallet/WalletTopUpService.java
@@ -1,0 +1,307 @@
+package service.wallet;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import conf.VnpayConfig;
+import dao.wallet.DepositRequestRepository;
+import dao.wallet.VnpayTransactionRepository;
+import dao.wallet.WalletRepository;
+import dao.wallet.WalletTransactionRepository;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import model.DepositRequests;
+import model.TransactionType;
+import model.VnpayTransaction;
+import model.Wallets;
+import service.wallet.dto.CreatePaymentResult;
+import service.wallet.dto.IpnResult;
+
+/**
+ * Core service orchestrating wallet top-up flows with VNPAY. The service keeps
+ * business logic separated from servlets and DAO layers so it can be unit
+ * tested in isolation.
+ */
+public class WalletTopUpService {
+
+    private static final Logger LOGGER = Logger.getLogger(WalletTopUpService.class.getName());
+    private static final DateTimeFormatter TXN_REF_DATE = DateTimeFormatter.ofPattern("yyMMdd");
+    private static final String ORDER_TYPE = "other";
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100L);
+
+    private final VnpayConfig config;
+    private final VnpayGateway gateway;
+    private final DepositRequestRepository depositRequestRepository;
+    private final VnpayTransactionRepository vnpayTransactionRepository;
+    private final WalletRepository walletRepository;
+    private final WalletTransactionRepository walletTransactionRepository;
+    private final ConnectionProvider connectionProvider;
+    private final Random random = new Random();
+    private final Gson gson = new Gson();
+
+    public WalletTopUpService(VnpayConfig config,
+            DepositRequestRepository depositRequestRepository,
+            VnpayTransactionRepository vnpayTransactionRepository,
+            WalletRepository walletRepository,
+            WalletTransactionRepository walletTransactionRepository,
+            ConnectionProvider connectionProvider) {
+        this.config = config;
+        this.gateway = new VnpayGateway(config);
+        this.depositRequestRepository = depositRequestRepository;
+        this.vnpayTransactionRepository = vnpayTransactionRepository;
+        this.walletRepository = walletRepository;
+        this.walletTransactionRepository = walletTransactionRepository;
+        this.connectionProvider = connectionProvider;
+    }
+
+    /**
+     * Generates a signed VNPAY payment URL and persists the associated deposit
+     * request for tracking.
+     */
+    public CreatePaymentResult createPaymentUrl(int userId, long amountVnd, String note,
+            Locale locale, String clientIp) {
+        if (amountVnd <= 0) {
+            throw new IllegalArgumentException("Số tiền nạp phải lớn hơn 0");
+        }
+        String resolvedIp = (clientIp == null || clientIp.isBlank()) ? "0.0.0.0" : clientIp;
+        Locale resolvedLocale = (locale == null) ? config.defaultLocale() : locale;
+
+        LocalDateTime createdAt = LocalDateTime.now(config.zoneId());
+        LocalDateTime expiresAt = createdAt.plus(config.paymentTimeout());
+        String txnRef = generateTxnRef(createdAt);
+        Map<String, String> params = gateway.createPaymentParams(txnRef, amountVnd,
+                buildOrderInfo(txnRef, note), ORDER_TYPE, resolvedIp, resolvedLocale,
+                createdAt, expiresAt);
+        String paymentUrl = gateway.buildPaymentUrl(txnRef, amountVnd,
+                buildOrderInfo(txnRef, note), ORDER_TYPE, resolvedIp, resolvedLocale,
+                createdAt, expiresAt);
+        String linkData = buildCreationLinkData(params, paymentUrl, resolvedIp, note);
+
+        Instant expireInstant = expiresAt.atZone(config.zoneId()).toInstant();
+        BigDecimal amount = BigDecimal.valueOf(amountVnd);
+        int depositId = insertDepositRequest(userId, amount, txnRef, expireInstant, linkData);
+
+        return new CreatePaymentResult(paymentUrl, txnRef, depositId);
+    }
+
+    /**
+     * Handles the VNPAY server-to-server callback.
+     */
+    public IpnResult handleIpn(Map<String, String> params, String rawQuery, String remoteIp) {
+        if (!gateway.isChecksumValid(params)) {
+            LOGGER.log(Level.WARNING, "IPN checksum không hợp lệ từ IP {0}", remoteIp);
+            return new IpnResult("97", "Invalid Checksum");
+        }
+
+        String txnRef = params.get("vnp_TxnRef");
+        if (txnRef == null || txnRef.isBlank()) {
+            return new IpnResult("01", "Order not Found");
+        }
+
+        try (Connection connection = connectionProvider.getConnection()) {
+            connection.setAutoCommit(false);
+            Optional<DepositRequests> depositOpt = depositRequestRepository.findByTxnRef(connection, txnRef, true);
+            if (depositOpt.isEmpty()) {
+                connection.rollback();
+                return new IpnResult("01", "Order not Found");
+            }
+            DepositRequests deposit = depositOpt.get();
+            BigDecimal expectedAmount = deposit.getAmount();
+            BigDecimal paidAmount = parseAmount(params.get("vnp_Amount"));
+            if (paidAmount == null || expectedAmount.compareTo(paidAmount) != 0) {
+                connection.rollback();
+                return new IpnResult("04", "Invalid Amount");
+            }
+
+            if (!"Pending".equalsIgnoreCase(deposit.getStatus())) {
+                connection.rollback();
+                return new IpnResult("02", "Order already confirmed");
+            }
+
+            Optional<VnpayTransaction> txOpt = vnpayTransactionRepository
+                    .findByDepositRequestId(connection, deposit.getId(), true);
+            String linkData = updateLinkData(txOpt.map(VnpayTransaction::getLinkData).orElse(null),
+                    params, rawQuery, remoteIp);
+
+            String responseCode = params.getOrDefault("vnp_ResponseCode", "");
+            String transactionStatus = params.getOrDefault("vnp_TransactionStatus", "");
+            String mappedStatus = mapVnpayStatus(responseCode, transactionStatus);
+
+            if ("success".equals(mappedStatus)) {
+                processSuccessfulIpn(connection, deposit, expectedAmount, txnRef, linkData);
+            } else {
+                String depositStatus = mapDepositStatus(mappedStatus);
+                depositRequestRepository.updateStatus(connection, deposit.getId(), depositStatus);
+                vnpayTransactionRepository.updateStatusAndPayload(connection, deposit.getId(), mappedStatus, linkData);
+            }
+
+            connection.commit();
+            return new IpnResult("00", "Confirm Success");
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không xử lý được IPN từ VNPAY", ex);
+            return new IpnResult("99", "Unknown error");
+        }
+    }
+
+    /**
+     * Verifies the checksum for UI return flows.
+     */
+    public boolean verifyChecksum(Map<String, String> params) {
+        return gateway.isChecksumValid(params);
+    }
+
+    private int insertDepositRequest(int userId, BigDecimal amount, String txnRef,
+            Instant expiresAt, String linkData) {
+        Connection connection = null;
+        try {
+            connection = connectionProvider.getConnection();
+            connection.setAutoCommit(false);
+            DepositRequests deposit = depositRequestRepository.insert(connection, userId,
+                    amount, "VNPAY-" + txnRef, txnRef, expiresAt);
+            vnpayTransactionRepository.insert(connection, deposit.getId(), linkData);
+            connection.commit();
+            return deposit.getId();
+        } catch (SQLException ex) {
+            if (connection != null) {
+                try {
+                    connection.rollback();
+                } catch (SQLException rollEx) {
+                    LOGGER.log(Level.WARNING, "Rollback create deposit failed", rollEx);
+                }
+            }
+            LOGGER.log(Level.SEVERE, "Không thể tạo yêu cầu nạp tiền", ex);
+            throw new IllegalStateException("Không thể tạo yêu cầu nạp tiền", ex);
+        } finally {
+            if (connection != null) {
+                try {
+                    connection.close();
+                } catch (SQLException closeEx) {
+                    LOGGER.log(Level.WARNING, "Không thể đóng kết nối sau khi tạo deposit", closeEx);
+                }
+            }
+        }
+    }
+
+    private void processSuccessfulIpn(Connection connection, DepositRequests deposit,
+            BigDecimal amount, String txnRef, String linkData) throws SQLException {
+        Wallets wallet = walletRepository.lockWalletForUser(connection, deposit.getUserId());
+        if (wallet == null) {
+            throw new SQLException("Wallet not found for user " + deposit.getUserId());
+        }
+        BigDecimal currentBalance = wallet.getBalance() == null ? BigDecimal.ZERO : wallet.getBalance();
+        BigDecimal newBalance = currentBalance.add(amount);
+
+        if (!walletRepository.updateBalance(connection, wallet.getId(), newBalance)) {
+            throw new SQLException("Không cập nhật được số dư ví");
+        }
+
+        walletTransactionRepository.insertTransaction(connection, wallet.getId(), deposit.getId(),
+                TransactionType.DEPOSIT, amount, currentBalance, newBalance,
+                "Nạp ví qua VNPAY - " + txnRef);
+
+        depositRequestRepository.updateStatus(connection, deposit.getId(), "Completed");
+        vnpayTransactionRepository.updateStatusAndPayload(connection, deposit.getId(), "success", linkData);
+    }
+
+    private String buildOrderInfo(String txnRef, String note) {
+        if (note != null && !note.isBlank()) {
+            return "Nap vi VNPAY " + txnRef + " - " + note;
+        }
+        return "Nap vi VNPAY " + txnRef;
+    }
+
+    private String buildCreationLinkData(Map<String, String> params, String paymentUrl,
+            String clientIp, String note) {
+        JsonObject event = new JsonObject();
+        event.addProperty("phase", "create");
+        event.addProperty("client_ip", clientIp);
+        event.addProperty("payment_url", paymentUrl);
+        event.addProperty("created_at", Instant.now().toString());
+        if (note != null && !note.isBlank()) {
+            event.addProperty("note", note);
+        }
+        event.add("params", gson.toJsonTree(params));
+        if (paymentUrl != null && paymentUrl.contains("?")) {
+            event.addProperty("query_string", paymentUrl.substring(paymentUrl.indexOf('?') + 1));
+        }
+        return appendHistory(null, event);
+    }
+
+    private String updateLinkData(String existing, Map<String, String> params,
+            String rawQuery, String remoteIp) {
+        JsonObject event = new JsonObject();
+        event.addProperty("phase", "ipn");
+        event.addProperty("received_at", Instant.now().toString());
+        event.addProperty("remote_ip", remoteIp);
+        if (rawQuery != null) {
+            event.addProperty("query_string", rawQuery);
+        }
+        event.add("params", gson.toJsonTree(params));
+        return appendHistory(existing, event);
+    }
+
+    private String appendHistory(String existing, JsonObject event) {
+        JsonObject root;
+        if (existing == null || existing.isBlank()) {
+            root = new JsonObject();
+        } else {
+            root = gson.fromJson(existing, JsonObject.class);
+        }
+        JsonArray history;
+        if (root.has("history") && root.get("history").isJsonArray()) {
+            history = root.getAsJsonArray("history");
+        } else {
+            history = new JsonArray();
+            root.add("history", history);
+        }
+        history.add(event);
+        root.addProperty("last_updated_at", Instant.now().toString());
+        return gson.toJson(root);
+    }
+
+    private String mapVnpayStatus(String responseCode, String transactionStatus) {
+        if ("00".equals(responseCode) && "00".equals(transactionStatus)) {
+            return "success";
+        }
+        if ("07".equals(responseCode) || "09".equals(responseCode)) {
+            return "suspected";
+        }
+        return "failed";
+    }
+
+    private String mapDepositStatus(String vnpayStatus) {
+        return switch (vnpayStatus) {
+            case "success" -> "Completed";
+            case "suspected" -> "RequiresManualCheck";
+            default -> "Failed";
+        };
+    }
+
+    private BigDecimal parseAmount(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+        try {
+            BigDecimal amount = new BigDecimal(raw);
+            return amount.divide(HUNDRED);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private String generateTxnRef(LocalDateTime createdAt) {
+        String datePart = createdAt.format(TXN_REF_DATE);
+        int randomNumber = 100000 + random.nextInt(900000);
+        return datePart + randomNumber;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/wallet/WalletTopUpServiceFactory.java
+++ b/MMO_Trader_Market/src/java/service/wallet/WalletTopUpServiceFactory.java
@@ -1,0 +1,31 @@
+package service.wallet;
+
+import conf.VnpayConfig;
+import dao.connect.DBConnect;
+import dao.user.WalletTransactionDAO;
+import dao.user.WalletsDAO;
+import dao.wallet.JdbcDepositRequestRepository;
+import dao.wallet.JdbcVnpayTransactionRepository;
+import dao.wallet.JdbcWalletRepository;
+import dao.wallet.JdbcWalletTransactionRepository;
+
+/**
+ * Centralised factory used by servlets to build the {@link WalletTopUpService}
+ * with concrete JDBC-based dependencies.
+ */
+public final class WalletTopUpServiceFactory {
+
+    private WalletTopUpServiceFactory() {
+    }
+
+    public static WalletTopUpService createDefault() {
+        VnpayConfig config = VnpayConfig.fromAppConfig();
+        return new WalletTopUpService(
+                config,
+                new JdbcDepositRequestRepository(),
+                new JdbcVnpayTransactionRepository(),
+                new JdbcWalletRepository(new WalletsDAO()),
+                new JdbcWalletTransactionRepository(new WalletTransactionDAO()),
+                DBConnect::getConnection);
+    }
+}

--- a/MMO_Trader_Market/src/java/service/wallet/dto/CreatePaymentResult.java
+++ b/MMO_Trader_Market/src/java/service/wallet/dto/CreatePaymentResult.java
@@ -1,0 +1,29 @@
+package service.wallet.dto;
+
+/**
+ * Immutable response returned when a payment URL is successfully generated.
+ */
+public class CreatePaymentResult {
+
+    private final String paymentUrl;
+    private final String txnRef;
+    private final int depositRequestId;
+
+    public CreatePaymentResult(String paymentUrl, String txnRef, int depositRequestId) {
+        this.paymentUrl = paymentUrl;
+        this.txnRef = txnRef;
+        this.depositRequestId = depositRequestId;
+    }
+
+    public String getPaymentUrl() {
+        return paymentUrl;
+    }
+
+    public String getTxnRef() {
+        return txnRef;
+    }
+
+    public int getDepositRequestId() {
+        return depositRequestId;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/wallet/dto/IpnResult.java
+++ b/MMO_Trader_Market/src/java/service/wallet/dto/IpnResult.java
@@ -1,0 +1,23 @@
+package service.wallet.dto;
+
+/**
+ * Represents the JSON payload required by VNPAY when answering an IPN request.
+ */
+public class IpnResult {
+
+    private final String rspCode;
+    private final String message;
+
+    public IpnResult(String rspCode, String message) {
+        this.rspCode = rspCode;
+        this.message = message;
+    }
+
+    public String getRspCode() {
+        return rspCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/MMO_Trader_Market/src/java/utils/crypto/HmacUtils.java
+++ b/MMO_Trader_Market/src/java/utils/crypto/HmacUtils.java
@@ -1,0 +1,50 @@
+package utils.crypto;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Small helper around {@link Mac} to create HMAC signatures using common
+ * algorithms. This utility intentionally avoids caching {@link Mac} instances
+ * because they are not thread-safe.
+ */
+public final class HmacUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(HmacUtils.class.getName());
+
+    private HmacUtils() {
+    }
+
+    /**
+     * Calculates an HMAC SHA-512 digest for the given data.
+     *
+     * @param secret raw secret string
+     * @param data   the input to sign
+     * @return hexadecimal upper case representation of the digest
+     */
+    public static String hmacSha512(String secret, String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA512");
+            SecretKeySpec secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA512");
+            mac.init(secretKey);
+            byte[] result = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return toHex(result);
+        } catch (NoSuchAlgorithmException | InvalidKeyException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể ký HMAC-SHA512", ex);
+            throw new IllegalStateException("Failed to sign payload using HMAC-SHA512", ex);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02X", b));
+        }
+        return sb.toString();
+    }
+}

--- a/MMO_Trader_Market/test/java/service/wallet/HmacUtilsTest.java
+++ b/MMO_Trader_Market/test/java/service/wallet/HmacUtilsTest.java
@@ -1,0 +1,22 @@
+package service.wallet;
+
+import utils.crypto.HmacUtils;
+
+/**
+ * Basic verification for the HMAC SHA-512 implementation against a known
+ * sample from VNPAY documentation.
+ */
+public class HmacUtilsTest {
+
+    public static void main(String[] args) {
+        String secret = "SECRETKEY";
+        String data = "vnp_Amount=10000000&vnp_Command=pay&vnp_TmnCode=ABC123&vnp_TxnRef=123456";
+        String expected = "3CE5254D5BA52975CB8F21C1F6052E04C4AA86708480D4AF1CA841E7595C5F79B7DBC2B82978EACD4756818FF1F49CA33B2D1973B9B9C743B975DB7564734C1C";
+
+        String actual = HmacUtils.hmacSha512(secret, data);
+        if (!expected.equals(actual)) {
+            throw new AssertionError("HMAC mismatch. Expected " + expected + " but got " + actual);
+        }
+        System.out.println("HmacUtilsTest passed");
+    }
+}

--- a/MMO_Trader_Market/test/java/service/wallet/WalletTopUpServiceIpnTest.java
+++ b/MMO_Trader_Market/test/java/service/wallet/WalletTopUpServiceIpnTest.java
@@ -1,0 +1,290 @@
+package service.wallet;
+
+import conf.VnpayConfig;
+import dao.wallet.DepositRequestRepository;
+import dao.wallet.VnpayTransactionRepository;
+import dao.wallet.WalletRepository;
+import dao.wallet.WalletTransactionRepository;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import model.DepositRequests;
+import model.TransactionType;
+import model.VnpayTransaction;
+import model.Wallets;
+import service.wallet.dto.CreatePaymentResult;
+import service.wallet.dto.IpnResult;
+import utils.crypto.HmacUtils;
+
+/**
+ * Unit tests covering IPN flows using in-memory repository implementations.
+ */
+public class WalletTopUpServiceIpnTest {
+
+    public static void main(String[] args) {
+        testSuccessfulIpn();
+        testInvalidAmount();
+        testChecksumFailure();
+        testIdempotentIpn();
+        System.out.println("WalletTopUpServiceIpnTest passed");
+    }
+
+    private static void testSuccessfulIpn() {
+        TestContext context = new TestContext();
+        CreatePaymentResult result = context.service.createPaymentUrl(1, 100_000, "test", Locale.forLanguageTag("vi-VN"), "127.0.0.1");
+        Map<String, String> params = baseParams(context, result.getTxnRef(), "10000000", "00", "00");
+        signParams(context, params);
+
+        IpnResult ipnResult = context.service.handleIpn(params, toQueryString(params), "127.0.0.1");
+        assertEquals("00", ipnResult.getRspCode(), "Expected IPN success code");
+        DepositRequests deposit = context.depositRepository.getByTxnRef(result.getTxnRef());
+        assertEquals("Completed", deposit.getStatus(), "Deposit status should update to Completed");
+        Wallets wallet = context.walletRepository.getWallet(1);
+        assertEquals(new BigDecimal("100000"), wallet.getBalance(), "Wallet should be credited");
+        assertEquals(1, context.walletTransactionRepository.transactionCount(), "Wallet transaction must be recorded");
+    }
+
+    private static void testInvalidAmount() {
+        TestContext context = new TestContext();
+        CreatePaymentResult result = context.service.createPaymentUrl(1, 50_000, null, Locale.US, "127.0.0.1");
+        Map<String, String> params = baseParams(context, result.getTxnRef(), "6000000", "00", "00");
+        signParams(context, params);
+
+        IpnResult ipnResult = context.service.handleIpn(params, toQueryString(params), "127.0.0.1");
+        assertEquals("04", ipnResult.getRspCode(), "Invalid amount must be detected");
+        DepositRequests deposit = context.depositRepository.getByTxnRef(result.getTxnRef());
+        assertEquals("Pending", deposit.getStatus(), "Deposit should remain pending on invalid amount");
+    }
+
+    private static void testChecksumFailure() {
+        TestContext context = new TestContext();
+        CreatePaymentResult result = context.service.createPaymentUrl(1, 10_000, null, Locale.US, "127.0.0.1");
+        Map<String, String> params = baseParams(context, result.getTxnRef(), "1000000", "00", "00");
+        params.put("vnp_SecureHash", "INVALID");
+        IpnResult ipnResult = context.service.handleIpn(params, toQueryString(params), "127.0.0.1");
+        assertEquals("97", ipnResult.getRspCode(), "Checksum failure must return 97");
+    }
+
+    private static void testIdempotentIpn() {
+        TestContext context = new TestContext();
+        CreatePaymentResult result = context.service.createPaymentUrl(1, 80_000, null, Locale.US, "127.0.0.1");
+        Map<String, String> params = baseParams(context, result.getTxnRef(), "8000000", "00", "00");
+        signParams(context, params);
+        context.service.handleIpn(params, toQueryString(params), "127.0.0.1");
+        IpnResult second = context.service.handleIpn(params, toQueryString(params), "127.0.0.1");
+        assertEquals("02", second.getRspCode(), "Second IPN should be idempotent");
+        Wallets wallet = context.walletRepository.getWallet(1);
+        assertEquals(new BigDecimal("80000"), wallet.getBalance(), "Wallet must not double credit");
+        assertEquals(1, context.walletTransactionRepository.transactionCount(), "Only one wallet transaction expected");
+    }
+
+    private static Map<String, String> baseParams(TestContext context, String txnRef, String amount,
+            String responseCode, String transactionStatus) {
+        Map<String, String> params = new HashMap<>();
+        params.put("vnp_TmnCode", context.config.tmnCode());
+        params.put("vnp_TxnRef", txnRef);
+        params.put("vnp_Amount", amount);
+        params.put("vnp_ResponseCode", responseCode);
+        params.put("vnp_TransactionStatus", transactionStatus);
+        params.put("vnp_OrderInfo", "Test");
+        params.put("vnp_PayDate", "20240101120000");
+        params.put("vnp_BankCode", "NCB");
+        params.put("vnp_TransactionNo", "12345678");
+        return params;
+    }
+
+    private static void signParams(TestContext context, Map<String, String> params) {
+        Map<String, String> sorted = new java.util.TreeMap<>(params);
+        StringBuilder data = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : sorted.entrySet()) {
+            if (!first) {
+                data.append('&');
+            }
+            first = false;
+            data.append(entry.getKey()).append('=').append(entry.getValue());
+        }
+        String hash = HmacUtils.hmacSha512(context.config.hashSecret(), data.toString());
+        params.put("vnp_SecureHash", hash);
+    }
+
+    private static String toQueryString(Map<String, String> params) {
+        StringBuilder builder = new StringBuilder();
+        boolean first = true;
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (!first) {
+                builder.append('&');
+            }
+            first = false;
+            builder.append(entry.getKey()).append('=').append(entry.getValue());
+        }
+        return builder.toString();
+    }
+
+    private static void assertEquals(Object expected, Object actual, String message) {
+        if (expected == null ? actual != null : !expected.equals(actual)) {
+            throw new AssertionError(message + ": expected=" + expected + ", actual=" + actual);
+        }
+    }
+
+    private static Connection createFakeConnection() {
+        return (Connection) java.lang.reflect.Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "setAutoCommit", "commit", "rollback", "close" -> null;
+                    case "isClosed" -> Boolean.FALSE;
+                    case "unwrap" -> null;
+                    case "isWrapperFor" -> Boolean.FALSE;
+                    default -> throw new UnsupportedOperationException("Method not implemented: " + method.getName());
+                });
+    }
+
+    private static final class TestContext {
+
+        final FakeDepositRequestRepository depositRepository = new FakeDepositRequestRepository();
+        final FakeVnpayTransactionRepository vnpayRepository = new FakeVnpayTransactionRepository();
+        final FakeWalletRepository walletRepository = new FakeWalletRepository();
+        final FakeWalletTransactionRepository walletTransactionRepository = new FakeWalletTransactionRepository();
+        final VnpayConfig config = VnpayConfig.of("TEST", "SECRETKEY",
+                "https://pay", "https://query", "https://return", "https://ipn");
+        final WalletTopUpService service = new WalletTopUpService(config,
+                depositRepository, vnpayRepository, walletRepository, walletTransactionRepository,
+                WalletTopUpServiceIpnTest::createFakeConnection);
+
+        TestContext() {
+            walletRepository.ensureWallet(1, BigDecimal.ZERO);
+        }
+    }
+
+    private static final class FakeDepositRequestRepository implements DepositRequestRepository {
+
+        private final Map<String, DepositRequests> byTxnRef = new HashMap<>();
+        private final Map<Integer, DepositRequests> byId = new HashMap<>();
+        private final AtomicInteger idSeq = new AtomicInteger(1);
+
+        @Override
+        public DepositRequests insert(Connection connection, int userId, BigDecimal amount,
+                String qrContent, String idempotencyKey, Instant expiresAt) {
+            DepositRequests deposit = new DepositRequests();
+            deposit.setId(idSeq.getAndIncrement());
+            deposit.setUserId(userId);
+            deposit.setAmount(amount);
+            deposit.setQrContent(qrContent);
+            deposit.setIdempotencyKey(idempotencyKey);
+            deposit.setStatus("Pending");
+            deposit.setExpiresAt(java.util.Date.from(expiresAt));
+            deposit.setCreatedAt(java.util.Date.from(Instant.now()));
+            byTxnRef.put(idempotencyKey, deposit);
+            byId.put(deposit.getId(), deposit);
+            return deposit;
+        }
+
+        @Override
+        public Optional<DepositRequests> findByTxnRef(Connection connection, String txnRef,
+                boolean forUpdate) {
+            return Optional.ofNullable(byTxnRef.get(txnRef));
+        }
+
+        @Override
+        public void updateStatus(Connection connection, int id, String status) {
+            DepositRequests deposit = byId.get(id);
+            if (deposit != null) {
+                deposit.setStatus(status);
+            }
+        }
+
+        DepositRequests getByTxnRef(String txnRef) {
+            return byTxnRef.get(txnRef);
+        }
+    }
+
+    private static final class FakeVnpayTransactionRepository implements VnpayTransactionRepository {
+
+        private final Map<Integer, VnpayTransaction> byDepositId = new HashMap<>();
+        private final AtomicInteger seq = new AtomicInteger(1);
+
+        @Override
+        public VnpayTransaction insert(Connection connection, int depositRequestId, String linkData) {
+            VnpayTransaction tx = new VnpayTransaction();
+            tx.setId(seq.getAndIncrement());
+            tx.setDepositRequestId(depositRequestId);
+            tx.setLinkData(linkData);
+            tx.setVnpayStatus("pending");
+            tx.setCreatedAt(java.util.Date.from(Instant.now()));
+            byDepositId.put(depositRequestId, tx);
+            return tx;
+        }
+
+        @Override
+        public void updateStatusAndPayload(Connection connection, int depositRequestId,
+                String status, String linkData) {
+            VnpayTransaction tx = byDepositId.get(depositRequestId);
+            if (tx != null) {
+                tx.setVnpayStatus(status);
+                tx.setLinkData(linkData);
+            }
+        }
+
+        @Override
+        public Optional<VnpayTransaction> findByDepositRequestId(Connection connection,
+                int depositRequestId, boolean forUpdate) {
+            return Optional.ofNullable(byDepositId.get(depositRequestId));
+        }
+    }
+
+    private static final class FakeWalletRepository implements WalletRepository {
+
+        private final Map<Integer, Wallets> wallets = new HashMap<>();
+        private final AtomicInteger seq = new AtomicInteger(1);
+
+        void ensureWallet(int userId, BigDecimal initialBalance) {
+            Wallets wallet = new Wallets();
+            wallet.setId(seq.getAndIncrement());
+            wallet.setUserId(userId);
+            wallet.setBalance(initialBalance);
+            wallets.put(userId, wallet);
+        }
+
+        Wallets getWallet(int userId) {
+            return wallets.get(userId);
+        }
+
+        @Override
+        public Wallets lockWalletForUser(Connection connection, int userId) {
+            return wallets.get(userId);
+        }
+
+        @Override
+        public boolean updateBalance(Connection connection, int walletId, BigDecimal newBalance) {
+            for (Wallets wallet : wallets.values()) {
+                if (wallet.getId() == walletId) {
+                    wallet.setBalance(newBalance);
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private static final class FakeWalletTransactionRepository implements WalletTransactionRepository {
+
+        private final AtomicInteger txCount = new AtomicInteger();
+
+        @Override
+        public int insertTransaction(Connection connection, int walletId, Integer relatedEntityId,
+                TransactionType type, BigDecimal amount, BigDecimal balanceBefore,
+                BigDecimal balanceAfter, String note) {
+            return txCount.incrementAndGet();
+        }
+
+        int transactionCount() {
+            return txCount.get();
+        }
+    }
+}

--- a/MMO_Trader_Market/web/WEB-INF/views/wallet/deposit.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/wallet/deposit.jsp
@@ -1,0 +1,94 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%
+    request.setAttribute("pageTitle", "Nạp tiền ví qua VNPAY");
+    request.setAttribute("bodyClass", "layout");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h1 class="panel__title">Nạp tiền ví qua VNPAY</h1>
+        </div>
+        <div class="panel__body">
+            <p>Vui lòng nhập số tiền muốn nạp (đơn vị VNĐ). Hệ thống sẽ chuyển bạn tới cổng thanh toán VNPAY và cập nhật số dư khi nhận được IPN thành công.</p>
+
+            <form id="topup-form" class="form">
+                <div class="form__group">
+                    <label for="amount" class="form__label">Số tiền</label>
+                    <input type="number" id="amount" name="amount" class="form-control" min="1000" step="1000" required aria-describedby="amount-help">
+                    <small id="amount-help" class="form__hint">Tối thiểu 1.000 VNĐ. VNPAY sẽ quy đổi sang đơn vị đồng x100.</small>
+                </div>
+
+                <div class="form__group">
+                    <label for="note" class="form__label">Ghi chú (tuỳ chọn)</label>
+                    <textarea id="note" name="note" class="form-control" rows="3" maxlength="120" placeholder="Thông tin giúp bạn ghi nhớ giao dịch"></textarea>
+                </div>
+
+                <div class="form__group">
+                    <button type="submit" class="btn btn--primary">Tạo yêu cầu nạp</button>
+                    <a href="${pageContext.request.contextPath}/wallet" class="btn btn--ghost">Quay lại ví</a>
+                </div>
+            </form>
+
+            <div id="topup-alert" class="alert" role="alert" style="display:none;"></div>
+        </div>
+    </section>
+</main>
+
+<script>
+    (function () {
+        const form = document.getElementById('topup-form');
+        const alertBox = document.getElementById('topup-alert');
+
+        function showAlert(message, type) {
+            alertBox.textContent = message;
+            alertBox.className = 'alert alert--' + (type === 'error' ? 'danger' : 'success');
+            alertBox.style.display = 'block';
+        }
+
+        form.addEventListener('submit', async function (event) {
+            event.preventDefault();
+            alertBox.style.display = 'none';
+
+            const amountInput = document.getElementById('amount');
+            const noteInput = document.getElementById('note');
+
+            const amountValue = parseInt(amountInput.value, 10);
+            if (Number.isNaN(amountValue) || amountValue <= 0) {
+                showAlert('Số tiền không hợp lệ.', 'error');
+                return;
+            }
+
+            const payload = { amount: amountValue };
+            const note = noteInput.value.trim();
+            if (note.length > 0) {
+                payload.note = note;
+            }
+
+            try {
+                const response = await fetch('${pageContext.request.contextPath}/wallet/deposit/create', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                const data = await response.json();
+                if (!response.ok) {
+                    throw new Error(data.error || 'Không thể tạo yêu cầu nạp.');
+                }
+                if (data.paymentUrl) {
+                    window.location.href = data.paymentUrl;
+                } else {
+                    showAlert('Không nhận được đường dẫn thanh toán.', 'error');
+                }
+            } catch (error) {
+                showAlert(error.message, 'error');
+            }
+        });
+    })();
+</script>
+
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/wallet/vnpay-return.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/wallet/vnpay-return.jsp
@@ -1,0 +1,65 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%
+    request.setAttribute("pageTitle", "Kết quả thanh toán VNPAY");
+    request.setAttribute("bodyClass", "layout");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+
+<main class="layout__content">
+    <section class="panel">
+        <div class="panel__header">
+            <h1 class="panel__title">Kết quả thanh toán</h1>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not checksumValid}">
+                    <div class="alert alert--danger">Chữ ký xác thực không hợp lệ. Vui lòng không làm mới trang và liên hệ hỗ trợ nếu bạn đã thanh toán.</div>
+                </c:when>
+                <c:when test="${paymentSuccess}">
+                    <div class="alert alert--success">Thanh toán thành công! Số dư ví sẽ được cộng sau khi hệ thống xác nhận IPN.</div>
+                </c:when>
+                <c:otherwise>
+                    <div class="alert alert--warning">Giao dịch chưa thành công. Bạn có thể thử lại hoặc kiểm tra lịch sử giao dịch.</div>
+                </c:otherwise>
+            </c:choose>
+
+            <table class="table table--interactive" role="presentation">
+                <tbody>
+                    <tr>
+                        <th scope="row">Mã giao dịch</th>
+                        <td><c:out value="${txnRef}" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Số tiền</th>
+                        <td>
+                            <c:choose>
+                                <c:when test="${not empty amount}">
+                                    <fmt:formatNumber value="${amount}" type="number" minFractionDigits="0" /> VNĐ
+                                </c:when>
+                                <c:otherwise>-</c:otherwise>
+                            </c:choose>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Mã phản hồi</th>
+                        <td><c:out value="${responseCode}" /></td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Trạng thái giao dịch</th>
+                        <td><c:out value="${transactionStatus}" /></td>
+                    </tr>
+                </tbody>
+            </table>
+
+            <p class="text-muted">Lưu ý: Số dư ví chỉ được cộng khi máy chủ nhận IPN thành công từ VNPAY. Nếu trạng thái vẫn chưa cập nhật sau vài phút, vui lòng liên hệ bộ phận hỗ trợ.</p>
+
+            <a href="${pageContext.request.contextPath}/wallet" class="btn btn--primary">Quay lại ví</a>
+        </div>
+    </section>
+</main>
+
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/WEB-INF/views/wallet/wallet.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/wallet/wallet.jsp
@@ -80,6 +80,11 @@
             </tbody>
         </table>
 
+        <div class="form__group" style="margin-top:1.6rem;">
+            <a class="btn btn--primary" href="${pageContext.request.contextPath}/wallet/deposit">Nạp tiền qua VNPAY</a>
+            <span class="form__hint">Thanh toán an toàn, số dư sẽ cập nhật sau khi IPN được xác nhận.</span>
+        </div>
+
 
         <!--Lịch sử ví -->
 


### PR DESCRIPTION
## Summary
- inline the VNPAY transaction audit table definition into the primary DB_v1.sql dump
- remove the now redundant standalone create_vnpay_transaction.sql helper script
