### PR TITLE
Add live eligibility check before opening order report modal

### DIFF
--- a/MMO_Trader_Market/src/java/service/DisputeService.java
+++ b/MMO_Trader_Market/src/java/service/DisputeService.java
@@ -72,7 +72,16 @@ public class DisputeService {
             throw new IllegalStateException("Đơn hàng hiện không nằm trong giai đoạn escrow để tạo báo cáo");
         }
         Timestamp now = new Timestamp(System.currentTimeMillis());
+        /*
+         * Đảm bảo đơn hàng vẫn đang trong giai đoạn escrow tại thời điểm người
+         * dùng gửi báo cáo. Khi người mua giữ lại trang mà không tải lại, thời
+         * gian escrow có thể đã hết nên chúng ta cần kiểm tra lại trước khi tạo
+         * dispute mới.
+         */
         int remainingSeconds = computeRemainingEscrowSeconds(order, now);
+        if (remainingSeconds <= 0) {
+            throw new IllegalStateException("Đơn hàng đã hết thời gian escrow hoặc đang được xử lý khiếu nại.");
+        }
         Disputes dispute = new Disputes();
         dispute.setOrderId(order.getId());
         dispute.setOrderReferenceCode(buildOrderReferenceCode(order.getId()));


### PR DESCRIPTION
## Summary
- add a JSON endpoint that validates dispute eligibility in real time when the order detail page requests it
- update the "Báo cáo đơn hàng" button to call the endpoint, block the modal when escrow expired, and show an inline alert

## Testing
- not run (project has no automated tests)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127b7c61d883209f288f0dec2620a0)