### PR TITLE
Enhance token handling and shop validation

### DIFF
--- a/MMO_Trader_Market/src/java/controller/auth/ForgotPasswordController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/ForgotPasswordController.java
@@ -32,8 +32,12 @@ public class ForgotPasswordController extends BaseController {
         String email = request.getParameter("email");
         try {
             String resetBaseUrl = buildResetBaseUrl(request); // tạo dd
-            userService.requestPasswordReset(email, resetBaseUrl); //tạo yêu cầu đặt lại mật khẩu
-            request.setAttribute("success", "Đã gửi email đặt lại mật khẩu. Vui lòng kiểm tra hộp thư của bạn");
+            boolean emailSent = userService.requestPasswordReset(email, resetBaseUrl); //tạo yêu cầu đặt lại mật khẩu
+            if (emailSent) {
+                request.setAttribute("success", "Đã gửi email đặt lại mật khẩu. Vui lòng kiểm tra hộp thư của bạn");
+            } else {
+                request.setAttribute("success", "Bạn đã yêu cầu đặt lại mật khẩu trong 24 giờ qua. Vui lòng kiểm tra email hoặc thử lại sau khi liên kết hết hạn.");
+            }
         } catch (IllegalArgumentException | IllegalStateException e) {
             request.setAttribute("error", e.getMessage());
         } catch (RuntimeException e) {

--- a/MMO_Trader_Market/src/java/dao/shop/ShopDAO.java
+++ b/MMO_Trader_Market/src/java/dao/shop/ShopDAO.java
@@ -214,6 +214,31 @@ public class ShopDAO extends BaseDAO {
     }
 
     /**
+     * Kiểm tra tên shop đã tồn tại hay chưa (không phân biệt hoa thường).
+     *
+     * @param name      tên shop cần kiểm tra
+     * @param excludeId ID shop cần loại trừ (dùng khi cập nhật), có thể null
+     * @return true nếu đã tồn tại tên trùng, false nếu chưa
+     * @throws SQLException nếu truy vấn thất bại
+     */
+    public boolean existsByName(String name, Integer excludeId) throws SQLException {
+        StringBuilder sql = new StringBuilder("SELECT 1 FROM shops WHERE LOWER(name) = LOWER(?)");
+        if (excludeId != null) {
+            sql.append(" AND id <> ?");
+        }
+        sql.append(" LIMIT 1");
+        try (Connection connection = getConnection(); PreparedStatement stmt = connection.prepareStatement(sql.toString())) {
+            stmt.setString(1, name);
+            if (excludeId != null) {
+                stmt.setInt(2, excludeId);
+            }
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    /**
      * Tạo shop mới với trạng thái Active và thời điểm hiện tại. Shop được tạo
      * sẽ tự động có status = 'Active' và created_at = NOW().
      *

--- a/MMO_Trader_Market/src/java/dao/user/EmailVerificationTokenDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/EmailVerificationTokenDAO.java
@@ -1,21 +1,31 @@
 package dao.user;
 
 import dao.connect.DBConnect;
+import model.EmailVerificationToken;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 
 /**
  * DAO thao tác với bảng lưu trữ mã xác thực email.
  */
 public class EmailVerificationTokenDAO {
 
-    public void createToken(int userId, String code) throws SQLException {
+    /**
+     * Tạo mới hoặc thay thế mã xác thực cho người dùng, đồng thời làm mới thời gian khởi tạo.
+     *
+     * @param userId ID người dùng
+     * @param code   mã xác thực cần lưu trữ
+     * @throws SQLException nếu truy vấn thất bại hoặc vi phạm unique key
+     */
+    public void upsertToken(int userId, String code) throws SQLException {
         final String sql = """
-                INSERT INTO email_verification_tokens (user_id, code)
-                VALUES (?, ?)
+                INSERT INTO email_verification_tokens (user_id, code, created_at)
+                VALUES (?, ?, CURRENT_TIMESTAMP)
+                ON DUPLICATE KEY UPDATE code = VALUES(code), created_at = VALUES(created_at)
                 """;
         try (Connection conn = DBConnect.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
             ps.setInt(1, userId);
@@ -25,8 +35,20 @@ public class EmailVerificationTokenDAO {
     }
 
     public String findCodeByUserId(int userId) throws SQLException {
+        EmailVerificationToken token = findTokenByUserId(userId);
+        return token == null ? null : token.getCode();
+    }
+
+    /**
+     * Truy vấn token gần nhất của người dùng (nếu có).
+     *
+     * @param userId ID người dùng
+     * @return {@link EmailVerificationToken} hoặc null nếu không có
+     * @throws SQLException nếu truy vấn thất bại
+     */
+    public EmailVerificationToken findTokenByUserId(int userId) throws SQLException {
         final String sql = """
-                SELECT code
+                SELECT user_id, code, created_at
                 FROM email_verification_tokens
                 WHERE user_id = ?
                 LIMIT 1
@@ -35,7 +57,12 @@ public class EmailVerificationTokenDAO {
             ps.setInt(1, userId);
             try (ResultSet rs = ps.executeQuery()) {
                 if (rs.next()) {
-                    return rs.getString("code");
+                    EmailVerificationToken token = new EmailVerificationToken();
+                    token.setUserId(rs.getInt("user_id"));
+                    token.setCode(rs.getString("code"));
+                    Timestamp createdAt = rs.getTimestamp("created_at");
+                    token.setCreatedAt(createdAt == null ? null : new java.util.Date(createdAt.getTime()));
+                    return token;
                 }
             }
         }
@@ -56,7 +83,8 @@ public class EmailVerificationTokenDAO {
             }
         }
     }
-//xóa userid trong bảng email_very..
+
+    //xóa userid trong bảng email_very..
     public int deleteByUserId(int userId) throws SQLException {
         final String sql = """
                 DELETE FROM email_verification_tokens

--- a/MMO_Trader_Market/src/java/dao/user/PasswordResetTokenDAO.java
+++ b/MMO_Trader_Market/src/java/dao/user/PasswordResetTokenDAO.java
@@ -45,6 +45,32 @@ public class PasswordResetTokenDAO {
         return null;
     }
 
+    /**
+     * Lấy yêu cầu đặt lại mật khẩu gần nhất chưa sử dụng của người dùng.
+     *
+     * @param userId ID người dùng
+     * @return {@link PasswordResetToken} nếu tồn tại, null nếu không có
+     * @throws SQLException nếu truy vấn thất bại
+     */
+    public PasswordResetToken findLatestActiveByUser(int userId) throws SQLException {
+        final String sql = """
+                SELECT id, user_id, token, expires_at, used_at, created_at
+                FROM password_reset_tokens
+                WHERE user_id = ? AND used_at IS NULL
+                ORDER BY created_at DESC
+                LIMIT 1
+                """;
+        try (Connection conn = DBConnect.getConnection(); PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setInt(1, userId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return mapRow(rs);
+                }
+            }
+        }
+        return null;
+    }
+
     public int markUsed(int id) throws SQLException {
         final String sql = """
                 UPDATE password_reset_tokens

--- a/MMO_Trader_Market/src/java/model/EmailVerificationToken.java
+++ b/MMO_Trader_Market/src/java/model/EmailVerificationToken.java
@@ -1,0 +1,37 @@
+package model;
+
+import java.util.Date;
+
+/**
+ * Đại diện cho mã xác thực email đang chờ xử lý cho người dùng.
+ */
+public class EmailVerificationToken {
+
+    private Integer userId;
+    private String code;
+    private Date createdAt;
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/MMO_Trader_Market/src/java/service/ShopService.java
+++ b/MMO_Trader_Market/src/java/service/ShopService.java
@@ -19,14 +19,14 @@ import java.util.regex.Pattern;
  */
 public class ShopService {
 
-        private static final Pattern BASIC_TEXT_PATTERN = Pattern.compile("^[\\p{L}\\s]+$");
-        private static final Pattern DIGIT_PATTERN = Pattern.compile(".*\\d.*");
-        private static final Pattern SPECIAL_CHARACTER_PATTERN = Pattern.compile(".*[^\\p{L}\\s].*");
-        private static final Pattern EXTRA_WHITESPACE_PATTERN = Pattern.compile(".*[\\t\\n\\r].*");
-        private static final int NAME_MIN_LENGTH = 8;
-        private static final int NAME_MAX_LENGTH = 50;
-        private static final int DESCRIPTION_MIN_LENGTH = 8;
-        private static final int DESCRIPTION_MAX_LENGTH = 50;
+    private static final Pattern BASIC_TEXT_PATTERN = Pattern.compile("^[\\p{L}\\s]+$");
+    private static final Pattern DIGIT_PATTERN = Pattern.compile(".*\\d.*");
+    private static final Pattern SPECIAL_CHARACTER_PATTERN = Pattern.compile(".*[^\\p{L}\\s].*");
+    private static final Pattern EXTRA_WHITESPACE_PATTERN = Pattern.compile(".*[\\t\\n\\r].*");
+    private static final int NAME_MIN_LENGTH = 8;
+    private static final int NAME_MAX_LENGTH = 50;
+    private static final int DESCRIPTION_MIN_LENGTH = 8;
+    private static final int DESCRIPTION_MAX_LENGTH = 50;
 
         private final ShopDAO shopDAO = new ShopDAO();
         private final ProductDAO productDAO = new ProductDAO();
@@ -56,16 +56,17 @@ public class ShopService {
 	 * @throws BusinessException nếu vượt quá 5 shop hoặc tên không hợp lệ
 	 * @throws SQLException nếu có lỗi khi truy vấn database
 	 */
-	public void createShop(int ownerId, String name, String description) throws BusinessException, SQLException {
-		// Kiểm tra giới hạn tối đa 5 shop
-		if (shopDAO.countByOwner(ownerId) >= 5) {
-			throw new BusinessException("Bạn chỉ được tạo tối đa 5 shop.");
-		}
-		// Chuẩn hóa và validate tên shop
+        public void createShop(int ownerId, String name, String description) throws BusinessException, SQLException {
+                // Kiểm tra giới hạn tối đa 5 shop
+                if (shopDAO.countByOwner(ownerId) >= 5) {
+                        throw new BusinessException("Bạn chỉ được tạo tối đa 5 shop.");
+                }
+                // Chuẩn hóa và validate tên shop
                 String normalizedName = normalize(name);
-                ensureValidText(normalizedName, "Tên shop", NAME_MIN_LENGTH, NAME_MAX_LENGTH);
+                ensureValidName(normalizedName);
+                ensureUniqueName(normalizedName, null);
                 String desc = normalize(description);
-                ensureValidText(desc, "Mô tả shop", DESCRIPTION_MIN_LENGTH, DESCRIPTION_MAX_LENGTH);
+                ensureValidDescription(desc);
                 // Gọi DAO để tạo shop (status = 'Active', created_at = NOW())
                 shopDAO.create(ownerId, normalizedName, desc);
         }
@@ -81,12 +82,13 @@ public class ShopService {
 	 * @throws BusinessException nếu tên không hợp lệ hoặc không tìm thấy shop/không có quyền
 	 * @throws SQLException nếu có lỗi khi truy vấn database
 	 */
-	public void updateShop(int id, int ownerId, String name, String description) throws BusinessException, SQLException {
-		// Chuẩn hóa và validate tên shop (giống như tạo mới)
+        public void updateShop(int id, int ownerId, String name, String description) throws BusinessException, SQLException {
+                // Chuẩn hóa và validate tên shop (giống như tạo mới)
                 String normalizedName = normalize(name);
-                ensureValidText(normalizedName, "Tên shop", NAME_MIN_LENGTH, NAME_MAX_LENGTH);
+                ensureValidName(normalizedName);
+                ensureUniqueName(normalizedName, id);
                 String desc = normalize(description);
-                ensureValidText(desc, "Mô tả shop", DESCRIPTION_MIN_LENGTH, DESCRIPTION_MAX_LENGTH);
+                ensureValidDescription(desc);
                 // Cập nhật shop (DAO sẽ kiểm tra owner_id trong WHERE clause)
                 boolean ok = shopDAO.update(id, ownerId, normalizedName, desc);
                 if (!ok) {
@@ -243,43 +245,59 @@ public class ShopService {
         }
 
         /**
-         * Kiểm tra chuỗi nhập liệu của shop theo yêu cầu nghiệp vụ của seller.
-         * Ràng buộc: không rỗng, độ dài trong khoảng cho phép, không chứa ký tự đặc biệt.
+         * Đảm bảo tên shop đáp ứng yêu cầu nghiệp vụ: đủ độ dài, không chứa số/ký tự đặc biệt,
+         * và chỉ bao gồm chữ cái cùng khoảng trắng hợp lệ.
          *
-         * @param value chuỗi cần kiểm tra (đã normalize)
-         * @param fieldLabel tên trường để hiển thị lỗi cho người dùng
-         * @param minLength độ dài tối thiểu
-         * @param maxLength độ dài tối đa
+         * @param value tên shop đã được normalize
          * @throws BusinessException nếu dữ liệu không hợp lệ
          */
-        private void ensureValidText(String value, String fieldLabel, int minLength, int maxLength) throws BusinessException {
+        private void ensureValidName(String value) throws BusinessException {
                 if (value == null || value.isBlank()) {
-                        throw new BusinessException(fieldLabel + " không được để trống.");
+                        throw new BusinessException("Tên shop không được để trống.");
                 }
                 int length = value.length();
-                if (length < minLength) {
-                        throw new BusinessException(fieldLabel + " phải có tối thiểu " + minLength + " ký tự.");
+                if (length < NAME_MIN_LENGTH) {
+                        throw new BusinessException("Tên shop phải có tối thiểu " + NAME_MIN_LENGTH + " ký tự.");
                 }
-                if (length > maxLength) {
-                        throw new BusinessException(fieldLabel + " không được vượt quá " + maxLength + " ký tự.");
+                if (length > NAME_MAX_LENGTH) {
+                        throw new BusinessException("Tên shop không được vượt quá " + NAME_MAX_LENGTH + " ký tự.");
                 }
-                                /*
-                 * Kiểm tra bổ sung dành cho nghiệp vụ tạo shop:
-                 * - Không cho phép chữ số.
-                 * - Không cho phép ký tự đặc biệt (bao gồm dấu câu).
-                 * - Không cho phép khoảng trắng không chuẩn (tab, xuống dòng).
-                 */
                 if (DIGIT_PATTERN.matcher(value).find()) {
-                        throw new BusinessException(fieldLabel + " không được chứa chữ số.");
+                        throw new BusinessException("Tên shop không được chứa chữ số.");
                 }
                 if (SPECIAL_CHARACTER_PATTERN.matcher(value).find()) {
-                        throw new BusinessException(fieldLabel + " không được chứa ký tự đặc biệt.");
+                        throw new BusinessException("Tên shop không được chứa ký tự đặc biệt.");
                 }
                 if (EXTRA_WHITESPACE_PATTERN.matcher(value).find()) {
-                        throw new BusinessException(fieldLabel + " không được chứa khoảng trắng không hợp lệ.");
+                        throw new BusinessException("Tên shop không được chứa khoảng trắng không hợp lệ.");
                 }
                 if (!BASIC_TEXT_PATTERN.matcher(value).matches()) {
-                        throw new BusinessException(fieldLabel + " chỉ được chứa chữ cái.");
+                        throw new BusinessException("Tên shop chỉ được chứa chữ cái.");
+                }
+        }
+
+        /**
+         * Kiểm tra độ dài mô tả shop, cho phép ký tự đặc biệt và số.
+         *
+         * @param value mô tả đã được normalize
+         * @throws BusinessException nếu dữ liệu không hợp lệ
+         */
+        private void ensureValidDescription(String value) throws BusinessException {
+                if (value == null || value.isBlank()) {
+                        throw new BusinessException("Mô tả shop không được để trống.");
+                }
+                int length = value.length();
+                if (length < DESCRIPTION_MIN_LENGTH) {
+                        throw new BusinessException("Mô tả shop phải có tối thiểu " + DESCRIPTION_MIN_LENGTH + " ký tự.");
+                }
+                if (length > DESCRIPTION_MAX_LENGTH) {
+                        throw new BusinessException("Mô tả shop không được vượt quá " + DESCRIPTION_MAX_LENGTH + " ký tự.");
+                }
+        }
+
+        private void ensureUniqueName(String value, Integer excludeId) throws BusinessException, SQLException {
+                if (shopDAO.existsByName(value, excludeId)) {
+                        throw new BusinessException("Tên shop đã tồn tại. Vui lòng chọn tên khác.");
                 }
         }
 }

--- a/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
+++ b/MMO_Trader_Market/web/WEB-INF/views/auth/register.jsp
@@ -38,7 +38,7 @@
                        <c:if test="${acceptTermsChecked}">checked</c:if> required>
                        <label class="form-card__option-text" for="acceptTerms">
                            Tôi đã đọc và đồng ý với
-                           <a href="#" target="_blank" rel="noopener">Điều khoản sử dụng Tap Hóa MMO</a>
+                           <a href="#" class="terms-link" id="termsLink">Điều khoản sử dụng Tap Hóa MMO</a>
                        </label>
                 </div>
                 <button class="button button--primary" type="submit">Đăng ký</button>
@@ -47,8 +47,67 @@
                     <!--<a class="button button--secondary" href="<c:url value='/auth/google' />">Đăng ký bằng Google</a>-->
             </div>
         </form>
+        <div class="terms-modal" id="termsModal" aria-hidden="true" role="dialog" aria-labelledby="termsTitle">
+            <div class="terms-modal__backdrop" data-dismiss="termsModal"></div>
+            <div class="terms-modal__content">
+                <header class="terms-modal__header">
+                    <h2 class="terms-modal__title" id="termsTitle">Điều khoản sử dụng Tap Hóa MMO</h2>
+                    <button type="button" class="terms-modal__close" data-dismiss="termsModal" aria-label="Đóng">×</button>
+                </header>
+                <div class="terms-modal__body">
+                    <p>Trước khi đăng ký, vui lòng đọc nhanh các lưu ý quan trọng để đảm bảo quyền lợi của bạn:</p>
+                    <ul>
+                        <li>Tuân thủ danh sách mặt hàng cấm và chính sách bảo hành trong <a href="<c:url value='/faq'/>" target="_blank" rel="noopener">FAQ</a>.</li>
+                        <li>MMO Trader Market giữ tiền 3 ngày để bảo vệ người mua; khiếu nại có thể được mở trong thời gian này.</li>
+                        <li>Người bán cần đảm bảo nội dung mô tả minh bạch, không spam và không vi phạm pháp luật.</li>
+                        <li>Email xác thực chỉ có hiệu lực ngắn hạn; không chia sẻ mã cho bất kỳ ai.</li>
+                        <li>Vi phạm chính sách có thể dẫn đến khóa tài khoản mà không cần thông báo trước.</li>
+                    </ul>
+                    <p>Chi tiết đầy đủ được trình bày trong trang FAQ. Bạn có thể cuộn để đọc thêm nội dung tóm tắt này.</p>
+                </div>
+                <footer class="terms-modal__footer">
+                    <a class="button button--ghost" href="<c:url value='/faq'/>" target="_blank" rel="noopener">Xem FAQ đầy đủ</a>
+                    <button type="button" class="button button--primary" data-dismiss="termsModal">Đã hiểu</button>
+                </footer>
+            </div>
+        </div>
     </div>
 </main>
+
+<script>
+    (function () {
+        const termsLink = document.getElementById('termsLink');
+        const modal = document.getElementById('termsModal');
+        const dismissTriggers = modal ? modal.querySelectorAll('[data-dismiss="termsModal"]') : [];
+
+        const openModal = (event) => {
+            event.preventDefault();
+            if (!modal) return;
+            modal.classList.add('terms-modal--open');
+            modal.setAttribute('aria-hidden', 'false');
+        };
+
+        const closeModal = () => {
+            if (!modal) return;
+            modal.classList.remove('terms-modal--open');
+            modal.setAttribute('aria-hidden', 'true');
+        };
+
+        if (termsLink) {
+            termsLink.addEventListener('click', openModal);
+        }
+
+        dismissTriggers.forEach((trigger) => {
+            trigger.addEventListener('click', closeModal);
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                closeModal();
+            }
+        });
+    })();
+</script>
 
 <%@ include file="/WEB-INF/views/shared/footer.jspf" %>
 <%@ include file="/WEB-INF/views/shared/page-end.jspf" %>

--- a/MMO_Trader_Market/web/assets/css/main.css
+++ b/MMO_Trader_Market/web/assets/css/main.css
@@ -3449,3 +3449,96 @@ code {
         align-items: start;
     }
 }
+
+/* Modal điều khoản đăng ký */
+.terms-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+    z-index: 1200;
+}
+
+.terms-modal--open {
+    display: flex;
+}
+
+.terms-modal__backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+}
+
+.terms-modal__content {
+    position: relative;
+    background: #fff;
+    border-radius: 12px;
+    max-width: 640px;
+    width: min(640px, 100%);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.terms-modal__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.terms-modal__title {
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.terms-modal__close {
+    border: none;
+    background: transparent;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    color: #555;
+}
+
+.terms-modal__body {
+    max-height: 260px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+    color: #333;
+    line-height: 1.5;
+}
+
+.terms-modal__body ul {
+    margin: 0.5rem 0 0.75rem 1.25rem;
+    padding: 0;
+    display: grid;
+    gap: 0.35rem;
+    list-style: disc;
+}
+
+.terms-modal__body a {
+    color: #2f80ed;
+    text-decoration: underline;
+}
+
+.terms-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.terms-link {
+    text-decoration: underline;
+    color: #2f80ed;
+}
+
+@media (max-width: 640px) {
+    .terms-modal__content {
+        padding: 1rem 1.25rem;
+    }
+}


### PR DESCRIPTION
## Summary
- enforce short-lived, rotating email verification codes and refresh forgot-password handling to avoid redundant emails
- block duplicate shop names while allowing richer descriptions and keep validations documented
- add a scrollable terms popup on the registration page referencing FAQ guidance

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b05fa2a788320b2baec863c681c4c)