### PR TITLE
Adjust shop creation validation and shop links

### DIFF
--- a/MMO_Trader_Market/src/java/model/view/product/ProductDetailView.java
+++ b/MMO_Trader_Market/src/java/model/view/product/ProductDetailView.java
@@ -195,6 +195,15 @@ public class ProductDetailView {
         return shopName;
     }
 
+    /**
+     * Lấy mã shop đã được mã hóa phục vụ định tuyến thân thiện.
+     *
+     * @return chuỗi mã hóa ID shop.
+     */
+    public String getShopEncodedId() {
+        return IdObfuscator.encode(shopId);
+    }
+
     // Lấy ID chủ shop.
     public Integer getShopOwnerId() {
         return shopOwnerId;

--- a/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/detail.jsp
@@ -126,7 +126,7 @@
                     <span class="badge">${product.productTypeLabel}</span>
                     <span class="badge badge--ghost">${product.productSubtypeLabel}</span>
                 </p>
-                <p class="product-detail__shop">Gian hàng: <strong><c:out value="${product.shopName}" /></strong></p>
+                <p class="product-detail__shop">Gian hàng: <strong><a class="product-card__shop" href="${cPath}/shops/${product.shopEncodedId}"><c:out value="${product.shopName}" /></a></strong></p>
             </header>
             <c:if test="${not empty purchaseError}">
                 <div class="alert alert--error" role="alert" aria-live="assertive">

--- a/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/featured.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/product/fragments/home/featured.jsp
@@ -47,7 +47,7 @@
                         </header>
                         <p class="product-card__meta">
                             <span><c:out value="${product.productTypeLabel}" /> • <c:out value="${product.productSubtypeLabel}" /></span>
-                            <span>Shop: <strong><a class="product-card__shop" href="${cPath}/shops/${p.shopEncodedId}"><c:out value="${p.shopName}" /></a></strong></span>
+                            <span>Shop: <strong><a class="product-card__shop" href="${cPath}/shops/${product.shopEncodedId}"><c:out value="${product.shopName}" /></a></strong></span>
                         </p>
                         <p class="product-card__description"><c:out value="${product.shortDescription}" /></p>
                         <p class="product-card__price">

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/shops/form.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/shops/form.jsp
@@ -42,17 +42,16 @@
                     <label class="form-card__label" for="name">Tên shop</label>
                     <input class="form-card__input" type="text" id="name" name="name"
                            value="${fn:escapeXml(formName)}" maxlength="50" minlength="8"
-                           data-basic-text
                            placeholder="Ví dụ: Cửa hàng tài khoản game chất lượng"
                            required />
-                    <p class="form-note">Tên shop phải từ 8 đến 50 ký tự, không chứa ký tự đặc biệt.</p>
+                    <p class="form-note">Tên shop phải từ 8 đến 50 ký tự, chỉ gồm chữ, số, khoảng trắng và dấu . , -. Nếu nhập ký tự đặc biệt hệ thống sẽ thông báo khi gửi.</p>
                 </div>
                 <div class="form-card__field">
                     <label class="form-card__label" for="description">Mô tả chi tiết</label>
                     <textarea class="form-card__input shop-form__textarea" id="description" name="description"
-                              rows="5" minlength="8" maxlength="50" data-basic-text
+                              rows="5" minlength="8" maxlength="50"
                               placeholder="Giới thiệu điểm mạnh, cam kết bảo hành, thời gian hỗ trợ..." required>${fn:escapeXml(formDescription)}</textarea>
-                    <p class="form-note">Mô tả phải từ 8 đến 50 ký tự, chỉ gồm chữ, số, khoảng trắng và dấu . , -</p>
+                    <p class="form-note">Mô tả phải từ 8 đến 50 ký tự, chỉ gồm chữ, số, khoảng trắng và dấu . , -. Nếu nhập ký tự đặc biệt hệ thống sẽ thông báo khi gửi.</p>
                 </div>
                 <div class="shop-form__actions">
                     <button type="submit" class="button button--primary">
@@ -68,18 +67,3 @@
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>
 
-<script>
-    (function () {
-        // Lọc ký tự đặc biệt theo yêu cầu seller (chỉ cho phép chữ, số, khoảng trắng và ., -)
-        const ALLOWED_PATTERN = /[^\p{L}\p{N}\s.,-]+/gu;
-        document.querySelectorAll('[data-basic-text]').forEach(function (field) {
-            field.addEventListener('input', function () {
-                const original = field.value;
-                const sanitized = original.replace(ALLOWED_PATTERN, '');
-                if (original !== sanitized) {
-                    field.value = sanitized;
-                }
-            });
-        });
-    })();
-</script>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -748,7 +748,7 @@ code {
 
 @media (min-width: 1200px) {
     .shop-grid {
-        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 2rem;
     }
 }


### PR DESCRIPTION
## Summary
- remove the client-side character filter on the seller shop form and rely on server validation messages
- ensure shop cards display in three columns on wide screens for improved layout
- link shop names in product detail and featured sections to their public shop pages

## Testing
- not run (UI change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691263f542888320aa9c574b9974dc7b)