### PR TITLE
Add seller shop detail view with quarterly insights

### DIFF
--- a/MMO_Trader_Market/src/java/controller/seller/SellerShopDetailController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerShopDetailController.java
@@ -1,0 +1,157 @@
+package controller.seller;
+
+import dao.order.OrderDAO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import model.ShopStatsView;
+import model.statistics.BestSellerProduct;
+import model.statistics.QuarterRevenue;
+import model.view.OrderRow;
+import service.ShopService;
+
+/**
+ * Trang chi tiết từng shop dành cho seller.
+ * <p>
+ * Hiển thị doanh thu theo quý, sản phẩm bán chạy và danh sách đơn hoàn thành.
+ * </p>
+ */
+@WebServlet(name = "SellerShopDetailController", urlPatterns = {"/seller/shops/detail"})
+public class SellerShopDetailController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final int DEFAULT_PAGE_SIZE = 8;
+
+    private final ShopService shopService = new ShopService();
+
+    private final OrderDAO orderDAO = new OrderDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+
+        HttpSession session = request.getSession(false);
+        Integer userId = session == null ? null : (Integer) session.getAttribute("userId");
+        if (userId == null) {
+            response.sendRedirect(request.getContextPath() + "/auth");
+            return;
+        }
+
+        int shopId = parseIntOrDefault(request.getParameter("id"), -1);
+        if (shopId <= 0) {
+            redirectWithError(session, response, request.getContextPath());
+            return;
+        }
+
+        ShopStatsView shop;
+        try {
+            Optional<ShopStatsView> detail = shopService.findDetailWithStats(shopId, userId);
+            if (detail.isEmpty()) {
+                redirectWithError(session, response, request.getContextPath());
+                return;
+            }
+            shop = detail.get();
+        } catch (SQLException ex) {
+            session.setAttribute("flashMessage", "Không thể tải thông tin shop. Vui lòng thử lại sau.");
+            session.setAttribute("flashType", "danger");
+            response.sendRedirect(request.getContextPath() + "/seller/shops");
+            return;
+        }
+
+        int range = parseRange(request.getParameter("range"));
+        List<QuarterRevenue> quarterlyRevenue = shopService.getQuarterlyRevenue(shop.getId(), range);
+        BigDecimal quarterTotal = quarterlyRevenue.stream()
+                .map(QuarterRevenue::getRevenue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        Optional<BestSellerProduct> bestSeller = shopService.findBestSellerProduct(shop.getId());
+
+        int completedOrders = orderDAO.countCompletedOrdersByShop(shop.getId());
+
+        int page = parseIntOrDefault(request.getParameter("page"), 1);
+        if (page < 1) {
+            page = 1;
+        }
+        int pageSize = parseIntOrDefault(request.getParameter("size"), DEFAULT_PAGE_SIZE);
+        if (pageSize <= 0) {
+            pageSize = DEFAULT_PAGE_SIZE;
+        }
+
+        int offset = (page - 1) * pageSize;
+        List<OrderRow> orders = orderDAO.findCompletedOrdersByShop(shop.getId(), pageSize, offset);
+        int totalPages = (int) Math.ceil(completedOrders / (double) pageSize);
+        if (totalPages == 0) {
+            totalPages = 1;
+        }
+        if (page > totalPages) {
+            page = totalPages;
+            offset = (page - 1) * pageSize;
+            orders = orderDAO.findCompletedOrdersByShop(shop.getId(), pageSize, offset);
+        }
+
+        request.setAttribute("shop", shop);
+        request.setAttribute("quarterRevenue", quarterlyRevenue);
+        request.setAttribute("quarterRevenueTotal", quarterTotal);
+        request.setAttribute("selectedRange", range);
+        request.setAttribute("bestSeller", bestSeller.orElse(null));
+        request.setAttribute("completedOrdersCount", completedOrders);
+        request.setAttribute("orders", orders);
+        request.setAttribute("page", page);
+        request.setAttribute("pageSize", pageSize);
+        request.setAttribute("totalPages", totalPages);
+        request.setAttribute("totalOrders", completedOrders);
+
+        request.setAttribute("pageTitle", "Chi tiết shop - " + shop.getName());
+        request.setAttribute("bodyClass", "layout");
+        request.setAttribute("headerModifier", "layout__header--split");
+
+        forward(request, response, "seller/shops/detail");
+    }
+
+    /**
+     * Ghi nhận thông báo lỗi vào session và chuyển hướng về danh sách shop.
+     */
+    private void redirectWithError(HttpSession session, HttpServletResponse response, String contextPath)
+            throws IOException {
+        session.setAttribute("flashMessage", "Shop không hợp lệ hoặc bạn không có quyền truy cập.");
+        session.setAttribute("flashType", "danger");
+        response.sendRedirect(contextPath + "/seller/shops");
+    }
+
+    /**
+     * Chuẩn hóa tham số khoảng thời gian doanh thu.
+     */
+    private int parseRange(String raw) {
+        int range = parseIntOrDefault(raw, 3);
+        return switch (range) {
+            case 6, 12 -> range;
+            default -> 3;
+        };
+    }
+
+    /**
+     * Parse số nguyên với giá trị mặc định khi rỗng hoặc không hợp lệ.
+     */
+    private int parseIntOrDefault(String raw, int defaultValue) {
+        if (raw == null || raw.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+}
+

--- a/MMO_Trader_Market/src/java/model/statistics/BestSellerProduct.java
+++ b/MMO_Trader_Market/src/java/model/statistics/BestSellerProduct.java
@@ -1,0 +1,58 @@
+package model.statistics;
+
+import java.math.BigDecimal;
+
+/**
+ * View-model mô tả sản phẩm bán chạy nhất của một shop.
+ */
+public class BestSellerProduct {
+
+    private final int productId;
+
+    private final String productName;
+
+    private final String productImageUrl;
+
+    private final int totalSold;
+
+    private final BigDecimal totalRevenue;
+
+    /**
+     * Tạo bản ghi thống kê sản phẩm bán chạy.
+     *
+     * @param productId      mã sản phẩm
+     * @param productName    tên sản phẩm
+     * @param productImageUrl ảnh đại diện (có thể null)
+     * @param totalSold      tổng số lượng đã bán
+     * @param totalRevenue   tổng doanh thu mang lại
+     */
+    public BestSellerProduct(int productId, String productName, String productImageUrl,
+            int totalSold, BigDecimal totalRevenue) {
+        this.productId = productId;
+        this.productName = productName;
+        this.productImageUrl = productImageUrl;
+        this.totalSold = totalSold;
+        this.totalRevenue = totalRevenue;
+    }
+
+    public int getProductId() {
+        return productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public String getProductImageUrl() {
+        return productImageUrl;
+    }
+
+    public int getTotalSold() {
+        return totalSold;
+    }
+
+    public BigDecimal getTotalRevenue() {
+        return totalRevenue;
+    }
+}
+

--- a/MMO_Trader_Market/src/java/model/statistics/QuarterRevenue.java
+++ b/MMO_Trader_Market/src/java/model/statistics/QuarterRevenue.java
@@ -1,0 +1,56 @@
+package model.statistics;
+
+import java.math.BigDecimal;
+
+/**
+ * Đại diện cho tổng doanh thu của một cửa hàng theo từng quý.
+ * <p>
+ * View-model này được xây dựng để phục vụ màn hình chi tiết shop của seller,
+ * nơi yêu cầu hiển thị doanh thu gom theo quý trong các mốc 3 - 6 - 12 tháng.
+ * </p>
+ */
+public class QuarterRevenue {
+
+    private final int year;
+
+    private final int quarter;
+
+    private BigDecimal revenue;
+
+    /**
+     * Khởi tạo đối tượng chứa thông tin doanh thu theo quý.
+     *
+     * @param year    năm của quý (ví dụ 2024)
+     * @param quarter số thứ tự quý (1-4)
+     * @param revenue tổng doanh thu của quý
+     */
+    public QuarterRevenue(int year, int quarter, BigDecimal revenue) {
+        this.year = year;
+        this.quarter = quarter;
+        this.revenue = revenue;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getQuarter() {
+        return quarter;
+    }
+
+    public BigDecimal getRevenue() {
+        return revenue;
+    }
+
+    public void setRevenue(BigDecimal revenue) {
+        this.revenue = revenue;
+    }
+
+    /**
+     * @return Nhãn hiển thị dạng {@code Qx yyyy}.
+     */
+    public String getLabel() {
+        return "Q" + quarter + ' ' + year;
+    }
+}
+

--- a/MMO_Trader_Market/src/java/service/ShopService.java
+++ b/MMO_Trader_Market/src/java/service/ShopService.java
@@ -1,11 +1,15 @@
 package service;
 
+import dao.order.OrderDAO;
 import dao.product.ProductDAO;
 import dao.shop.ShopDAO;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import model.ShopStatsView;
 import model.Shops;
+import model.statistics.BestSellerProduct;
+import model.statistics.QuarterRevenue;
 import java.util.regex.Pattern;
 
 /**
@@ -22,6 +26,7 @@ public class ShopService {
 
         private final ShopDAO shopDAO = new ShopDAO();
         private final ProductDAO productDAO = new ProductDAO();
+        private final OrderDAO orderDAO = new OrderDAO();
 
 	/**
 	 * Tạo shop mới cho seller.
@@ -130,8 +135,81 @@ public class ShopService {
 	 * @return Optional chứa Shops nếu tìm thấy và thuộc về owner, Optional.empty() nếu không
 	 * @throws SQLException nếu có lỗi khi truy vấn database
 	 */
-        public java.util.Optional<Shops> findByIdAndOwner(int id, int ownerId) throws SQLException {
+        public Optional<Shops> findByIdAndOwner(int id, int ownerId) throws SQLException {
                 return shopDAO.findByIdAndOwner(id, ownerId);
+        }
+
+        /**
+         * Lấy chi tiết shop kèm thống kê cơ bản theo ID và owner.
+         *
+         * @param shopId  ID shop
+         * @param ownerId ID chủ sở hữu
+         * @return {@link Optional} chứa {@link ShopStatsView} nếu tìm thấy
+         * @throws SQLException nếu truy vấn lỗi
+         */
+        public Optional<ShopStatsView> findDetailWithStats(int shopId, int ownerId) throws SQLException {
+                return shopDAO.findDetailByIdAndOwner(shopId, ownerId);
+        }
+
+        /**
+         * Lấy thống kê doanh thu theo quý cho shop trong các mốc 3/6/12 tháng.
+         *
+         * @param shopId      ID shop
+         * @param rangeMonths số tháng cần thống kê (3,6,12)
+         * @return danh sách doanh thu từng quý (luôn đủ số phần tử tương ứng)
+         */
+        public List<QuarterRevenue> getQuarterlyRevenue(int shopId, int rangeMonths) {
+                int sanitizedMonths = switch (rangeMonths) {
+                        case 6 -> 6;
+                        case 12 -> 12;
+                        default -> 3;
+                };
+                int quarters = sanitizedMonths / 3;
+
+                java.util.Calendar cal = java.util.Calendar.getInstance();
+                cal.set(java.util.Calendar.DAY_OF_MONTH, 1);
+                cal.set(java.util.Calendar.HOUR_OF_DAY, 0);
+                cal.set(java.util.Calendar.MINUTE, 0);
+                cal.set(java.util.Calendar.SECOND, 0);
+                cal.set(java.util.Calendar.MILLISECOND, 0);
+                int monthInQuarter = cal.get(java.util.Calendar.MONTH) % 3;
+                cal.add(java.util.Calendar.MONTH, -monthInQuarter);
+
+                java.util.Calendar start = (java.util.Calendar) cal.clone();
+                start.add(java.util.Calendar.MONTH, -3 * (quarters - 1));
+
+                java.sql.Timestamp startTimestamp = new java.sql.Timestamp(start.getTimeInMillis());
+                List<QuarterRevenue> raw = orderDAO.getQuarterlyRevenue(shopId, startTimestamp);
+                java.util.Map<String, QuarterRevenue> mapped = new java.util.LinkedHashMap<>();
+                for (QuarterRevenue item : raw) {
+                        String key = item.getYear() + "-" + item.getQuarter();
+                        mapped.put(key, item);
+                }
+
+                List<QuarterRevenue> result = new java.util.ArrayList<>();
+                java.util.Calendar cursor = (java.util.Calendar) start.clone();
+                for (int i = 0; i < quarters; i++) {
+                        int year = cursor.get(java.util.Calendar.YEAR);
+                        int quarter = (cursor.get(java.util.Calendar.MONTH) / 3) + 1;
+                        String key = year + "-" + quarter;
+                        QuarterRevenue existing = mapped.get(key);
+                        if (existing == null) {
+                                existing = new QuarterRevenue(year, quarter, java.math.BigDecimal.ZERO);
+                        }
+                        result.add(existing);
+                        cursor.add(java.util.Calendar.MONTH, 3);
+                }
+                return result;
+        }
+
+        /**
+         * Tìm sản phẩm bán chạy nhất của shop.
+         *
+         * @param shopId ID shop
+         * @return {@link Optional} chứa {@link BestSellerProduct} nếu có
+         */
+        public Optional<BestSellerProduct> findBestSellerProduct(int shopId) {
+                return orderDAO.findBestSellingProduct(shopId);
         }
 
         /**

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/shops/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/shops/detail.jsp
@@ -1,0 +1,298 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
+<fmt:setLocale value="vi_VN" scope="request" />
+<c:set var="cPath" value="${pageContext.request.contextPath}" />
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+
+<main class="layout__content seller-page shop-detail">
+    <section class="panel">
+        <div class="panel__header shop-detail__header">
+            <div class="shop-detail__title-group">
+                <a class="button button--ghost shop-detail__back" href="${cPath}/seller/shops">← Danh sách shop</a>
+                <h1 class="panel__title shop-detail__title">${shop.name}</h1>
+                <span class="shop-detail__status ${shop.status == 'Active' ? 'is-active' : 'is-suspended'}">
+                    <c:choose>
+                        <c:when test="${shop.status == 'Active'}">Đang hoạt động</c:when>
+                        <c:when test="${shop.status == 'Suspended'}">Tạm dừng</c:when>
+                        <c:otherwise>${shop.status}</c:otherwise>
+                    </c:choose>
+                </span>
+            </div>
+            <div class="shop-detail__meta">
+                <p class="shop-detail__description">
+                    <c:choose>
+                        <c:when test="${not empty shop.description}">${shop.description}</c:when>
+                        <c:otherwise><span class="shop-detail__description--empty">Chưa có mô tả cho shop này.</span></c:otherwise>
+                    </c:choose>
+                </p>
+                <div class="shop-detail__meta-grid">
+                    <div>
+                        <span class="shop-detail__meta-label">Tạo ngày</span>
+                        <span class="shop-detail__meta-value">
+                            <fmt:formatDate value="${shop.createdAt}" pattern="dd/MM/yyyy" />
+                        </span>
+                    </div>
+                    <div>
+                        <span class="shop-detail__meta-label">Cập nhật</span>
+                        <span class="shop-detail__meta-value">
+                            <fmt:formatDate value="${shop.updatedAt}" pattern="dd/MM/yyyy" />
+                        </span>
+                    </div>
+                    <div>
+                        <span class="shop-detail__meta-label">Tổng sản phẩm</span>
+                        <span class="shop-detail__meta-value">${shop.productCount}</span>
+                    </div>
+                    <div>
+                        <span class="shop-detail__meta-label">Tồn kho mô phỏng</span>
+                        <span class="shop-detail__meta-value">${shop.totalInventory}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="panel__body">
+            <div class="shop-detail__metrics">
+                <article class="stat-card shop-detail__metric-card">
+                    <div>
+                        <p class="stat-card__label">Đơn hàng hoàn thành</p>
+                        <p class="stat-card__value">${completedOrdersCount}</p>
+                    </div>
+                </article>
+                <article class="stat-card shop-detail__metric-card">
+                    <div>
+                        <p class="stat-card__label">Tổng lượng bán</p>
+                        <p class="stat-card__value">${shop.totalSold}</p>
+                    </div>
+                </article>
+                <article class="stat-card shop-detail__metric-card">
+                    <div>
+                        <p class="stat-card__label">Tồn kho hiện có</p>
+                        <p class="stat-card__value">${shop.totalInventory}</p>
+                    </div>
+                </article>
+                <article class="stat-card shop-detail__metric-card">
+                    <div>
+                        <p class="stat-card__label">Doanh thu theo quý</p>
+                        <p class="stat-card__value"><fmt:formatNumber value="${quarterRevenueTotal}" type="currency" /></p>
+                    </div>
+                </article>
+            </div>
+
+            <c:if test="${not empty bestSeller}">
+                <article class="shop-detail__best-seller">
+                    <div class="shop-detail__best-seller-thumb">
+                        <c:choose>
+                            <c:when test="${not empty bestSeller.productImageUrl}">
+                                <img src="${bestSeller.productImageUrl}" alt="${bestSeller.productName}" loading="lazy" />
+                            </c:when>
+                            <c:otherwise>
+                                <c:set var="initial" value="${not empty bestSeller.productName ? fn:substring(bestSeller.productName, 0, 1) : '?'}" />
+                                <div class="shop-detail__best-seller-placeholder">${initial}</div>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                    <div class="shop-detail__best-seller-info">
+                        <h2>Sản phẩm bán chạy</h2>
+                        <p class="shop-detail__best-seller-name">${bestSeller.productName}</p>
+                        <ul>
+                            <li><strong>${bestSeller.totalSold}</strong> lượt bán</li>
+                            <li>Doanh thu: <strong><fmt:formatNumber value="${bestSeller.totalRevenue}" type="currency" /></strong></li>
+                        </ul>
+                        <a class="button button--ghost" href="${cPath}/seller/products/edit?id=${bestSeller.productId}">Quản lý sản phẩm</a>
+                    </div>
+                </article>
+            </c:if>
+
+            <div class="shop-detail__actions">
+                <a class="button button--ghost" href="${cPath}/seller/shops/edit?id=${shop.id}">Chỉnh sửa shop</a>
+                <a class="button button--ghost" href="${cPath}/seller/products/create?shopId=${shop.id}">Thêm sản phẩm mới</a>
+                <form method="post" action="${cPath}/seller/credentials/generate">
+                    <button type="submit" class="button button--primary">Cập nhật kho từ tồn hiện tại</button>
+                </form>
+                <a class="button" href="${cPath}/seller/inventory">Quản lý tồn kho</a>
+            </div>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel__header shop-detail__section-header">
+            <div>
+                <h2 class="panel__title">Doanh thu theo quý</h2>
+                <p class="panel__subtitle">So sánh các quý gần đây để nắm bắt đà tăng trưởng.</p>
+            </div>
+            <div class="shop-detail__range">
+                <c:url var="range3Url" value="${cPath}/seller/shops/detail">
+                    <c:param name="id" value="${shop.id}" />
+                    <c:param name="range" value="3" />
+                </c:url>
+                <c:url var="range6Url" value="${cPath}/seller/shops/detail">
+                    <c:param name="id" value="${shop.id}" />
+                    <c:param name="range" value="6" />
+                </c:url>
+                <c:url var="range12Url" value="${cPath}/seller/shops/detail">
+                    <c:param name="id" value="${shop.id}" />
+                    <c:param name="range" value="12" />
+                </c:url>
+                <a class="shop-detail__range-button ${selectedRange == 3 ? 'is-active' : ''}" href="${range3Url}">3 tháng</a>
+                <a class="shop-detail__range-button ${selectedRange == 6 ? 'is-active' : ''}" href="${range6Url}">6 tháng</a>
+                <a class="shop-detail__range-button ${selectedRange == 12 ? 'is-active' : ''}" href="${range12Url}">12 tháng</a>
+            </div>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not empty quarterRevenue}">
+                    <div class="shop-detail__chart">
+                        <canvas id="quarterRevenueChart" height="180"></canvas>
+                    </div>
+                    <table class="shop-detail__revenue-table">
+                        <thead>
+                            <tr>
+                                <th>Quý</th>
+                                <th>Doanh thu</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <c:forEach var="item" items="${quarterRevenue}">
+                                <tr>
+                                    <td>${item.label}</td>
+                                    <td><fmt:formatNumber value="${item.revenue}" type="currency" /></td>
+                                </tr>
+                            </c:forEach>
+                        </tbody>
+                    </table>
+                </c:when>
+                <c:otherwise>
+                    <p class="shop-detail__empty">Chưa có dữ liệu doanh thu cho khoảng thời gian này.</p>
+                </c:otherwise>
+            </c:choose>
+        </div>
+    </section>
+
+    <section class="panel">
+        <div class="panel__header shop-detail__section-header">
+            <div>
+                <h2 class="panel__title">Đơn hàng đã hoàn thành</h2>
+                <p class="panel__subtitle">Tổng quan các đơn đã bàn giao cho người mua.</p>
+            </div>
+        </div>
+        <div class="panel__body">
+            <c:choose>
+                <c:when test="${not empty orders}">
+                    <div class="table-responsive">
+                        <table class="table table--interactive shop-detail__orders">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Sản phẩm</th>
+                                    <th>Doanh thu</th>
+                                    <th>Ngày tạo</th>
+                                    <th>Trạng thái</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <c:forEach var="order" items="${orders}">
+                                    <tr>
+                                        <td>#${order.id}</td>
+                                        <td>${order.productName}</td>
+                                        <td><fmt:formatNumber value="${order.totalAmount}" type="currency" /></td>
+                                        <td>
+                                            <c:if test="${not empty order.createdAt}">
+                                                <fmt:formatDate value="${order.createdAt}" pattern="dd/MM/yyyy HH:mm" />
+                                            </c:if>
+                                        </td>
+                                        <td><span class="shop-detail__badge">${order.status}</span></td>
+                                    </tr>
+                                </c:forEach>
+                            </tbody>
+                        </table>
+                    </div>
+                </c:when>
+                <c:otherwise>
+                    <p class="shop-detail__empty">Chưa có đơn hàng hoàn thành nào.</p>
+                </c:otherwise>
+            </c:choose>
+
+            <div class="shop-detail__pagination">
+                <div class="shop-detail__pagination-info">
+                    <span>Tổng ${totalOrders} đơn</span>
+                    <span>Trang ${page} / ${totalPages}</span>
+                </div>
+                <div class="shop-detail__pagination-actions">
+                    <c:url var="prevUrl" value="${cPath}/seller/shops/detail">
+                        <c:param name="id" value="${shop.id}" />
+                        <c:param name="range" value="${selectedRange}" />
+                        <c:param name="page" value="${page - 1}" />
+                        <c:param name="size" value="${pageSize}" />
+                    </c:url>
+                    <c:url var="nextUrl" value="${cPath}/seller/shops/detail">
+                        <c:param name="id" value="${shop.id}" />
+                        <c:param name="range" value="${selectedRange}" />
+                        <c:param name="page" value="${page + 1}" />
+                        <c:param name="size" value="${pageSize}" />
+                    </c:url>
+                    <button class="button button--ghost" type="button" ${page <= 1 ? 'disabled' : ''} onclick="location.href='${prevUrl}'">Trước</button>
+                    <button class="button button--ghost" type="button" ${page >= totalPages ? 'disabled' : ''} onclick="location.href='${nextUrl}'">Sau</button>
+                </div>
+            </div>
+        </div>
+    </section>
+</main>
+
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    (function () {
+        const ctx = document.getElementById('quarterRevenueChart');
+        if (!ctx) {
+            return;
+        }
+        const labels = [
+            <c:forEach var="item" items="${quarterRevenue}" varStatus="loop">
+                '${item.label}'<c:if test="${!loop.last}">,</c:if>
+            </c:forEach>
+        ];
+        const data = [
+            <c:forEach var="item" items="${quarterRevenue}" varStatus="loop">
+                ${item.revenue}<c:if test="${!loop.last}">,</c:if>
+            </c:forEach>
+        ];
+        const formatter = new Intl.NumberFormat('vi-VN', { style: 'currency', currency: 'VND' });
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels,
+                datasets: [{
+                    label: 'Doanh thu',
+                    data,
+                    backgroundColor: 'rgba(0, 102, 255, 0.2)',
+                    borderColor: 'rgba(0, 102, 255, 0.75)',
+                    borderWidth: 2,
+                    borderRadius: 6,
+                    maxBarThickness: 48
+                }]
+            },
+            options: {
+                responsive: true,
+                scales: {
+                    y: {
+                        ticks: {
+                            callback: (value) => formatter.format(value)
+                        },
+                        beginAtZero: true
+                    }
+                },
+                plugins: {
+                    tooltip: {
+                        callbacks: {
+                            label: (context) => formatter.format(context.parsed.y)
+                        }
+                    }
+                }
+            }
+        });
+    })();
+</script>

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/shops/list.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/shops/list.jsp
@@ -103,6 +103,7 @@
                                     </div>
                                 </div>
                                 <div class="shop-card__actions">
+                                    <a class="button button--ghost" href="${cPath}/seller/shops/detail?id=${shop.id}">Xem chi tiết</a>
                                     <a class="button button--ghost" href="${cPath}/seller/shops/edit?id=${shop.id}">Sửa</a>
                                     <a class="button button--ghost" href="${cPath}/seller/products/create?shopId=${shop.id}">Tạo sản phẩm</a>
                                     <c:choose>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -884,6 +884,308 @@ code {
     }
 }
 
+/* Seller shop detail */
+.shop-detail {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.shop-detail__header {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.shop-detail__title-group {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.shop-detail__title {
+    margin: 0;
+}
+
+.shop-detail__status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.shop-detail__status.is-active {
+    background: rgba(34, 197, 94, 0.12);
+    color: #047857;
+}
+
+.shop-detail__status.is-suspended {
+    background: rgba(248, 113, 113, 0.14);
+    color: #b91c1c;
+}
+
+.shop-detail__meta {
+    display: grid;
+    gap: 1rem;
+}
+
+.shop-detail__description {
+    margin: 0;
+    color: var(--text-light);
+    max-width: 720px;
+}
+
+.shop-detail__description--empty {
+    color: rgba(15, 23, 42, 0.5);
+    font-style: italic;
+}
+
+.shop-detail__meta-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+}
+
+.shop-detail__meta-label {
+    display: block;
+    font-size: 0.85rem;
+    color: var(--text-light);
+}
+
+.shop-detail__meta-value {
+    font-weight: 600;
+    font-size: 1.05rem;
+}
+
+.shop-detail__metrics {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+    margin-bottom: 2rem;
+}
+
+.shop-detail__metric-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.shop-detail__metric-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(0, 102, 255, 0.12), transparent 55%);
+    pointer-events: none;
+}
+
+.shop-detail__metric-card > div {
+    position: relative;
+    z-index: 1;
+}
+
+.shop-detail__best-seller {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.75rem;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(130deg, rgba(0, 102, 255, 0.12), rgba(0, 102, 255, 0.02));
+    border: 1px solid rgba(0, 102, 255, 0.18);
+    margin-bottom: 2rem;
+}
+
+.shop-detail__best-seller-thumb {
+    width: 104px;
+    height: 104px;
+    border-radius: var(--radius-md);
+    background: white;
+    border: 1px solid rgba(15, 23, 42, 0.1);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+}
+
+.shop-detail__best-seller-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.shop-detail__best-seller-placeholder {
+    font-size: 2.25rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.shop-detail__best-seller-info {
+    display: grid;
+    gap: 0.35rem;
+}
+
+.shop-detail__best-seller-info h2 {
+    margin: 0;
+    font-size: 1.125rem;
+}
+
+.shop-detail__best-seller-name {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.shop-detail__best-seller-info ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    color: var(--text-light);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.shop-detail__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.shop-detail__actions .button,
+.shop-detail__actions form {
+    flex: 1 1 220px;
+}
+
+.shop-detail__actions form {
+    display: flex;
+}
+
+.shop-detail__actions form .button {
+    width: 100%;
+}
+
+.shop-detail__range {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.shop-detail__range-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    background: rgba(15, 23, 42, 0.02);
+    color: inherit;
+    font-size: 0.9rem;
+    transition: var(--transition);
+    text-decoration: none;
+}
+
+.shop-detail__range-button:hover {
+    border-color: rgba(0, 102, 255, 0.35);
+}
+
+.shop-detail__range-button.is-active {
+    background: rgba(0, 102, 255, 0.12);
+    color: var(--primary-color);
+    border-color: rgba(0, 102, 255, 0.35);
+    font-weight: 600;
+}
+
+.shop-detail__chart {
+    margin-bottom: 1.5rem;
+}
+
+.shop-detail__revenue-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+
+.shop-detail__revenue-table th,
+.shop-detail__revenue-table td {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+    text-align: left;
+}
+
+.shop-detail__revenue-table tbody tr:hover {
+    background: rgba(15, 23, 42, 0.02);
+}
+
+.shop-detail__orders td,
+.shop-detail__orders th {
+    white-space: nowrap;
+}
+
+.shop-detail__badge {
+    display: inline-flex;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(15, 23, 42, 0.08);
+    font-size: 0.85rem;
+}
+
+.shop-detail__empty {
+    margin: 0;
+    color: var(--text-light);
+    text-align: center;
+    padding: 1.5rem 0;
+}
+
+.shop-detail__pagination {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+}
+
+.shop-detail__pagination-actions {
+    display: inline-flex;
+    gap: 0.75rem;
+}
+
+.shop-detail__pagination-info {
+    display: flex;
+    gap: 0.75rem;
+    color: var(--text-light);
+    font-size: 0.95rem;
+}
+
+.table-responsive {
+    width: 100%;
+    overflow-x: auto;
+}
+
+@media (max-width: 768px) {
+    .shop-detail__metrics {
+        grid-template-columns: 1fr;
+    }
+
+    .shop-detail__actions {
+        flex-direction: column;
+    }
+
+    .shop-detail__range {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .shop-detail__best-seller {
+        grid-template-columns: minmax(0, 1fr);
+        text-align: center;
+        justify-items: center;
+    }
+}
+
 .panel__footer {
     display: flex;
     gap: 1rem;


### PR DESCRIPTION
## Summary
- add a seller shop detail screen with quarterly revenue chart, best seller spotlight, and completed order pagination
- extend shop/order services to expose quarterly revenue, best seller, and paged completed order data
- refresh seller UI styles and link the shop list to the new detail experience

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69116e942ec883208f0cf77bc7e41759)