### PR TITLE
Add granular escrow duration configuration inputs

### DIFF
--- a/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/systems.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/systems.jsp
@@ -11,13 +11,28 @@
 
     <form class="row g-3 shadow-sm bg-white p-4 rounded" method="post"
           action="${pageContext.request.contextPath}/admin/systems/escrow">
-        <div class="col-md-6">
-            <label class="form-label" for="escrowHoldHours">Thời gian giữ tiền escrow (giờ)</label>
-            <input type="number" class="form-control" id="escrowHoldHours" name="escrowHoldHours"
-                   min="1" max="720" required value="${escrowHoldHours}" />
-            <div class="form-text">
-                Tiền của người mua sẽ được giữ tối đa <strong>${escrowHoldHours}</strong> giờ
-                (${escrowHoldSeconds} giây) trước khi hệ thống tự động giải ngân cho người bán nếu không phát sinh khiếu nại.
+        <div class="col-lg-8 col-md-10">
+            <label class="form-label" for="escrowHoldHours">Thời gian giữ tiền escrow</label>
+            <div class="d-flex flex-wrap gap-2">
+                <div class="input-group" style="max-width: 160px;">
+                    <input type="number" class="form-control" id="escrowHoldHours" name="escrowHoldHours"
+                           min="0" max="720" value="${escrowHoldHoursPart}" />
+                    <span class="input-group-text">Giờ</span>
+                </div>
+                <div class="input-group" style="max-width: 160px;">
+                    <input type="number" class="form-control" id="escrowHoldMinutes" name="escrowHoldMinutes"
+                           min="0" max="59" value="${escrowHoldMinutesPart}" />
+                    <span class="input-group-text">Phút</span>
+                </div>
+                <div class="input-group" style="max-width: 160px;">
+                    <input type="number" class="form-control" id="escrowHoldSeconds" name="escrowHoldSeconds"
+                           min="0" max="59" value="${escrowHoldSecondsPart}" />
+                    <span class="input-group-text">Giây</span>
+                </div>
+            </div>
+            <div class="form-text mt-2">
+                Tiền của người mua sẽ được giữ tối đa <strong>${escrowHoldDurationLabel}</strong>
+                (<strong>${escrowHoldTotalSeconds}</strong> giây) trước khi hệ thống tự động giải ngân cho người bán nếu không phát sinh khiếu nại.
             </div>
         </div>
         <div class="col-12 text-end mt-3">


### PR DESCRIPTION
## Summary
- replace the admin escrow configuration form with hour, minute, and second inputs and display the formatted duration
- validate the new granular inputs server-side before persisting the escrow hold duration in seconds

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691274a0e9f48320af65f0e05df92284)