### PR TITLE
Add admin dispute resolution service and seller dispute listing

### DIFF
--- a/MMO_Trader_Market/src/java/controller/seller/SellerDisputesController.java
+++ b/MMO_Trader_Market/src/java/controller/seller/SellerDisputesController.java
@@ -1,0 +1,153 @@
+package controller.seller;
+
+import dao.admin.ManageDisputeDAO;
+import dao.connect.DBConnect;
+import dao.product.ProductDAO;
+import dao.shop.ShopDAO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import model.Disputes;
+import model.Products;
+import model.Shops;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Màn hình tổng hợp khiếu nại dành cho người bán để theo dõi trạng thái tranh
+ * chấp của các đơn thuộc cửa hàng.
+ */
+@WebServlet(name = "SellerDisputesController", urlPatterns = {"/seller/disputes"})
+public class SellerDisputesController extends SellerBaseController {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ShopDAO shopDAO = new ShopDAO();
+    private final ProductDAO productDAO = new ProductDAO();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!ensureSellerAccess(request, response)) {
+            return;
+        }
+
+        HttpSession session = request.getSession();
+        Integer userId = (Integer) session.getAttribute("userId");
+        if (userId == null) {
+            response.sendRedirect(request.getContextPath() + "/auth");
+            return;
+        }
+
+        Shops shop = shopDAO.findByOwnerId(userId);
+        if (shop == null) {
+            request.setAttribute("errorMessage", "Bạn chưa có cửa hàng để theo dõi khiếu nại.");
+            forward(request, response, "seller/disputes");
+            return;
+        }
+
+        String status = normalize(request.getParameter("status"));
+        String issueType = normalize(request.getParameter("issueType"));
+        String query = trimToNull(request.getParameter("q"));
+        Integer productId = parseIntOrNull(request.getParameter("productId"));
+
+        int page = parsePositiveInt(request.getParameter("page"), 1);
+        int size = parsePositiveInt(request.getParameter("size"), 10);
+
+        List<Disputes> disputes;
+        try (Connection connection = DBConnect.getConnection()) {
+            ManageDisputeDAO dao = new ManageDisputeDAO(connection);
+            disputes = dao.search(query,
+                    status == null || "all".equalsIgnoreCase(status) ? null : status,
+                    issueType == null || "all".equalsIgnoreCase(issueType) ? null : issueType,
+                    null,
+                    null,
+                    userId,
+                    shop.getId(),
+                    productId);
+        } catch (Exception ex) {
+            throw new ServletException("Không thể tải danh sách khiếu nại", ex);
+        }
+
+        disputes = disputes.stream()
+                .sorted(Comparator.comparing(Disputes::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+
+        int total = disputes.size();
+        int pages = (int) Math.ceil(total / (double) size);
+        if (pages <= 0) {
+            pages = 1;
+        }
+        if (page > pages) {
+            page = pages;
+        }
+        int fromIdx = Math.max(0, (page - 1) * size);
+        int toIdx = Math.min(total, fromIdx + size);
+        List<Disputes> paged = disputes.subList(fromIdx, toIdx);
+
+        List<Products> products = productDAO.findByShopId(shop.getId(), null, 200, 0);
+
+        request.setAttribute("shop", shop);
+        request.setAttribute("disputes", paged);
+        request.setAttribute("pg_total", total);
+        request.setAttribute("pg_page", page);
+        request.setAttribute("pg_size", size);
+        request.setAttribute("pg_pages", pages);
+        request.setAttribute("pg_isFirst", page <= 1);
+        request.setAttribute("pg_isLast", page >= pages);
+        request.setAttribute("pg_single", pages <= 1);
+
+        request.setAttribute("status", status == null ? "all" : status);
+        request.setAttribute("issueType", issueType == null ? "all" : issueType);
+        request.setAttribute("query", query == null ? "" : query);
+        request.setAttribute("selectedProductId", productId);
+        request.setAttribute("products", products);
+
+        request.setAttribute("pageTitle", "Khiếu nại từ người mua");
+        forward(request, response, "seller/disputes");
+    }
+
+    private String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private Integer parseIntOrNull(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
+
+    private int parsePositiveInt(String value, int defaultValue) {
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            return parsed > 0 ? parsed : defaultValue;
+        } catch (NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+}

--- a/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
+++ b/MMO_Trader_Market/src/java/dao/order/CredentialDAO.java
@@ -327,6 +327,37 @@ public class CredentialDAO extends BaseDAO {
         }
     }
 
+    /**
+     * Hoàn trả toàn bộ credential đã gắn với đơn hàng về trạng thái chưa bán.
+     *
+     * @param orderId mã đơn hàng cần hoàn trả
+     * @return số credential được cập nhật
+     */
+    public int releaseCredentialsForOrder(int orderId) {
+        try (Connection connection = getConnection()) {
+            return releaseCredentialsForOrder(connection, orderId);
+        } catch (SQLException ex) {
+            LOGGER.log(Level.SEVERE, "Không thể hoàn trả credential của đơn hàng", ex);
+            return 0;
+        }
+    }
+
+    /**
+     * Hoàn trả credential của đơn hàng trong transaction hiện tại.
+     *
+     * @param connection kết nối đang mở
+     * @param orderId    mã đơn hàng cần hoàn trả
+     * @return số credential được cập nhật
+     * @throws SQLException nếu câu lệnh SQL lỗi
+     */
+    public int releaseCredentialsForOrder(Connection connection, int orderId) throws SQLException {
+        final String sql = "UPDATE product_credentials SET is_sold = 0, order_id = NULL WHERE order_id = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setInt(1, orderId);
+            return statement.executeUpdate();
+        }
+    }
+
     public List<String> findPlainCredentialsByOrder(int orderId) {
         final String sql = "SELECT encrypted_value FROM product_credentials WHERE order_id = ? ORDER BY id ASC";
         List<String> results = new ArrayList<>();

--- a/MMO_Trader_Market/src/java/model/Disputes.java
+++ b/MMO_Trader_Market/src/java/model/Disputes.java
@@ -23,6 +23,14 @@ public class Disputes {
     private Integer resolvedByAdminId;
     private String resolvedByAdminName;
 
+    private Integer productId;
+    private String productName;
+    private Integer shopId;
+    private String shopName;
+
+    private Integer orderQuantity;
+    private String orderStatus;
+
     private String issueType;          // ACCOUNT_NOT_WORKING / OTHER / ...
     private String customIssueTitle;   // tiêu đề tùy chọn khi chọn OTHER
 
@@ -118,6 +126,54 @@ public class Disputes {
 
     public void setResolvedByAdminName(String resolvedByAdminName) {
         this.resolvedByAdminName = resolvedByAdminName;
+    }
+
+    public Integer getProductId() {
+        return productId;
+    }
+
+    public void setProductId(Integer productId) {
+        this.productId = productId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public Integer getShopId() {
+        return shopId;
+    }
+
+    public void setShopId(Integer shopId) {
+        this.shopId = shopId;
+    }
+
+    public String getShopName() {
+        return shopName;
+    }
+
+    public void setShopName(String shopName) {
+        this.shopName = shopName;
+    }
+
+    public Integer getOrderQuantity() {
+        return orderQuantity;
+    }
+
+    public void setOrderQuantity(Integer orderQuantity) {
+        this.orderQuantity = orderQuantity;
+    }
+
+    public String getOrderStatus() {
+        return orderStatus;
+    }
+
+    public void setOrderStatus(String orderStatus) {
+        this.orderStatus = orderStatus;
     }
 
     // ===== Issue / Reason / Status =====

--- a/MMO_Trader_Market/src/java/service/DisputeResolutionService.java
+++ b/MMO_Trader_Market/src/java/service/DisputeResolutionService.java
@@ -1,0 +1,193 @@
+package service;
+
+import dao.order.CredentialDAO;
+import dao.order.OrderDAO;
+import dao.product.ProductDAO;
+import dao.support.DisputeDAO;
+import dao.user.WalletTransactionDAO;
+import dao.user.WalletsDAO;
+import model.Disputes;
+import model.Orders;
+import model.TransactionType;
+import model.Wallets;
+
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Dịch vụ dành cho admin xử lý vòng đời khiếu nại: chuyển trạng thái, hoàn tiền
+ * hoặc tiếp tục escrow.
+ */
+public class DisputeResolutionService {
+
+    /**
+     * Hành động xử lý dispute từ phía admin.
+     */
+    public enum ResolutionAction {
+        IN_REVIEW,
+        ACCEPT,
+        REJECT
+    }
+
+    private final DisputeDAO disputeDAO;
+    private final OrderDAO orderDAO;
+    private final WalletsDAO walletsDAO;
+    private final WalletTransactionDAO walletTransactionDAO;
+    private final CredentialDAO credentialDAO;
+    private final ProductDAO productDAO;
+
+    public DisputeResolutionService() {
+        this(new DisputeDAO(), new OrderDAO(), new WalletsDAO(), new WalletTransactionDAO(), new CredentialDAO(),
+                new ProductDAO());
+    }
+
+    public DisputeResolutionService(DisputeDAO disputeDAO, OrderDAO orderDAO, WalletsDAO walletsDAO,
+            WalletTransactionDAO walletTransactionDAO, CredentialDAO credentialDAO, ProductDAO productDAO) {
+        this.disputeDAO = disputeDAO;
+        this.orderDAO = orderDAO;
+        this.walletsDAO = walletsDAO;
+        this.walletTransactionDAO = walletTransactionDAO;
+        this.credentialDAO = credentialDAO;
+        this.productDAO = productDAO;
+    }
+
+    /**
+     * Xử lý khiếu nại theo hành động được lựa chọn.
+     *
+     * @param disputeId mã khiếu nại cần xử lý
+     * @param action    hành động (IN_REVIEW/ACCEPT/REJECT)
+     * @param adminId   admin đang thao tác (có thể null)
+     * @param note      ghi chú xử lý
+     */
+    public void handle(int disputeId, ResolutionAction action, Integer adminId, String note) {
+        try (Connection connection = disputeDAO.createConnection()) {
+            boolean previousAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+            try {
+                Disputes dispute = disputeDAO.findByIdForUpdate(connection, disputeId)
+                        .orElseThrow(() -> new IllegalArgumentException("Không tìm thấy khiếu nại #" + disputeId));
+                ensureNotResolved(dispute);
+                switch (action) {
+                    case IN_REVIEW -> markInReview(connection, dispute, adminId, note);
+                    case ACCEPT -> resolveWithRefund(connection, dispute, adminId, note);
+                    case REJECT -> resolveWithoutRefund(connection, dispute, adminId, note);
+                    default -> throw new IllegalArgumentException("Hành động không hợp lệ");
+                }
+                connection.commit();
+            } catch (Exception ex) {
+                connection.rollback();
+                if (ex instanceof RuntimeException runtime) {
+                    throw runtime;
+                }
+                throw new IllegalStateException("Không thể xử lý khiếu nại", ex);
+            } finally {
+                connection.setAutoCommit(previousAutoCommit);
+            }
+        } catch (SQLException ex) {
+            throw new IllegalStateException("Không thể xử lý khiếu nại", ex);
+        }
+    }
+
+    private void markInReview(Connection connection, Disputes dispute, Integer adminId, String note) throws SQLException {
+        disputeDAO.updateStatus(connection, dispute.getId(), "InReview", adminId, trimToNull(note), null);
+    }
+
+    private void resolveWithRefund(Connection connection, Disputes dispute, Integer adminId, String note)
+            throws SQLException {
+        Orders order = orderDAO.findByIdForUpdate(connection, dispute.getOrderId())
+                .orElseThrow(() -> new IllegalStateException("Không tìm thấy đơn hàng liên quan"));
+        Wallets wallet = walletsDAO.lockWalletForUpdate(connection, order.getBuyerId());
+        if (wallet == null) {
+            throw new IllegalStateException("Không thể khóa ví của người mua");
+        }
+        BigDecimal totalAmount = Optional.ofNullable(order.getTotalAmount())
+                .orElseThrow(() -> new IllegalStateException("Đơn hàng thiếu thông tin tổng tiền"));
+        BigDecimal balanceBefore = wallet.getBalance() == null ? BigDecimal.ZERO : wallet.getBalance();
+        BigDecimal balanceAfter = balanceBefore.add(totalAmount);
+        boolean balanceUpdated = walletsDAO.updateBalance(connection, wallet.getId(), balanceAfter);
+        if (!balanceUpdated) {
+            throw new IllegalStateException("Không thể cập nhật số dư ví");
+        }
+        String transactionNote = "Hoàn tiền tranh chấp đơn #" + order.getId();
+        walletTransactionDAO.insertTransaction(connection, wallet.getId(), order.getId(), TransactionType.REFUND,
+                totalAmount, balanceBefore, balanceAfter, transactionNote);
+
+        credentialDAO.releaseCredentialsForOrder(connection, order.getId());
+        Integer quantity = order.getQuantity();
+        if (quantity != null && quantity > 0) {
+            productDAO.incrementInventoryWithVariant(connection, order.getProductId(), order.getVariantCode(), quantity);
+            orderDAO.insertInventoryLog(connection, order.getProductId(), order.getId(), quantity,
+                    "Restock after dispute refund");
+        }
+
+        boolean cancelled = orderDAO.cancelEscrowForRefund(connection, order.getId());
+        if (!cancelled) {
+            throw new IllegalStateException("Không thể cập nhật trạng thái escrow của đơn hàng");
+        }
+        orderDAO.insertEscrowCancelledEvent(connection, order.getId(), adminId, dispute.getId(),
+                "{\"action\":\"ACCEPT\"}");
+
+        Timestamp resolvedAt = Timestamp.from(Instant.now());
+        disputeDAO.updateStatus(connection, dispute.getId(), "ResolvedWithRefund", adminId, trimToNull(note), resolvedAt);
+    }
+
+    private void resolveWithoutRefund(Connection connection, Disputes dispute, Integer adminId, String note)
+            throws SQLException {
+        Orders order = orderDAO.findByIdForUpdate(connection, dispute.getOrderId())
+                .orElseThrow(() -> new IllegalStateException("Không tìm thấy đơn hàng liên quan"));
+        Integer remainingSeconds = resolveEscrowSeconds(order, dispute);
+        Timestamp resumedAt = Timestamp.from(Instant.now());
+        Timestamp releaseAt = null;
+        if (remainingSeconds != null && remainingSeconds > 0) {
+            releaseAt = new Timestamp(resumedAt.getTime() + remainingSeconds * 1000L);
+        }
+        boolean resumed = orderDAO.resumeEscrowAfterDispute(connection, order.getId(), resumedAt, releaseAt);
+        if (!resumed) {
+            throw new IllegalStateException("Không thể khôi phục escrow cho đơn hàng");
+        }
+        orderDAO.insertEscrowResumedEvent(connection, order.getId(), resumedAt, releaseAt, remainingSeconds, adminId,
+                dispute.getId(), "{\"action\":\"REJECT\"}");
+
+        Timestamp resolvedAt = Timestamp.from(Instant.now());
+        disputeDAO.updateStatus(connection, dispute.getId(), "ResolvedWithoutRefund", adminId, trimToNull(note),
+                resolvedAt);
+    }
+
+    private Integer resolveEscrowSeconds(Orders order, Disputes dispute) {
+        if (dispute != null && dispute.getEscrowRemainingSeconds() != null
+                && dispute.getEscrowRemainingSeconds() > 0) {
+            return dispute.getEscrowRemainingSeconds();
+        }
+        if (order.getEscrowRemainingSeconds() != null && order.getEscrowRemainingSeconds() > 0) {
+            return order.getEscrowRemainingSeconds();
+        }
+        return order.getEscrowHoldSeconds();
+    }
+
+    private void ensureNotResolved(Disputes dispute) {
+        if (dispute == null) {
+            return;
+        }
+        String status = dispute.getStatus();
+        if (status == null) {
+            return;
+        }
+        String normalized = status.trim().toUpperCase();
+        if (normalized.equals("RESOLVEDWITHREFUND") || normalized.equals("RESOLVEDWITHOUTREFUND")
+                || normalized.equals("CLOSED") || normalized.equals("CANCELLED")) {
+            throw new IllegalStateException("Khiếu nại đã được xử lý trước đó");
+        }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/util/ProductVariantUtils.java
+++ b/MMO_Trader_Market/src/java/service/util/ProductVariantUtils.java
@@ -117,6 +117,21 @@ public final class ProductVariantUtils {
         variant.setInventoryCount(Math.max(remaining, 0));
     }
 
+    /**
+     * Tăng tồn kho cho biến thể khi hoàn trả credential về kho.
+     *
+     * @param variant  biến thể cần cập nhật
+     * @param quantity số lượng hoàn trả
+     */
+    public static void increaseInventory(ProductVariantOption variant, int quantity) {
+        if (variant == null || quantity <= 0) {
+            return;
+        }
+        Integer current = variant.getInventoryCount();
+        int next = (current == null ? 0 : current) + quantity;
+        variant.setInventoryCount(Math.max(next, 0));
+    }
+
     // Chuyển danh sách biến thể thành JSON để lưu trữ.
     public static String toJson(List<ProductVariantOption> variants) {
         if (variants == null || variants.isEmpty()) {

--- a/MMO_Trader_Market/src/java/units/NavigationBuilder.java
+++ b/MMO_Trader_Market/src/java/units/NavigationBuilder.java
@@ -136,6 +136,14 @@ public final class NavigationBuilder {
         inventoryItem.put("active", inventoryActive);
         children.add(inventoryItem);
 
+        Map<String, Object> disputesItem = new HashMap<>();
+        disputesItem.put("href", contextPath + "/seller/disputes");
+        disputesItem.put("text", "Khiếu nại");
+        disputesItem.put("label", "Khiếu nại");
+        boolean disputesActive = isActive(currentPath, "/seller/disputes");
+        disputesItem.put("active", disputesActive);
+        children.add(disputesItem);
+
         Map<String, Object> buyerOrdersItem = new HashMap<>();
         buyerOrdersItem.put("href", contextPath + "/orders/my");
         buyerOrdersItem.put("text", "Đơn đã mua & khiếu nại");
@@ -152,7 +160,7 @@ public final class NavigationBuilder {
         incomeItem.put("active", incomeActive);
         children.add(incomeItem);
 
-        boolean active = dashboardActive || inventoryActive || incomeActive || ordersActive;
+        boolean active = dashboardActive || inventoryActive || disputesActive || incomeActive || ordersActive;
         Map<String, Object> dropdown = createNavItem(contextPath + "/dashboard", "Quản lý cửa hàng", active);
         dropdown.put("dropdown", true);
         dropdown.put("children", children);

--- a/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/disputes.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/disputes.jsp
@@ -232,7 +232,8 @@
                                                         <div class="d-flex flex-wrap gap-2">
                                                             <c:forEach var="att" items="${d.attachments}">
                                                                 <c:if test="${not empty att.filePath}">
-                                                                    <img src="${fn:escapeXml(att.filePath)}"
+                                                                    <c:url var="attUrl" value="${att.filePath}" />
+                                                                    <img src="${fn:escapeXml(attUrl)}"
                                                                          alt="Attachment"
                                                                          class="img-thumbnail js-zoomable"
                                                                          style="width:90px;height:90px;object-fit:cover;cursor:zoom-in;">

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/disputes.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/disputes.jsp
@@ -1,0 +1,174 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%
+    request.setAttribute("bodyClass", "layout");
+    request.setAttribute("headerModifier", "layout__header--split");
+%>
+<%@ include file="/WEB-INF/views/shared/page-start.jspf" %>
+<%@ include file="/WEB-INF/views/shared/header.jspf" %>
+<c:set var="base" value="${pageContext.request.contextPath}" />
+
+<main class="layout__content seller-page">
+    <c:if test="${not empty errorMessage}">
+        <div class="alert alert--danger" role="alert">${errorMessage}</div>
+    </c:if>
+
+    <c:if test="${not empty shop}">
+        <section class="panel">
+            <div class="panel__header">
+                <div>
+                    <h2 class="panel__title">Khiếu nại từ người mua</h2>
+                    <p class="panel__subtitle">Theo dõi trạng thái tranh chấp của đơn hàng thuộc cửa hàng ${fn:escapeXml(shop.name)}.</p>
+                </div>
+            </div>
+            <div class="panel__body">
+                <form method="get" action="${base}/seller/disputes" class="form" style="display:flex;flex-wrap:wrap;gap:12px;">
+                    <input type="hidden" name="size" value="${pg_size != null ? pg_size : 10}">
+                    <div style="flex:1 1 220px;">
+                        <label class="form__label" for="q">Từ khóa</label>
+                        <input id="q" name="q" class="form__control" type="search" placeholder="Mã đơn, email người mua..."
+                               value="${fn:escapeXml(query)}">
+                    </div>
+                    <div style="flex:1 1 160px;">
+                        <label class="form__label" for="status">Trạng thái</label>
+                        <select id="status" name="status" class="form__control">
+                            <c:set var="currentStatus" value="${status}" />
+                            <option value="all" ${currentStatus=='all'?'selected':''}>Tất cả</option>
+                            <option value="Open" ${currentStatus=='Open'?'selected':''}>Open</option>
+                            <option value="InReview" ${currentStatus=='InReview'?'selected':''}>In review</option>
+                            <option value="ResolvedWithRefund" ${currentStatus=='ResolvedWithRefund'?'selected':''}>Resolved + Refund</option>
+                            <option value="ResolvedWithoutRefund" ${currentStatus=='ResolvedWithoutRefund'?'selected':''}>Resolved (Không hoàn)</option>
+                            <option value="Closed" ${currentStatus=='Closed'?'selected':''}>Closed</option>
+                            <option value="Cancelled" ${currentStatus=='Cancelled'?'selected':''}>Cancelled</option>
+                        </select>
+                    </div>
+                    <div style="flex:1 1 160px;">
+                        <label class="form__label" for="issueType">Loại vấn đề</label>
+                        <select id="issueType" name="issueType" class="form__control">
+                            <c:set var="currentIssue" value="${issueType}" />
+                            <option value="all" ${currentIssue=='all'?'selected':''}>Tất cả</option>
+                            <option value="ACCOUNT_NOT_WORKING" ${currentIssue=='ACCOUNT_NOT_WORKING'?'selected':''}>Account không hoạt động</option>
+                            <option value="ACCOUNT_DUPLICATED" ${currentIssue=='ACCOUNT_DUPLICATED'?'selected':''}>Account trùng</option>
+                            <option value="ACCOUNT_EXPIRED" ${currentIssue=='ACCOUNT_EXPIRED'?'selected':''}>Account hết hạn</option>
+                            <option value="ACCOUNT_MISSING" ${currentIssue=='ACCOUNT_MISSING'?'selected':''}>Thiếu credential</option>
+                            <option value="OTHER" ${currentIssue=='OTHER'?'selected':''}>Khác</option>
+                        </select>
+                    </div>
+                    <div style="flex:1 1 200px;">
+                        <label class="form__label" for="productId">Sản phẩm</label>
+                        <select id="productId" name="productId" class="form__control">
+                            <option value="" ${empty selectedProductId ? 'selected' : ''}>Tất cả sản phẩm</option>
+                            <c:forEach var="p" items="${products}">
+                                <option value="${p.id}" ${selectedProductId == p.id ? 'selected' : ''}>${fn:escapeXml(p.name)}</option>
+                            </c:forEach>
+                        </select>
+                    </div>
+                    <div style="align-self:flex-end;display:flex;gap:8px;">
+                        <button type="submit" class="button button--primary">Lọc</button>
+                        <a href="${base}/seller/disputes" class="button">Xóa lọc</a>
+                    </div>
+                </form>
+            </div>
+        </section>
+
+        <section class="panel">
+            <div class="panel__body">
+                <c:choose>
+                    <c:when test="${empty disputes}">
+                        <p class="text-muted" style="text-align:center;padding:2rem;">Chưa có khiếu nại nào.</p>
+                    </c:when>
+                    <c:otherwise>
+                        <div class="table-responsive">
+                            <table class="table table--interactive" style="width:100%;">
+                                <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Mã đơn</th>
+                                    <th>Sản phẩm</th>
+                                    <th>Cửa hàng</th>
+                                    <th>Trạng thái</th>
+                                    <th>Tạo lúc</th>
+                                    <th>Hoàn tất</th>
+                                    <th>Chi tiết</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <c:forEach var="d" items="${disputes}" varStatus="st">
+                                    <tr>
+                                        <td>${(pg_page-1)*pg_size + st.index + 1}</td>
+                                        <td>${fn:escapeXml(d.orderReferenceCode)}</td>
+                                        <td>${fn:escapeXml(d.productName)}</td>
+                                        <td>${fn:escapeXml(d.shopName)}</td>
+                                        <td>${fn:escapeXml(d.status)}</td>
+                                        <td><fmt:formatDate value="${d.createdAt}" pattern="dd-MM-yyyy HH:mm"/></td>
+                                        <td><fmt:formatDate value="${d.resolvedAt}" pattern="dd-MM-yyyy HH:mm"/></td>
+                                        <td>
+                                            <details>
+                                                <summary>Xem</summary>
+                                                <div style="margin-top:8px;">
+                                                    <div><strong>Loại vấn đề:</strong>
+                                                        <c:choose>
+                                                            <c:when test="${not empty d.customIssueTitle}">${fn:escapeXml(d.customIssueTitle)}</c:when>
+                                                            <c:otherwise>${fn:escapeXml(d.issueType)}</c:otherwise>
+                                                        </c:choose>
+                                                    </div>
+                                                    <div style="margin-top:6px;"><strong>Lý do:</strong>
+                                                        <div class="text-muted" style="white-space:pre-wrap;">${fn:escapeXml(d.reason)}</div>
+                                                    </div>
+                                                    <c:if test="${not empty d.resolutionNote}">
+                                                        <div style="margin-top:6px;"><strong>Ghi chú xử lý:</strong>
+                                                            <div class="text-muted" style="white-space:pre-wrap;">${fn:escapeXml(d.resolutionNote)}</div>
+                                                        </div>
+                                                    </c:if>
+                                                    <c:if test="${not empty d.attachments}">
+                                                        <div style="margin-top:6px;"><strong>Ảnh đính kèm:</strong>
+                                                            <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:4px;">
+                                                                <c:forEach var="att" items="${d.attachments}">
+                                                                    <c:if test="${not empty att.filePath}">
+                                                                        <c:url var="attUrl" value="${att.filePath}" />
+                                                                        <a href="${fn:escapeXml(attUrl)}" target="_blank" rel="noopener"
+                                                                           style="display:inline-block;border:1px solid #ddd;border-radius:6px;overflow:hidden;">
+                                                                            <img src="${fn:escapeXml(attUrl)}" alt="Attachment"
+                                                                                 style="width:80px;height:80px;object-fit:cover;display:block;">
+                                                                        </a>
+                                                                    </c:if>
+                                                                </c:forEach>
+                                                            </div>
+                                                        </div>
+                                                    </c:if>
+                                                </div>
+                                            </details>
+                                        </td>
+                                    </tr>
+                                </c:forEach>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <c:if test="${pg_pages > 1}">
+                            <div style="display:flex;justify-content:center;gap:8px;margin-top:16px;flex-wrap:wrap;">
+                                <c:forEach var="i" begin="1" end="${pg_pages}">
+                                    <c:url var="pageUrl" value="/seller/disputes">
+                                        <c:param name="page" value="${i}" />
+                                        <c:param name="size" value="${pg_size}" />
+                                        <c:param name="status" value="${status}" />
+                                        <c:param name="issueType" value="${issueType}" />
+                                        <c:param name="q" value="${query}" />
+                                        <c:if test="${not empty selectedProductId}">
+                                            <c:param name="productId" value="${selectedProductId}" />
+                                        </c:if>
+                                    </c:url>
+                                    <a href="${base}${pageUrl}" class="button ${i == pg_page ? 'button--primary' : ''}">${i}</a>
+                                </c:forEach>
+                            </div>
+                        </c:if>
+                    </c:otherwise>
+                </c:choose>
+            </div>
+        </section>
+    </c:if>
+</main>
+<%@ include file="/WEB-INF/views/shared/footer.jspf" %>
+<%@ include file="/WEB-INF/views/shared/page-end.jspf" %>


### PR DESCRIPTION
## Summary
- route admin dispute actions through a dedicated DisputeResolutionService to support in-review, accept, and reject flows
- restock credentials and inventory, record escrow events, and surface dispute metadata for admin and seller views
- add seller dispute list page and navigation entry to review disputes by product or shop

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914d21fae448320bf21a47810aba7bc)