### PR TITLE
Expose async queue timeline on order detail

### DIFF
--- a/MMO_Trader_Market/src/java/controller/order/OrderController.java
+++ b/MMO_Trader_Market/src/java/controller/order/OrderController.java
@@ -495,8 +495,9 @@ public class OrderController extends BaseController {
         Orders order = detailOpt.get().order();
         orderService.releaseEscrowIfExpired(order);
         Optional<WalletTransactions> paymentTxOpt = orderService.getPaymentTransactionForOrder(order);
+        Optional<Disputes> disputeOpt = disputeService.findByOrderId(order.getId());
         // Xây dựng danh sách sự kiện ví và trả về JSON để front-end polling.
-        List<OrderWalletEvent> events = orderService.buildWalletTimeline(order, paymentTxOpt);
+        List<OrderWalletEvent> events = orderService.buildWalletTimeline(order, paymentTxOpt, disputeOpt);
         response.setContentType("application/json; charset=UTF-8");
         response.getWriter().write(buildWalletEventsPayload(events));
     }

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -558,11 +558,9 @@
                         <div class="order-detail__info-column order-detail__info-column--wallet">
                             <h4 class="order-detail__info-title">Giao dịch ví</h4>
                             <c:url var="walletEventsUrl" value="/orders/detail/${orderToken}/wallet-events" />
-                            <%--
                             <div class="wallet-events" id="walletEvents" data-endpoint="${walletEventsUrl}">
                                 <div class="wallet-events__placeholder">Đang tải dữ liệu giao dịch ví...</div>
                             </div>
-                            --%>
                             <c:if test="${not empty paymentTransaction}">
                                 <h5 class="order-detail__info-subtitle">Chi tiết giao dịch</h5>
                                 <ul class="definition-list">

--- a/docs/purchase-flow.md
+++ b/docs/purchase-flow.md
@@ -39,7 +39,7 @@ Nếu có lỗi nghiệp vụ/SQL, worker rollback và đánh dấu đơn `Faile
   - Hàm kiểm tra quyền sở hữu, nạp `OrderDetailView` qua `OrderService#getDetail`.
   - Nếu người dùng đã mở khóa credential, service trả về danh sách plaintext để JSP hiển thị.
 - Giao diện `order/detail.jsp` gọi AJAX `/orders/detail/{token}/wallet-events` (do `OrderController#handleWalletEventsApi` cung cấp).
-  - API trả về danh sách sự kiện ví được dựng bởi `OrderService#buildWalletTimeline`, mô tả các bước: kiểm tra ví, trừ tiền, chờ giao dịch và trạng thái đơn.
+  - API trả về danh sách sự kiện ví được dựng bởi `OrderService#buildWalletTimeline`, mô tả các bước từ lúc thông điệp được đưa vào queue, worker khóa ví, ghi nhận giao dịch, cho tới khiếu nại và vòng đời escrow.
 
 ## 6. Mở khóa thông tin bàn giao
 - Khi đơn ở trạng thái `Completed`, người dùng bấm nút mở khóa.


### PR DESCRIPTION
## Summary
- restore the wallet timeline widget on the order detail screen so buyers can see live processing updates
- extend the order timeline builder to include async queue, dispute, and escrow milestones with richer descriptions
- surface disputes to the wallet-events API and update documentation to reflect the expanded timeline

## Testing
- ⚠️ `ant -q compile` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69127ee4e73883208d96d92e688e338c)