### PR TITLE
Fix dispute attachment URLs and improve dispute error visibility

### DIFF
--- a/MMO_Trader_Market/src/java/model/DisputeAttachment.java
+++ b/MMO_Trader_Market/src/java/model/DisputeAttachment.java
@@ -51,4 +51,29 @@ public class DisputeAttachment {
     public void setCreatedAt(Date createdAt) {
         this.createdAt = createdAt;
     }
+
+    /**
+     * Chuẩn hóa đường dẫn để hiển thị trên web. Đảm bảo đường dẫn luôn bắt đầu
+     * bằng dấu {@code '/'} và sử dụng dấu gạch chéo xuôi giúp trình duyệt đọc
+     * đúng resource.
+     *
+     * @return đường dẫn ảnh sẵn sàng dùng cho thuộc tính {@code src}; trả về
+     * {@code null} nếu giá trị rỗng.
+     */
+    public String getWebPath() {
+        if (filePath == null) {
+            return null;
+        }
+        String normalized = filePath.trim().replace('\\', '/');
+        if (normalized.isEmpty()) {
+            return null;
+        }
+        if (!normalized.startsWith("/")) {
+            normalized = "/" + normalized;
+        }
+        while (normalized.contains("//")) {
+            normalized = normalized.replace("//", "/");
+        }
+        return normalized;
+    }
 }

--- a/MMO_Trader_Market/src/java/service/DisputeResolutionService.java
+++ b/MMO_Trader_Market/src/java/service/DisputeResolutionService.java
@@ -83,12 +83,32 @@ public class DisputeResolutionService {
                 if (ex instanceof RuntimeException runtime) {
                     throw runtime;
                 }
-                throw new IllegalStateException("Không thể xử lý khiếu nại", ex);
+                String message = ex.getMessage();
+                if (message == null || message.isBlank()) {
+                    Throwable cause = ex.getCause();
+                    while (cause != null && (cause.getMessage() == null || cause.getMessage().isBlank())) {
+                        cause = cause.getCause();
+                    }
+                    message = (cause != null && cause.getMessage() != null && !cause.getMessage().isBlank())
+                            ? cause.getMessage()
+                            : "Không thể xử lý khiếu nại";
+                }
+                throw new IllegalStateException(message, ex);
             } finally {
                 connection.setAutoCommit(previousAutoCommit);
             }
         } catch (SQLException ex) {
-            throw new IllegalStateException("Không thể xử lý khiếu nại", ex);
+            String message = ex.getMessage();
+            if (message == null || message.isBlank()) {
+                Throwable cause = ex.getCause();
+                while (cause != null && (cause.getMessage() == null || cause.getMessage().isBlank())) {
+                    cause = cause.getCause();
+                }
+                message = (cause != null && cause.getMessage() != null && !cause.getMessage().isBlank())
+                        ? cause.getMessage()
+                        : "Không thể xử lý khiếu nại";
+            }
+            throw new IllegalStateException(message, ex);
         }
     }
 

--- a/MMO_Trader_Market/src/java/units/FileUploadUtil.java
+++ b/MMO_Trader_Market/src/java/units/FileUploadUtil.java
@@ -72,7 +72,16 @@ public class FileUploadUtil {
         filePart.write(filePath);
 
         // Trả về đường dẫn relative (dùng / thay vì File.separator cho web path)
-        return sanitizedRelativeDir.replace(File.separatorChar, '/') + "/" + uniqueFileName;
+        String relativePath = sanitizedRelativeDir.replace(File.separatorChar, '/') + "/" + uniqueFileName;
+        relativePath = relativePath.replace("\\", "/");
+        if (!relativePath.startsWith("/")) {
+            relativePath = "/" + relativePath;
+        }
+        // Loại bỏ trường hợp nhiều dấu '/' liên tiếp khi ghép chuỗi.
+        while (relativePath.contains("//")) {
+            relativePath = relativePath.replace("//", "/");
+        }
+        return relativePath;
     }
     
     /**
@@ -87,7 +96,12 @@ public class FileUploadUtil {
         }
         
         try {
-            String fullPath = applicationPath + File.separator + oldFilePath.replace("/", File.separator);
+            String normalized = oldFilePath.replace('\', '/');
+            while (normalized.startsWith("/")) {
+                normalized = normalized.substring(1);
+            }
+            normalized = normalized.replace("//", "/");
+            String fullPath = applicationPath + File.separator + normalized.replace("/", File.separator);
             File file = new File(fullPath);
             if (file.exists() && file.isFile()) {
                 file.delete();

--- a/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/disputes.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/Admin/pages/disputes.jsp
@@ -231,8 +231,9 @@
                                                         <div class="small text-muted mb-1">Ảnh đính kèm</div>
                                                         <div class="d-flex flex-wrap gap-2">
                                                             <c:forEach var="att" items="${d.attachments}">
-                                                                <c:if test="${not empty att.filePath}">
-                                                                    <c:url var="attUrl" value="${att.filePath}" />
+                                                                <c:set var="attWebPath" value="${att.webPath}" />
+                                                                <c:if test="${not empty attWebPath}">
+                                                                    <c:url var="attUrl" value="${attWebPath}" />
                                                                     <img src="${fn:escapeXml(attUrl)}"
                                                                          alt="Attachment"
                                                                          class="img-thumbnail js-zoomable"

--- a/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/order/detail.jsp
@@ -587,13 +587,17 @@
                     <c:if test="${not empty existingDisputeAttachments}">
                         <div class="order-report__evidences">
                             <c:forEach var="attachment" items="${existingDisputeAttachments}">
-                                <div class="order-report__evidence">
-                                    <a href="<c:url value='/${attachment.filePath}' />" target="_blank" rel="noopener">
-                                        <img src="<c:url value='/${attachment.filePath}' />"
-                                             alt="Ảnh bằng chứng liên quan đến báo cáo"
-                                             loading="lazy" />
-                                    </a>
-                                </div>
+                                <c:set var="attachmentWebPath" value="${attachment.webPath}" />
+                                <c:if test="${not empty attachmentWebPath}">
+                                    <c:url var="attachmentUrl" value="${attachmentWebPath}" />
+                                    <div class="order-report__evidence">
+                                        <a href="${attachmentUrl}" target="_blank" rel="noopener">
+                                            <img src="${attachmentUrl}"
+                                                 alt="Ảnh bằng chứng liên quan đến báo cáo"
+                                                 loading="lazy" />
+                                        </a>
+                                    </div>
+                                </c:if>
                             </c:forEach>
                         </div>
                     </c:if>

--- a/MMO_Trader_Market/web/WEB-INF/views/seller/disputes.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/seller/disputes.jsp
@@ -126,8 +126,9 @@
                                                         <div style="margin-top:6px;"><strong>Ảnh đính kèm:</strong>
                                                             <div style="display:flex;flex-wrap:wrap;gap:8px;margin-top:4px;">
                                                                 <c:forEach var="att" items="${d.attachments}">
-                                                                    <c:if test="${not empty att.filePath}">
-                                                                        <c:url var="attUrl" value="${att.filePath}" />
+                                                                    <c:set var="attWebPath" value="${att.webPath}" />
+                                                                    <c:if test="${not empty attWebPath}">
+                                                                        <c:url var="attUrl" value="${attWebPath}" />
                                                                         <a href="${fn:escapeXml(attUrl)}" target="_blank" rel="noopener"
                                                                            style="display:inline-block;border:1px solid #ddd;border-radius:6px;overflow:hidden;">
                                                                             <img src="${fn:escapeXml(attUrl)}" alt="Attachment"


### PR DESCRIPTION
## Summary
- normalize saved upload paths and filesystem cleanup to always use forward-slash URLs
- expose a helper on dispute attachments and update admin, seller, and order views to render evidence images reliably
- surface root-cause details when dispute resolution fails instead of the generic message

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914de296e2c8320b8ab2d949a4ac40f)