### PR TITLE
Fix KYC upload path resolution for saved images

### DIFF
--- a/MMO_Trader_Market/src/java/controller/auth/KycRequestController.java
+++ b/MMO_Trader_Market/src/java/controller/auth/KycRequestController.java
@@ -64,6 +64,7 @@ public class KycRequestController extends HttpServlet {
 
         try {
             boolean success = service.handleKycRequest(
+                    getServletContext(),
                     user,
                     request.getParameter("cccd_number"),
                     request.getPart("front"),


### PR DESCRIPTION
## Summary
- normalize KYC upload paths and resolve them using servlet context for portability
- store KYC image URLs with forward slashes for correct rendering
- update controller to provide servlet context when handling KYC requests

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923f851503c832086bf619785533ad4)